### PR TITLE
Keep independent same-name method requirements principal

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -752,6 +752,10 @@ const CheckTypeCheckerPatternsStep = struct {
         // inspected_run.zig dispatches on a hosted function's ABI symbol, which is
         // matched by name at the host boundary and has no Ident.Idx.
         .{ .file = "inspected_run.zig", .start = 107, .end = 107 },
+        // report.zig compares already-formatted diagnostic text only to avoid
+        // printing two visually identical types. This is presentation logic,
+        // not a type-checking or identifier comparison.
+        .{ .file = "report.zig", .start = 563, .end = 563 },
     };
 
     fn isInExcludedRange(file_path: []const u8, line_number: usize) bool {

--- a/design.md
+++ b/design.md
@@ -7183,8 +7183,19 @@ occurrence, then constraint fn types walked the same way). Index `k` in this
 list is the shared identity between a plan's `constraint(k)` resolution and
 the k-th evidence entry a call edge supplies. The definition's module and any
 importing module enumerate identical lists from their structural copies of the
-scheme. A dispatcher's requirements are a set keyed by method identity: repeated
-source constraints share one callable type and contribute one evidence param.
+scheme. Repeated declarative constraints share one callable type, while
+independently inferred dot-method calls retain separate callable relations so a
+rank-1 method scheme can be instantiated independently at each use. Operators
+and literal conversions retain one numeric/defaulting relation per method
+identity. Same-name relations must agree on fixed outer function properties:
+rank-1 instantiation can vary types but cannot vary a declaration's argument
+count or known effect mode. Once a scheme's public type is fixed, equivalent
+requirements whose only differences are private generalized variables collapse;
+public type variables remain identity anchors, so requirements a caller can
+specialize differently stay separate. Independent same-name callable relations
+share one evidence parameter: the runtime target is selected by dispatcher and
+method, while each dispatch plan checks and instantiates that target against its
+own callable relation.
 
 **Edges supply evidence.** Checking persists every constrained-scheme edge.
 An ordinary instantiation records the (pristine var, fresh var) pairs of its

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -11896,6 +11896,7 @@ fn predeclareAnnotationScheme(
     );
     try self.judgeFieldKindsAtBoundary(env);
     try self.generalizer.generalize(self.gpa, &env.var_pool, env.rank());
+    try self.deduplicateGeneralizedDispatchRequirements(scheme_var);
     try self.publishBindingScheme(scheme_var);
     env.var_pool.popRank();
 
@@ -12269,6 +12270,7 @@ fn checkGroup(self: *Self, group_index: u32, env: *Env) std.mem.Allocator.Error!
         for (scc.defs) |member_def_idx| {
             const member_def = self.cir.store.getDef(member_def_idx);
             const expr_var = ModuleEnv.varFrom(member_def.expr);
+            try self.deduplicateGeneralizedDispatchRequirements(expr_var);
             try self.publishBindingScheme(expr_var);
             try self.bindBindingSchemeVar(expr_var, ModuleEnv.varFrom(member_def.pattern));
             try self.bindBindingSchemeVar(expr_var, ModuleEnv.varFrom(member_def_idx));
@@ -18059,6 +18061,7 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
         }
         try self.judgeFieldKindsAtBoundary(env);
         try self.generalizer.generalize(self.gpa, &env.var_pool, env.rank());
+        try self.deduplicateGeneralizedDispatchRequirements(expr_var_raw);
         try self.publishBindingScheme(expr_var_raw);
         self.retireNonGeneralizedTypeSchemes(&.{.{ .owner = expr_var_raw, .interface = expr_var }});
         try self.retireStructurallyPublishedTypeSchemeRequirements(
@@ -19213,6 +19216,7 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     try self.defaultLiteralsAtGeneralizationBoundary(.{ .owner = decl_pattern_var, .interface = decl_pattern_var }, env);
                     try self.judgeFieldKindsAtBoundary(env);
                     try self.generalizer.generalize(self.gpa, &env.var_pool, env.rank());
+                    try self.deduplicateGeneralizedDispatchRequirements(decl_pattern_var);
                     try self.publishBindingScheme(decl_pattern_var);
                     try self.bindBindingSchemeVar(decl_pattern_var, decl_expr_var);
                     self.retireNonGeneralizedTypeSchemes(&.{.{ .owner = decl_pattern_var, .interface = decl_pattern_var }});
@@ -23890,6 +23894,142 @@ fn typeSchemeHasRequirement(
         return true;
     }
     return false;
+}
+
+const GeneralizedSchemeRequirementKey = struct {
+    receiver_root: Var,
+    fn_name: Ident.Idx,
+    origin_tag: std.meta.Tag(StaticDispatchConstraint.Origin),
+    origin_flag: bool,
+    callable_shape: [32]u8,
+};
+
+const GeneralizedAttachedConstraintKey = struct {
+    fn_name: Ident.Idx,
+    origin_tag: std.meta.Tag(StaticDispatchConstraint.Origin),
+    origin_flag: bool,
+    callable_shape: [32]u8,
+};
+
+fn dispatchConstraintOriginFlag(origin: StaticDispatchConstraint.Origin) bool {
+    return switch (origin) {
+        .desugared_binop => |binop| binop.negated,
+        .where_clause => |where_clause| where_clause.body_required,
+        .desugared_unaryop, .method_call, .from_literal => false,
+    };
+}
+
+/// Collapse requirements that ask for the same target with the same finalized
+/// callable shape. Variables exposed through the enclosing scheme remain fixed
+/// anchors; only requirement-private generalized variables may be renamed.
+/// This keeps repeated helper uses compact without conflating call results that
+/// a caller can still specialize differently.
+fn deduplicateGeneralizedDispatchRequirements(
+    self: *Self,
+    scheme_var: Var,
+) Allocator.Error!void {
+    const identity_vars = try canonical_type_keys.identityVarsFromVarIgnoringConstraints(
+        self.gpa,
+        self.types,
+        self.cir,
+        scheme_var,
+    );
+    defer self.gpa.free(identity_vars);
+
+    var anchors = std.AutoHashMap(Var, void).init(self.gpa);
+    defer anchors.deinit();
+    try anchors.ensureTotalCapacity(@intCast(identity_vars.len));
+    for (identity_vars) |identity_var| {
+        anchors.putAssumeCapacity(self.types.resolveVar(identity_var).var_, {});
+    }
+
+    var retained_constraints: std.ArrayListUnmanaged(StaticDispatchConstraint) = .empty;
+    defer retained_constraints.deinit(self.gpa);
+    var seen_attached = std.AutoHashMap(GeneralizedAttachedConstraintKey, void).init(self.gpa);
+    defer seen_attached.deinit();
+
+    for (identity_vars) |identity_var| {
+        const resolved = self.types.resolveVar(identity_var);
+        const constraints_range = contentConstraintRange(resolved.desc.content) orelse continue;
+        const constraints = self.types.sliceStaticDispatchConstraints(constraints_range);
+        if (constraints.len <= 1) continue;
+
+        retained_constraints.clearRetainingCapacity();
+        seen_attached.clearRetainingCapacity();
+        try retained_constraints.ensureTotalCapacity(self.gpa, constraints.len);
+        try seen_attached.ensureTotalCapacity(@intCast(constraints.len));
+        for (constraints) |constraint| {
+            // Literal metadata is aggregated by the literal-specific path.
+            if (constraint.origin == .from_literal) {
+                retained_constraints.appendAssumeCapacity(constraint);
+                continue;
+            }
+            const callable_key = try canonical_type_keys.fromVarWithAnchoredIdentities(
+                self.gpa,
+                self.types,
+                self.cir,
+                constraint.fn_var,
+                &anchors,
+            );
+            const key = GeneralizedAttachedConstraintKey{
+                .fn_name = constraint.fn_name,
+                .origin_tag = std.meta.activeTag(constraint.origin),
+                .origin_flag = dispatchConstraintOriginFlag(constraint.origin),
+                .callable_shape = callable_key.bytes,
+            };
+            if (seen_attached.contains(key)) continue;
+            seen_attached.putAssumeCapacity(key, {});
+            retained_constraints.appendAssumeCapacity(constraint);
+        }
+        if (retained_constraints.items.len == constraints.len) continue;
+
+        const retained_range = try self.types.appendStaticDispatchConstraints(retained_constraints.items);
+        const retained_content: Content = switch (resolved.desc.content) {
+            .flex => |flex| .{ .flex = flex.withConstraints(retained_range) },
+            .rigid => |rigid| .{ .rigid = rigid.withConstraints(retained_range) },
+            .alias, .structure, .field_presence, .err => unreachable,
+        };
+        try self.types.setVarContent(resolved.var_, retained_content);
+    }
+
+    const scheme_idx = self.typeSchemeIndexForRoot(scheme_var) orelse return;
+    const scheme = &self.type_schemes.items[scheme_idx];
+    if (scheme.dispatch_requirements.items.len <= 1) return;
+
+    var seen = std.AutoHashMap(GeneralizedSchemeRequirementKey, void).init(self.gpa);
+    defer seen.deinit();
+    try seen.ensureTotalCapacity(@intCast(scheme.dispatch_requirements.items.len));
+
+    var write: usize = 0;
+    for (scheme.dispatch_requirements.items) |requirement| {
+        // Literal metadata participates in defaulting and is intentionally
+        // aggregated by the literal-specific path, not this method-target pass.
+        if (requirement.constraint.origin == .from_literal) {
+            scheme.dispatch_requirements.items[write] = requirement;
+            write += 1;
+            continue;
+        }
+
+        const callable_key = try canonical_type_keys.fromVarWithAnchoredIdentities(
+            self.gpa,
+            self.types,
+            self.cir,
+            requirement.constraint.fn_var,
+            &anchors,
+        );
+        const key = GeneralizedSchemeRequirementKey{
+            .receiver_root = self.types.resolveVar(requirement.receiver_var).var_,
+            .fn_name = requirement.constraint.fn_name,
+            .origin_tag = std.meta.activeTag(requirement.constraint.origin),
+            .origin_flag = dispatchConstraintOriginFlag(requirement.constraint.origin),
+            .callable_shape = callable_key.bytes,
+        };
+        if (seen.contains(key)) continue;
+        seen.putAssumeCapacity(key, {});
+        scheme.dispatch_requirements.items[write] = requirement;
+        write += 1;
+    }
+    scheme.dispatch_requirements.shrinkRetainingCapacity(write);
 }
 
 /// Retire side-table requirements only after their exact deferred callable was

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -63,6 +63,8 @@ const TypeDeclDependency = struct {
     dependency: u32,
 };
 
+const InterpolationPartsIdx = InterpolationPartMetadata.SafeList.Idx;
+
 const no_type_decl_dense_index = std.math.maxInt(u32);
 
 const no_def_group = std.math.maxInt(u32);
@@ -307,8 +309,9 @@ u64_var: Var,
 builtin_types_copied: bool,
 /// Map representation of Ident -> Var, used in checking static dispatch constraints
 ident_to_var_map: std.AutoHashMap(Ident.Idx, Var),
-/// Interpolation constraint function vars whose custom part checks have already run.
-checked_interpolation_part_constraints: std.AutoHashMap(Var, void),
+/// Interpolation metadata ranges whose occurrence-specific custom part checks
+/// have already run.
+checked_interpolation_part_constraints: std.AutoHashMap(InterpolationPartsIdx, void),
 /// Vars that originated as single-quote (.int_unbound) literals.
 int_unbound_vars: std.AutoHashMap(Var, void),
 /// Dispatcher/method pairs already reported by `reportConstraintError`, so a
@@ -2375,7 +2378,7 @@ fn initAssumePrepared(
         .u64_var = undefined,
         .builtin_types_copied = false,
         .ident_to_var_map = std.AutoHashMap(Ident.Idx, Var).init(gpa),
-        .checked_interpolation_part_constraints = std.AutoHashMap(Var, void).init(gpa),
+        .checked_interpolation_part_constraints = std.AutoHashMap(InterpolationPartsIdx, void).init(gpa),
         .scratch_generated_codec_calls = .empty,
         .int_unbound_vars = std.AutoHashMap(Var, void).init(gpa),
         .reported_constraint_errors = std.AutoHashMap(ReportedConstraintError, void).init(gpa),
@@ -27847,8 +27850,12 @@ fn ensureCustomInterpolationPartsChecked(
         unreachable;
     }
 
-    const checked_key = self.types.resolveVar(constraint.fn_var).var_;
-    if ((try self.checked_interpolation_part_constraints.getOrPut(checked_key)).found_existing) return;
+    // Empty interpolations have no part constraints to validate and their
+    // SafeList range intentionally has no usable start index.
+    if (metadata.interpolated_parts.isEmpty()) return;
+    if ((try self.checked_interpolation_part_constraints.getOrPut(
+        metadata.interpolated_parts.start,
+    )).found_existing) return;
 
     const item_var = metadata.item_var;
     // Use the captured part metadata, not the original CIR `parts`, so an instantiated call

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -23911,6 +23911,26 @@ const GeneralizedAttachedConstraintKey = struct {
     callable_shape: [32]u8,
 };
 
+fn generalizedCallableShape(
+    self: *Self,
+    anchors: *const std.AutoHashMap(Var, void),
+    cache: *std.AutoHashMap(Var, [32]u8),
+    fn_var: Var,
+) Allocator.Error![32]u8 {
+    const fn_root = self.types.resolveVar(fn_var).var_;
+    if (cache.get(fn_root)) |shape| return shape;
+
+    const shape = (try canonical_type_keys.fromVarWithAnchoredIdentities(
+        self.gpa,
+        self.types,
+        self.cir,
+        fn_root,
+        anchors,
+    )).bytes;
+    try cache.put(fn_root, shape);
+    return shape;
+}
+
 fn dispatchConstraintOriginFlag(origin: StaticDispatchConstraint.Origin) bool {
     return switch (origin) {
         .desugared_binop => |binop| binop.negated,
@@ -23923,7 +23943,9 @@ fn dispatchConstraintOriginFlag(origin: StaticDispatchConstraint.Origin) bool {
 /// callable shape. Variables exposed through the enclosing scheme remain fixed
 /// anchors; only requirement-private generalized variables may be renamed.
 /// This keeps repeated helper uses compact without conflating call results that
-/// a caller can still specialize differently.
+/// a caller can still specialize differently. Shape keys are memoized by
+/// finalized callable root for the duration of this pass because attached and
+/// side-table requirements commonly refer to the same callable graph.
 fn deduplicateGeneralizedDispatchRequirements(
     self: *Self,
     scheme_var: Var,
@@ -23942,6 +23964,9 @@ fn deduplicateGeneralizedDispatchRequirements(
     for (identity_vars) |identity_var| {
         anchors.putAssumeCapacity(self.types.resolveVar(identity_var).var_, {});
     }
+
+    var callable_shapes = std.AutoHashMap(Var, [32]u8).init(self.gpa);
+    defer callable_shapes.deinit();
 
     var retained_constraints: std.ArrayListUnmanaged(StaticDispatchConstraint) = .empty;
     defer retained_constraints.deinit(self.gpa);
@@ -23964,18 +23989,16 @@ fn deduplicateGeneralizedDispatchRequirements(
                 retained_constraints.appendAssumeCapacity(constraint);
                 continue;
             }
-            const callable_key = try canonical_type_keys.fromVarWithAnchoredIdentities(
-                self.gpa,
-                self.types,
-                self.cir,
-                constraint.fn_var,
+            const callable_shape = try self.generalizedCallableShape(
                 &anchors,
+                &callable_shapes,
+                constraint.fn_var,
             );
             const key = GeneralizedAttachedConstraintKey{
                 .fn_name = constraint.fn_name,
                 .origin_tag = std.meta.activeTag(constraint.origin),
                 .origin_flag = dispatchConstraintOriginFlag(constraint.origin),
-                .callable_shape = callable_key.bytes,
+                .callable_shape = callable_shape,
             };
             if (seen_attached.contains(key)) continue;
             seen_attached.putAssumeCapacity(key, {});
@@ -24010,19 +24033,17 @@ fn deduplicateGeneralizedDispatchRequirements(
             continue;
         }
 
-        const callable_key = try canonical_type_keys.fromVarWithAnchoredIdentities(
-            self.gpa,
-            self.types,
-            self.cir,
-            requirement.constraint.fn_var,
+        const callable_shape = try self.generalizedCallableShape(
             &anchors,
+            &callable_shapes,
+            requirement.constraint.fn_var,
         );
         const key = GeneralizedSchemeRequirementKey{
             .receiver_root = self.types.resolveVar(requirement.receiver_var).var_,
             .fn_name = requirement.constraint.fn_name,
             .origin_tag = std.meta.activeTag(requirement.constraint.origin),
             .origin_flag = dispatchConstraintOriginFlag(requirement.constraint.origin),
-            .callable_shape = callable_key.bytes,
+            .callable_shape = callable_shape,
         };
         if (seen.contains(key)) continue;
         seen.putAssumeCapacity(key, {});

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -29333,11 +29333,41 @@ fn reportInvalidBuiltinFromNumeralLiteral(
     env: *Env,
 ) Allocator.Error!bool {
     const num_literal = constraint.origin.numeralInfo() orelse return false;
-    if (!try self.reportInvalidBuiltinFromNumeralInfo(dispatcher_var, num_kind, num_literal, env)) return false;
+    if (validateBuiltinFromNumeralLiteral(num_kind, num_literal) == null) return false;
 
-    try self.poisonConstraintSourceExpr(dispatcher_var, constraint);
-    try self.markStaticDispatchRejected(constraint);
+    // Constraint merging retains aggregate fit facts, while this occurrence
+    // table retains the source literal responsible for a concrete rejection.
+    const rejected_entry = self.firstRejectedOpenNumeral(
+        dispatcher_var,
+        num_kind,
+    );
+    const rejected_constraint = if (rejected_entry) |entry| entry.constraint else constraint;
+    const rejected_literal = rejected_constraint.origin.numeralInfo().?;
+    if (!try self.reportInvalidBuiltinFromNumeralInfo(dispatcher_var, num_kind, rejected_literal, env)) return false;
+
+    const rejected_expr: ?CIR.Expr.Idx = if (rejected_entry) |entry| if (entry.source_node) |node_idx|
+        if (isExprNodeTag(self.cir.store.nodes.get(node_idx).tag)) @enumFromInt(@intFromEnum(node_idx)) else null
+    else
+        null else null;
+    try self.poisonConstraintFailureSource(dispatcher_var, rejected_constraint, rejected_expr);
+    try self.markStaticDispatchRejected(rejected_constraint);
     return true;
+}
+
+fn firstRejectedOpenNumeral(
+    self: *Self,
+    dispatcher_var: Var,
+    num_kind: CIR.NumKind,
+) ?OpenNumeralLiteral {
+    const dispatcher_root = self.types.resolveVar(dispatcher_var).var_;
+    for (self.open_numeral_literals.items) |entry| {
+        if (self.types.resolveVar(entry.var_).var_ != dispatcher_root) continue;
+        const info = entry.constraint.origin.numeralInfo() orelse continue;
+        if (validateBuiltinFromNumeralLiteral(num_kind, info) != null) {
+            return entry;
+        }
+    }
+    return null;
 }
 
 fn reportInvalidBuiltinFromNumeralInfo(

--- a/src/check/canonical_type_keys.zig
+++ b/src/check/canonical_type_keys.zig
@@ -52,6 +52,26 @@ pub fn fromVarInfo(
     };
 }
 
+/// Build a checker-local shape key while preserving the identity of variables
+/// exposed by the enclosing scheme. Variables absent from `anchors` are
+/// alpha-normalized, so equivalent private requirement details compare equal;
+/// anchored variables include their resolved store identity. This key must
+/// never cross a checked-module boundary.
+pub fn fromVarWithAnchoredIdentities(
+    allocator: Allocator,
+    store: *const TypeStore,
+    env: *const ModuleEnv,
+    var_: Var,
+    anchors: *const std.AutoHashMap(Var, void),
+) Allocator.Error!canonical.CanonicalTypeKey {
+    var builder = Builder.init(allocator, store, env);
+    defer builder.deinit();
+    builder.identity_anchors = anchors;
+    builder.write_identity_names = false;
+    try builder.writeVar(var_);
+    return .{ .bytes = builder.hasher.finalResult() };
+}
+
 /// Public `identityVarsFromVar` function.
 ///
 /// The identity variables (flex/rigid) reachable from `var_`, in the exact
@@ -68,6 +88,21 @@ pub fn identityVarsFromVar(
 ) Allocator.Error![]types.Var {
     var builder = Builder.init(allocator, store, env);
     defer builder.deinit();
+    try builder.writeVar(var_);
+    return try allocator.dupe(types.Var, builder.identity_variables.items);
+}
+
+/// Return the identity variables exposed by a type's ordinary structure,
+/// without following method requirements attached to those identities.
+pub fn identityVarsFromVarIgnoringConstraints(
+    allocator: Allocator,
+    store: *const TypeStore,
+    env: *const ModuleEnv,
+    var_: Var,
+) Allocator.Error![]types.Var {
+    var builder = Builder.init(allocator, store, env);
+    defer builder.deinit();
+    builder.walk_identity_constraints = false;
     try builder.writeVar(var_);
     return try allocator.dupe(types.Var, builder.identity_variables.items);
 }
@@ -261,6 +296,16 @@ const Builder = struct {
     /// Digest erroneous content as its resolved root var instead of one
     /// universal token, so unrelated poisoned positions never key equal.
     err_by_var: bool = false,
+    /// Checker-local identities that must not be alpha-renamed while comparing
+    /// private requirement shapes.
+    identity_anchors: ?*const std.AutoHashMap(Var, void) = null,
+    /// Durable canonical keys preserve source-level variable names. Ephemeral
+    /// requirement-shape keys ignore them because names do not affect type
+    /// compatibility.
+    write_identity_names: bool = true,
+    /// Structural scheme-interface walks stop at an identity so attached
+    /// requirements do not become externally visible anchors.
+    walk_identity_constraints: bool = true,
 
     fn init(allocator: Allocator, store: *const TypeStore, env: *const ModuleEnv) Builder {
         return .{
@@ -395,6 +440,13 @@ const Builder = struct {
         constraints: types.StaticDispatchConstraint.SafeList.Range,
     ) Allocator.Error!bool {
         self.contains_identity_variables = true;
+        if (self.identity_anchors) |anchors| {
+            if (anchors.contains(root)) {
+                self.writeTag("identity_var_anchor");
+                self.writeU32(@intFromEnum(root));
+                return true;
+            }
+        }
         if (varSlot(self.identity_variables.items, root)) |slot| {
             self.writeTag("identity_var_ref");
             self.writeU32(slot);
@@ -405,8 +457,11 @@ const Builder = struct {
         try self.identity_variables.append(self.allocator, root);
         self.writeTag(tag);
         self.writeU32(slot);
-        try self.writeOptionalIdent(name);
+        if (self.write_identity_names) {
+            try self.writeOptionalIdent(name);
+        }
 
+        if (!self.walk_identity_constraints) return true;
         const items = self.store.sliceStaticDispatchConstraints(constraints);
         self.writeU32(@intCast(items.len));
         if (items.len == 0) return true;

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -17218,12 +17218,25 @@ const EvidencePass = struct {
         return numericDefaultPhaseForConstraints(self.module, constraints);
     }
 
-    /// The canonical `(depth, index)` of `dispatcher_root`'s `method`
-    /// obligation in the chain, searching innermost-out.
-    fn chainParamIndex(self: *EvidencePass, chain: []const []const EvidenceParam, dispatcher_root: Var, method: canonical.MethodNameId) Allocator.Error!?static_dispatch.EvidenceChainIndex {
+    /// The canonical `(depth, index)` of one method target in the chain,
+    /// searching innermost-out. Independent same-name callable relations share
+    /// the target slot, while their checked plans retain the per-call shape.
+    fn chainParamIndex(
+        self: *EvidencePass,
+        chain: []const []const EvidenceParam,
+        dispatcher_root: Var,
+        method: canonical.MethodNameId,
+        constraint_fn_var: ?Var,
+    ) Allocator.Error!?struct {
+        index: static_dispatch.EvidenceChainIndex,
+        exact_callable: bool,
+    } {
         for (chain, 0..) |params, depth| {
-            if (try self.paramIndexFor(params, dispatcher_root, method)) |k| {
-                return .{ .depth = @intCast(depth), .index = @intCast(k) };
+            if (try self.paramIndexFor(params, dispatcher_root, method, constraint_fn_var)) |match| {
+                return .{
+                    .index = .{ .depth = @intCast(depth), .index = @intCast(match.index) },
+                    .exact_callable = match.exact_callable,
+                };
             }
         }
         return null;
@@ -17283,15 +17296,36 @@ const EvidencePass = struct {
         }
     }
 
-    /// The canonical param index of `dispatcher_root`'s `method` obligation.
-    fn paramIndexFor(self: *EvidencePass, params: []const EvidenceParam, dispatcher_root: Var, method: canonical.MethodNameId) Allocator.Error!?u32 {
+    /// The canonical param index of one dispatch obligation.
+    fn paramIndexFor(
+        self: *EvidencePass,
+        params: []const EvidenceParam,
+        dispatcher_root: Var,
+        method: canonical.MethodNameId,
+        constraint_fn_var: ?Var,
+    ) Allocator.Error!?struct {
+        index: u32,
+        exact_callable: bool,
+    } {
         const idents = self.module.identStoreConst();
+        const constraint_fn_root = if (constraint_fn_var) |fn_var|
+            self.types.resolveVar(fn_var).var_
+        else
+            null;
+        var same_method_fallback: ?u32 = null;
         for (params, 0..) |param, k| {
             if (self.types.resolveVar(param.dispatcher_var).var_ != dispatcher_root) continue;
             if (try self.names.internMethodIdent(idents, param.constraint.fn_name) != method) continue;
-            return @intCast(k);
+            if (same_method_fallback == null) same_method_fallback = @intCast(k);
+            if (constraint_fn_root) |fn_root| {
+                if (self.types.resolveVar(param.constraint.fn_var).var_ != fn_root) continue;
+            }
+            return .{ .index = @intCast(k), .exact_callable = true };
         }
-        return null;
+        return if (same_method_fallback) |index|
+            .{ .index = index, .exact_callable = false }
+        else
+            null;
     }
 
     fn resolvePlan(self: *EvidencePass, plan_id: static_dispatch.StaticDispatchPlanId, chain: []const []const EvidenceParam, commit_unpinned: bool) Allocator.Error!void {
@@ -17508,20 +17542,11 @@ const EvidencePass = struct {
         chain: []const []const EvidenceParam,
         commit_unpinned: bool,
     ) Allocator.Error!?static_dispatch.CheckedCallResolution {
-        if (try self.chainParamIndex(chain, dispatcher_root, method)) |ref| {
-            // A constraint(k) resolution consumes evidence entry k, whose
-            // callable is the scheme's pristine constraint fn type. The
-            // obligation's own callable must be that same type: same-named
-            // constraints on a shared dispatcher var unify their fn vars, so
-            // a mismatched root here means the site's callable was pinned to
-            // one instantiation's concrete type.
-            if (constraint_fn_var) |fn_var| {
-                const chain_fn_var = chain[ref.depth][ref.index].constraint.fn_var;
-                if (self.types.resolveVar(fn_var).var_ != self.types.resolveVar(chain_fn_var).var_) {
-                    checkedArtifactInvariant("constraint-resolved dispatch callable was not the scheme-pristine constraint fn type", .{});
-                }
-            }
-            return .{ .evidence_dependent = ref };
+        if (try self.chainParamIndex(chain, dispatcher_root, method, constraint_fn_var)) |match| {
+            return .{ .evidence_dependent = .{
+                .index = match.index,
+                .independent_callable = !match.exact_callable,
+            } };
         }
 
         // Not bound by this chain. During template walks another template's
@@ -17975,7 +18000,10 @@ const EvidencePass = struct {
             .resolution = switch (resolution) {
                 .direct_pending => |node| .{ .direct = node },
                 .direct_closed, .direct_parametric => checkedArtifactInvariant("call resolution was finalized before evidence publication completed", .{}),
-                .evidence_dependent => |ref| .{ .constraint = ref },
+                .evidence_dependent => |dependent| .{ .constraint = .{
+                    .index = dependent.index,
+                    .independent_callable = dependent.independent_callable,
+                } },
                 .structural => |kind| blk: {
                     const callable_var = fresh_fn_var orelse param.constraint.fn_var;
                     const callable_ty = self.checked_types.rootForSourceVar(self.module, callable_var) orelse
@@ -29233,7 +29261,9 @@ pub const CheckedModuleArtifact = struct {
     // entrypoint contract cannot share a cache entry with one checked under it.
     // Version 70 retains canonical callable type keys in stored function
     // evidence so specialization identity does not depend on fresh checked ids.
-    const serialized_layout_version: u32 = 70;
+    // Version 71 preserves whether forwarded evidence supplies an exact
+    // callable relation or only the shared method target.
+    const serialized_layout_version: u32 = 71;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -35386,8 +35416,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0xF4, 0x44, 0xBF, 0x73, 0x28, 0x33, 0x3B, 0x3E, 0x4E, 0xD1, 0xF6, 0x56, 0x8D, 0x7E, 0x27, 0x88,
-        0x5A, 0x77, 0x16, 0xA5, 0xA3, 0x94, 0xB2, 0x00, 0xA8, 0xD6, 0xCA, 0xB1, 0x7B, 0x8C, 0x8E, 0x54,
+        0x84, 0xB2, 0x88, 0x05, 0xB4, 0x35, 0x1B, 0x08, 0x07, 0xE1, 0x5D, 0x11, 0x4E, 0xD2, 0x11, 0xEF,
+        0x8A, 0x64, 0xDB, 0x78, 0xDE, 0x65, 0xBA, 0xA9, 0x50, 0xEC, 0x80, 0xB0, 0x9B, 0x3D, 0x3C, 0x39,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }
@@ -35407,7 +35437,7 @@ test "closed direct evidence excludes specialization-dependent nested recipes" {
     const context_anchor = testIndexId(CheckedStatementId, 0);
 
     var refs = [_]static_dispatch.CheckedEvidence{
-        .{ .dispatcher_ty = callable_ty, .runtime_dictionary = true, .resolution = .{ .constraint = .{ .depth = 0, .index = 0 } } },
+        .{ .dispatcher_ty = callable_ty, .runtime_dictionary = true, .resolution = .{ .constraint = .{ .index = .{ .depth = 0, .index = 0 } } } },
         .{ .dispatcher_ty = callable_ty, .runtime_dictionary = true, .resolution = .{ .direct = evidence_0 } },
         .{ .dispatcher_ty = callable_ty, .runtime_dictionary = true, .resolution = .{ .direct = evidence_1 } },
     };
@@ -35512,7 +35542,7 @@ test "template dispatch classification separates direct calls from graph relatio
         .{ .expr = testIndexId(CheckedExprId, 0), .method = method, .dispatcher = .type_only, .dispatcher_ty = callable_ty, .callable_ty = callable_ty, .result_mode = .value, .resolution = .{ .direct_closed = .{ .evidence = evidence_0 } } },
         .{ .expr = testIndexId(CheckedExprId, 1), .method = method, .dispatcher = .type_only, .dispatcher_ty = callable_ty, .callable_ty = callable_ty, .result_mode = .value, .resolution = .{ .direct_parametric = .{ .evidence = evidence_1 } } },
         .{ .expr = testIndexId(CheckedExprId, 2), .method = method, .dispatcher = .type_only, .dispatcher_ty = callable_ty, .callable_ty = callable_ty, .result_mode = .value, .resolution = .{ .direct_closed = .{ .evidence = evidence_2 } } },
-        .{ .expr = testIndexId(CheckedExprId, 3), .method = method, .dispatcher = .type_only, .dispatcher_ty = callable_ty, .callable_ty = callable_ty, .result_mode = .value, .resolution = .{ .evidence_dependent = .{ .depth = 0, .index = 0 } } },
+        .{ .expr = testIndexId(CheckedExprId, 3), .method = method, .dispatcher = .type_only, .dispatcher_ty = callable_ty, .callable_ty = callable_ty, .result_mode = .value, .resolution = .{ .evidence_dependent = .{ .index = .{ .depth = 0, .index = 0 } } } },
     };
     var refs = [_]static_dispatch.StaticDispatchPlanId{
         plan_0,

--- a/src/check/dispatch_evidence.zig
+++ b/src/check/dispatch_evidence.zig
@@ -12,9 +12,9 @@
 //! Order contract: depth-first over the resolved type structure—function
 //! args then return, ordinary alias/nominal args then backing, and logical row
 //! fields/tags across the complete extension chain, all in store order—
-//! emitting each constrained var's constraints in range order at its first
-//! occurrence; then the collected
-//! constraints' fn types are walked the same way in emission order (they can
+//! emitting one target parameter per dispatcher/method at the constrained
+//! var's first occurrence; then every independent constraint fn type is walked
+//! the same way in source order (they can
 //! bind further constrained vars, e.g. `where [a.iter : a -> i, i.next : ..]`).
 //!
 //! Each param also carries the semantic PATH from the scheme root to its
@@ -27,6 +27,7 @@
 //! paths over the concrete monomorphic callable instead.
 
 const std = @import("std");
+const Ident = @import("base").Ident;
 const types_mod = @import("types");
 
 const Allocator = std.mem.Allocator;
@@ -103,6 +104,11 @@ pub const Scratch = struct {
     visited: std.AutoHashMapUnmanaged(Var, void) = .{},
     stack: std.ArrayListUnmanaged(StackEntry) = .empty,
     fn_var_queue: std.ArrayListUnmanaged(Var) = .empty,
+    /// Runtime evidence selects a method target, not one particular
+    /// instantiation of that target's callable scheme. Independent same-name
+    /// calls therefore share this receiver-local slot while retaining their
+    /// own callable relations in the checked plans.
+    emitted_methods: std.AutoHashMapUnmanaged(Ident.Idx, void) = .{},
     /// Flat pool backing every stack entry's (and emitted param's) path.
     path_pool: std.ArrayListUnmanaged(PathStep) = .empty,
     /// Child collection buffer for one node's children, in declared order.
@@ -119,6 +125,7 @@ pub const Scratch = struct {
         self.visited.deinit(gpa);
         self.stack.deinit(gpa);
         self.fn_var_queue.deinit(gpa);
+        self.emitted_methods.deinit(gpa);
         self.path_pool.deinit(gpa);
         self.children.deinit(gpa);
         self.* = .{};
@@ -128,6 +135,7 @@ pub const Scratch = struct {
         self.visited.clearRetainingCapacity();
         self.stack.clearRetainingCapacity();
         self.fn_var_queue.clearRetainingCapacity();
+        self.emitted_methods.clearRetainingCapacity();
         self.path_pool.clearRetainingCapacity();
         self.children.clearRetainingCapacity();
     }
@@ -437,13 +445,19 @@ fn emitConstraints(
     scratch: *Scratch,
     out: *std.ArrayListUnmanaged(EvidenceParam),
 ) Allocator.Error!void {
+    scratch.emitted_methods.clearRetainingCapacity();
     for (store.sliceStaticDispatchConstraints(constraints)) |constraint| {
-        try out.append(gpa, .{
-            .dispatcher_var = dispatcher_root,
-            .constraint = constraint,
-            .path_start = if (with_paths) entry.path_start else 0,
-            .path_len = if (with_paths) entry.path_len else 0,
-        });
+        const emitted = try scratch.emitted_methods.getOrPut(gpa, constraint.fn_name);
+        if (!emitted.found_existing) {
+            try out.append(gpa, .{
+                .dispatcher_var = dispatcher_root,
+                .constraint = constraint,
+                .path_start = if (with_paths) entry.path_start else 0,
+                .path_len = if (with_paths) entry.path_len else 0,
+            });
+        }
+        // A shared target does not make the callables interchangeable: each
+        // one can expose further independently constrained variables.
         try scratch.fn_var_queue.append(gpa, constraint.fn_var);
     }
 }

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -557,22 +557,41 @@ pub const ReportBuilder = struct {
         }
         try report.document.addLineBreak();
 
-        // Print the actual
-        try D.renderSlice(actual_label, self, &report);
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
-        const actual_type_str = try report.addOwnedString(self.getFormattedString(actual_snapshot));
-        try report.document.addCodeBlock(actual_type_str);
+        const actual_formatted = self.getFormattedString(actual_snapshot);
+        const expected_formatted = self.getFormattedString(expected_snapshot);
 
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
+        if (std.mem.eql(u8, actual_formatted, expected_formatted)) {
+            try D.renderSlice(&.{D.bytes("The type involved is:")}, self, &report);
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            const type_str = try report.addOwnedString(actual_formatted);
+            try report.document.addCodeBlock(type_str);
 
-        // Print the expected
-        try D.renderSlice(expected_label, self, &report);
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
-        const expected_type_str = try report.addOwnedString(self.getFormattedString(expected_snapshot));
-        try report.document.addCodeBlock(expected_type_str);
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try D.renderSlice(
+                &.{D.bytes("The difference is inside this type, but it is not visible in this display.")},
+                self,
+                &report,
+            );
+        } else {
+            // Print the actual
+            try D.renderSlice(actual_label, self, &report);
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            const actual_type_str = try report.addOwnedString(actual_formatted);
+            try report.document.addCodeBlock(actual_type_str);
+
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            // Print the expected
+            try D.renderSlice(expected_label, self, &report);
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            const expected_type_str = try report.addOwnedString(expected_formatted);
+            try report.document.addCodeBlock(expected_type_str);
+        }
 
         // Print static hints
         for (hints, 0..) |hint, i| {

--- a/src/check/static_dispatch_registry.zig
+++ b/src/check/static_dispatch_registry.zig
@@ -1314,6 +1314,14 @@ pub const EvidenceChainIndex = struct {
     index: u16,
 };
 
+/// Reference to an enclosing evidence slot. Same-name method calls can share
+/// target identity without sharing the callable instantiation recorded by the
+/// representative slot.
+pub const ConstraintEvidenceRef = struct {
+    index: EvidenceChainIndex,
+    independent_callable: bool = false,
+};
+
 /// Public `CheckedEvidence` declaration.
 ///
 /// How one dispatch obligation was satisfied: with a concrete target (plus
@@ -1334,7 +1342,7 @@ pub const CheckedEvidence = struct {
 
     pub const Resolution = union(enum) {
         direct: EvidenceNodeId,
-        constraint: EvidenceChainIndex,
+        constraint: ConstraintEvidenceRef,
         structural: StructuralEvidence,
         /// The checker proved this nested-procedure obligation is the matching
         /// evidence parameter projected from the concrete callable request.
@@ -1457,7 +1465,13 @@ pub const CheckedCallResolution = union(enum) {
     direct_parametric: DirectCall,
     /// The dispatcher is one of the enclosing callable's constrained scheme
     /// vars; each specialization edge supplies the target as evidence.
-    evidence_dependent: EvidenceChainIndex,
+    evidence_dependent: struct {
+        index: EvidenceChainIndex,
+        /// The evidence slot is shared with another same-name call. It supplies
+        /// only target identity; this plan must instantiate that target against
+        /// its own callable relation.
+        independent_callable: bool = false,
+    },
     /// The checker chose a compiler-derived structural implementation.
     structural: StructuralDerivation,
     /// Checking rejected this site; lowering must never consume the plan.

--- a/src/check/test/dispatch_evidence_test.zig
+++ b/src/check/test/dispatch_evidence_test.zig
@@ -113,6 +113,26 @@ test "evidence params enumerate in signature order" {
     try std.testing.expect(params.items[0].dispatcher_var != params.items[1].dispatcher_var);
 }
 
+test "independent same-name method uses share one evidence target" {
+    const source =
+        \\f1 = |list| list.map(|item| U32.to_u64(item))
+        \\f2 = |list| list.map(|item| U32.to_u128(item))
+        \\g = |list| (f1(list), f2(list))
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    const gpa = std.testing.allocator;
+    const env = test_env.module_env;
+    var params = std.ArrayListUnmanaged(dispatch_evidence.EvidenceParam).empty;
+    defer params.deinit(gpa);
+    try enumerate(gpa, env, try defVar(env, "g"), &params);
+
+    try std.testing.expectEqual(@as(usize, 1), params.items.len);
+    const idents = env.getIdentStoreConst();
+    try std.testing.expectEqualStrings("map", idents.getText(params.items[0].constraint.fn_name));
+}
+
 test "evidence params reach vars bound only inside constraint fn types" {
     // The clauses on `b` are phantom (the body never dispatches them), which
     // keeps this a valid polymorphic signature; the enumeration must still

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -2186,6 +2186,79 @@ test "unify - flex with constraints unifies with flex with same constraints" {
     try std.testing.expectEqual(.unified, result);
 }
 
+test "unify - declarative static dispatch representative survives repeated merges" {
+    const gpa = std.testing.allocator;
+    var env = try TestEnv.init(gpa);
+    defer env.deinit();
+
+    const method_name = try env.module_env.getIdentStore().insert(
+        env.module_env.gpa,
+        Ident.for_text("combine"),
+    );
+    const argument = try env.module_env.types.fresh();
+    const result_var = try env.module_env.types.fresh();
+    const declarative_fn = try env.module_env.types.freshFromContent(
+        try env.mkFuncPure(&.{argument}, result_var),
+    );
+    const first_call_fn = try env.module_env.types.freshFromContent(
+        try env.mkFuncPure(&.{argument}, result_var),
+    );
+    const second_call_fn = try env.module_env.types.freshFromContent(
+        try env.mkFuncPure(&.{argument}, result_var),
+    );
+
+    const declarative_constraint = types_mod.StaticDispatchConstraint{
+        .fn_name = method_name,
+        .fn_var = declarative_fn,
+        .origin = .{ .desugared_binop = .{ .negated = true } },
+    };
+    const first_call_constraint = types_mod.StaticDispatchConstraint{
+        .fn_name = method_name,
+        .fn_var = first_call_fn,
+        .origin = .method_call,
+    };
+    const second_call_constraint = types_mod.StaticDispatchConstraint{
+        .fn_name = method_name,
+        .fn_var = second_call_fn,
+        .origin = .method_call,
+    };
+
+    const declarative_range = try env.module_env.types.appendStaticDispatchConstraints(
+        &.{declarative_constraint},
+    );
+    const first_call_range = try env.module_env.types.appendStaticDispatchConstraints(
+        &.{first_call_constraint},
+    );
+    const second_call_range = try env.module_env.types.appendStaticDispatchConstraints(
+        &.{second_call_constraint},
+    );
+
+    const receiver = try env.module_env.types.freshFromContent(.{ .flex = .{
+        .name = null,
+        .constraints = declarative_range,
+    } });
+    const first_call_receiver = try env.module_env.types.freshFromContent(.{ .flex = .{
+        .name = null,
+        .constraints = first_call_range,
+    } });
+    const second_call_receiver = try env.module_env.types.freshFromContent(.{ .flex = .{
+        .name = null,
+        .constraints = second_call_range,
+    } });
+
+    try std.testing.expectEqual(.unified, try env.unify(receiver, first_call_receiver));
+    try std.testing.expectEqual(.unified, try env.unify(receiver, second_call_receiver));
+
+    const resolved = env.module_env.types.resolveVar(receiver);
+    try std.testing.expect(resolved.desc.content == .flex);
+    const retained = env.module_env.types.sliceStaticDispatchConstraints(
+        resolved.desc.content.flex.constraints,
+    );
+    try std.testing.expectEqual(@as(usize, 1), retained.len);
+    try std.testing.expect(retained[0].origin == .desugared_binop);
+    try std.testing.expect(retained[0].origin.desugared_binop.negated);
+}
+
 // capture constraints
 
 test "unify - flex with constraints vs structure captures deferred check" {

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -2259,6 +2259,66 @@ test "unify - declarative static dispatch representative survives repeated merge
     try std.testing.expect(retained[0].origin.desugared_binop.negated);
 }
 
+test "unify - static dispatch method ordering ignores ident interning order" {
+    const gpa = std.testing.allocator;
+    var env = try TestEnv.init(gpa);
+    defer env.deinit();
+
+    // Deliberately intern and produce zeta first. Partitioning must still use
+    // lexical method order because Ident.Idx values are remapped by imports.
+    const zeta = try env.module_env.getIdentStore().insert(
+        env.module_env.gpa,
+        Ident.for_text("zeta"),
+    );
+    const alpha = try env.module_env.getIdentStore().insert(
+        env.module_env.gpa,
+        Ident.for_text("alpha"),
+    );
+    try std.testing.expect(zeta.idx < alpha.idx);
+
+    const argument = try env.module_env.types.fresh();
+    const result_var = try env.module_env.types.fresh();
+    const fn_var = try env.module_env.types.freshFromContent(
+        try env.mkFuncPure(&.{argument}, result_var),
+    );
+    const zeta_constraint = types_mod.StaticDispatchConstraint{
+        .fn_name = zeta,
+        .fn_var = fn_var,
+        .origin = .method_call,
+    };
+    const alpha_constraint = types_mod.StaticDispatchConstraint{
+        .fn_name = alpha,
+        .fn_var = fn_var,
+        .origin = .method_call,
+    };
+    const first_range = try env.module_env.types.appendStaticDispatchConstraints(
+        &.{ zeta_constraint, alpha_constraint },
+    );
+    const second_range = try env.module_env.types.appendStaticDispatchConstraints(
+        &.{ zeta_constraint, alpha_constraint },
+    );
+    const first = try env.module_env.types.freshFromContent(.{ .flex = .{
+        .name = null,
+        .constraints = first_range,
+    } });
+    const second = try env.module_env.types.freshFromContent(.{ .flex = .{
+        .name = null,
+        .constraints = second_range,
+    } });
+
+    try std.testing.expectEqual(.unified, try env.unify(first, second));
+    const resolved = env.module_env.types.resolveVar(first);
+    try std.testing.expect(resolved.desc.content == .flex);
+    const retained = env.module_env.types.sliceStaticDispatchConstraints(
+        resolved.desc.content.flex.constraints,
+    );
+    try std.testing.expectEqual(@as(usize, 4), retained.len);
+    try std.testing.expect(retained[0].fn_name.eql(alpha));
+    try std.testing.expect(retained[1].fn_name.eql(zeta));
+    try std.testing.expect(retained[2].fn_name.eql(alpha));
+    try std.testing.expect(retained[3].fn_name.eql(zeta));
+}
+
 // capture constraints
 
 test "unify - flex with constraints vs structure captures deferred check" {

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -3291,55 +3291,14 @@ const Unifier = struct {
 
         const top: u32 = @intCast(self.types_store.static_dispatch_constraints.len());
 
-        // Ensure we have enough memory for the new contiguous list.
-        const capacity = partitioned.in_both.len() + partitioned.only_in_a.len() + partitioned.only_in_b.len();
+        // Shared pairs validate callable compatibility. The partitioner places
+        // every constraint that must survive into one of the retained ranges.
+        const capacity = partitioned.only_in_a.len() + partitioned.only_in_b.len();
         try self.types_store.static_dispatch_constraints.items.ensureUnusedCapacity(
             self.types_store.gpa,
             capacity,
         );
 
-        for (self.scratch.in_both_static_dispatch_constraints.sliceRange(partitioned.in_both)) |two_constraints| {
-            var constraint = two_constraints.b;
-            if (two_constraints.a.origin == .from_literal and two_constraints.b.origin == .from_literal) {
-                if (mergeFromNumeralLiteralInfo(
-                    two_constraints.a.origin.numeralInfo(),
-                    two_constraints.b.origin.numeralInfo(),
-                )) |merged| {
-                    constraint.origin = .{ .from_literal = .{ .numeral = merged } };
-                }
-            }
-            // Preserve a body-forced where-clause across unification. The bit only
-            // exists on a `where_clause` origin, so it survives only by keeping that
-            // origin—or by promoting a payload-less `method_call` to it (the gap the
-            // ambiguity judgment would otherwise miss when a same-named direct call
-            // wins the merge). A `from_literal`/operator origin is left intact: its
-            // payload (numeral info, binop negation) is load-bearing for defaulting
-            // and reporting, and such a receiver is pinned by defaulting rather than
-            // judged ambiguous, so dropping the bit there is correct (overwriting it
-            // breaks e.g. ranges).
-            {
-                const a_forced = two_constraints.a.origin == .where_clause and two_constraints.a.origin.where_clause.body_required;
-                const b_forced = two_constraints.b.origin == .where_clause and two_constraints.b.origin.where_clause.body_required;
-                if (a_forced or b_forced) {
-                    switch (constraint.origin) {
-                        .where_clause => constraint.origin.where_clause.body_required = true,
-                        .method_call => constraint.origin = .{ .where_clause = .{ .body_required = true } },
-                        .from_literal, .desugared_binop, .desugared_unaryop => {},
-                    }
-                }
-            }
-            // Provenance is metadata (excluded from constraint identity): merge it
-            // field-wise, keeping the winner's value and falling back to the other
-            // side's so an introducing site recorded on either constraint
-            // survives the merge.
-            if (constraint.provenance.intro_expr == .none) {
-                constraint.provenance.intro_expr = two_constraints.a.provenance.intro_expr;
-            }
-            if (!constraint.interpolation.isPresent()) {
-                constraint.interpolation = two_constraints.a.interpolation;
-            }
-            self.types_store.static_dispatch_constraints.items.appendAssumeCapacity(constraint);
-        }
         for (self.scratch.only_in_a_static_dispatch_constraints.sliceRange(partitioned.only_in_a)) |only_a| {
             self.types_store.static_dispatch_constraints.items.appendAssumeCapacity(only_a);
         }
@@ -3386,6 +3345,22 @@ const Unifier = struct {
         only_in_b: StaticDispatchConstraint.SafeList.Range,
         in_both: TwoStaticDispatchConstraints.SafeList.Range,
     };
+
+    fn retainDeclarativeStaticDispatchConstraint(
+        self: *const Self,
+        retained_group_start: usize,
+        constraint: StaticDispatchConstraint,
+    ) Error!void {
+        for (self.scratch.only_in_a_static_dispatch_constraints.items.items[retained_group_start..]) |*existing| {
+            if (!sameDeclarativeOriginClass(existing.origin, constraint.origin)) continue;
+            existing.* = mergeStaticDispatchConstraintMetadata(constraint, existing.*);
+            return;
+        }
+        _ = try self.scratch.only_in_a_static_dispatch_constraints.append(
+            self.scratch.gpa,
+            constraint,
+        );
+    }
 
     /// Match relations that deliberately share one callable type while leaving
     /// independent same-name method calls separate. When a same-name group
@@ -3546,15 +3521,29 @@ const Unifier = struct {
                 // A written/defaulting requirement describes the one method
                 // available to the body, so every same-name declarative must
                 // agree on a single callable type and every independent call
-                // on either side must satisfy it. Pair each constraint against
-                // one representative declarative: unification is transitive,
-                // so the whole group shares one callable type, and each pair
-                // keeps its second constraint, so the merged range keeps every
-                // constraint but the representative exactly once.
+                // on either side must satisfy it. Retain one metadata-bearing
+                // declarative per semantic origin, then validate every callable
+                // against one representative. Method-call entries are subsumed
+                // by that relation; their function vars remain unified with it.
                 const representative = if (a_has_declarative)
                     a_constraints[a_indices[a_group_start]]
                 else
                     b_constraints[b_indices[b_group_start]];
+                const retained_group_start = scratch.only_in_a_static_dispatch_constraints.len();
+                var a_declarative = a_group_start;
+                while (a_declarative < a_non_method_end) : (a_declarative += 1) {
+                    try self.retainDeclarativeStaticDispatchConstraint(
+                        retained_group_start,
+                        a_constraints[a_indices[a_declarative]],
+                    );
+                }
+                var b_declarative = b_group_start;
+                while (b_declarative < b_non_method_end) : (b_declarative += 1) {
+                    try self.retainDeclarativeStaticDispatchConstraint(
+                        retained_group_start,
+                        b_constraints[b_indices[b_declarative]],
+                    );
+                }
                 var a_index = if (a_has_declarative) a_group_start + 1 else a_group_start;
                 while (a_index < a_group_end) : (a_index += 1) {
                     _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
@@ -3649,6 +3638,54 @@ const Unifier = struct {
         }
     }
 };
+
+fn sameDeclarativeOriginClass(
+    a: StaticDispatchConstraint.Origin,
+    b: StaticDispatchConstraint.Origin,
+) bool {
+    return switch (a) {
+        .method_call => false,
+        .where_clause => b == .where_clause,
+        .desugared_unaryop => b == .desugared_unaryop,
+        .desugared_binop => |a_binop| b == .desugared_binop and
+            a_binop.negated == b.desugared_binop.negated,
+        .from_literal => |a_literal| b == .from_literal and
+            std.meta.activeTag(a_literal) == std.meta.activeTag(b.from_literal),
+    };
+}
+
+fn mergeStaticDispatchConstraintMetadata(
+    other: StaticDispatchConstraint,
+    retained: StaticDispatchConstraint,
+) StaticDispatchConstraint {
+    var merged = retained;
+    if (other.origin == .from_literal and retained.origin == .from_literal) {
+        if (mergeFromNumeralLiteralInfo(
+            other.origin.numeralInfo(),
+            retained.origin.numeralInfo(),
+        )) |numeral_info| {
+            merged.origin = .{ .from_literal = .{ .numeral = numeral_info } };
+        }
+    }
+
+    const other_forced = other.origin == .where_clause and other.origin.where_clause.body_required;
+    const retained_forced = retained.origin == .where_clause and retained.origin.where_clause.body_required;
+    if (other_forced or retained_forced) {
+        std.debug.assert(merged.origin == .where_clause);
+        merged.origin.where_clause.body_required = true;
+    }
+
+    // Provenance is excluded from constraint identity. Keep the retained
+    // relation's metadata and fill any missing introducing site from the
+    // equivalent relation being folded into it.
+    if (merged.provenance.intro_expr == .none) {
+        merged.provenance.intro_expr = other.provenance.intro_expr;
+    }
+    if (!merged.interpolation.isPresent()) {
+        merged.interpolation = other.interpolation;
+    }
+    return merged;
+}
 
 fn mergeFromNumeralLiteralInfo(
     a: ?types_mod.NumeralInfo,

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -3392,12 +3392,20 @@ const Unifier = struct {
         }
 
         const ConstraintOrder = struct {
+            unifier: *const Self,
             constraints: []const StaticDispatchConstraint,
 
             fn lessThan(context: @This(), a_index: u32, b_index: u32) bool {
                 const a = context.constraints[a_index];
                 const b = context.constraints[b_index];
-                if (!a.fn_name.eql(b.fn_name)) return a.fn_name.idx < b.fn_name.idx;
+                if (!a.fn_name.eql(b.fn_name)) {
+                    // Evidence order must survive import/copy remapping, but
+                    // Ident.Idx ordering is local to one interner.
+                    return Ident.textLessThan(
+                        context.unifier.getTypeIdentText(a.fn_name),
+                        context.unifier.getTypeIdentText(b.fn_name),
+                    );
+                }
 
                 // Put declarative/defaulting relations before independent
                 // dot-call relations so each same-name group can be matched
@@ -3420,9 +3428,11 @@ const Unifier = struct {
             .count = @intCast(b_constraints.len),
         });
         std.mem.sort(u32, a_indices, ConstraintOrder{
+            .unifier = self,
             .constraints = a_constraints,
         }, ConstraintOrder.lessThan);
         std.mem.sort(u32, b_indices, ConstraintOrder{
+            .unifier = self,
             .constraints = b_constraints,
         }, ConstraintOrder.lessThan);
 
@@ -3432,7 +3442,10 @@ const Unifier = struct {
             const a_name = a_constraints[a_indices[a_group_start]].fn_name;
             const b_name = b_constraints[b_indices[b_group_start]].fn_name;
             if (!a_name.eql(b_name)) {
-                if (a_name.idx < b_name.idx) {
+                if (Ident.textLessThan(
+                    self.getTypeIdentText(a_name),
+                    self.getTypeIdentText(b_name),
+                )) {
                     _ = try scratch.only_in_a_static_dispatch_constraints.append(
                         scratch.gpa,
                         a_constraints[a_indices[a_group_start]],
@@ -3649,8 +3662,13 @@ fn sameDeclarativeOriginClass(
         .desugared_unaryop => b == .desugared_unaryop,
         .desugared_binop => |a_binop| b == .desugared_binop and
             a_binop.negated == b.desugared_binop.negated,
-        .from_literal => |a_literal| b == .from_literal and
-            std.meta.activeTag(a_literal) == std.meta.activeTag(b.from_literal),
+        .from_literal => |a_literal| b == .from_literal and switch (a_literal) {
+            // Each interpolation carries its own part vars and source regions;
+            // sharing one callable relation must not discard those checks.
+            .interpolation => false,
+            .numeral, .quote => std.meta.activeTag(a_literal) ==
+                std.meta.activeTag(b.from_literal),
+        },
     };
 }
 

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -3387,84 +3387,259 @@ const Unifier = struct {
         in_both: TwoStaticDispatchConstraints.SafeList.Range,
     };
 
-    /// Given two ranges of record fields stored in `scratch.gathered_fields`, this function:
-    /// * sorts both slices in-place by field name
-    /// * partitions them into three disjoint groups:
-    ///     - fields only in `a`
-    ///     - fields only in `b`
-    ///     - fields present in both (by name)
-    ///
-    /// These groups are stored into dedicated scratch buffers:
-    /// * `only_in_a_fields`
-    /// * `only_in_b_fields`
-    /// * `in_both_fields`
-    ///
-    /// The result is a set of ranges that can be used to slice those buffers.
+    /// Match relations that deliberately share one callable type while leaving
+    /// independent same-name method calls separate. Keeping those calls separate
+    /// lets each use instantiate a selected rank-1 method scheme independently.
     fn partitionStaticDispatchConstraints(
         self: *const Self,
         a_constraints_range: StaticDispatchConstraint.SafeList.Range,
         b_constraints_range: StaticDispatchConstraint.SafeList.Range,
-    ) std.mem.Allocator.Error!PartitionedStaticDispatchConstraints {
+    ) Error!PartitionedStaticDispatchConstraints {
         const scratch = self.scratch;
 
-        // First sort the fields
         const a_constraints = self.types_store.static_dispatch_constraints.sliceRange(a_constraints_range);
-        std.mem.sort(StaticDispatchConstraint, a_constraints, self, struct {
-            fn less(unifier: *const Self, a: StaticDispatchConstraint, b: StaticDispatchConstraint) bool {
-                return std.mem.order(u8, unifier.getTypeIdentText(a.fn_name), unifier.getTypeIdentText(b.fn_name)) == .lt;
-            }
-        }.less);
         const b_constraints = self.types_store.static_dispatch_constraints.sliceRange(b_constraints_range);
-        std.mem.sort(StaticDispatchConstraint, b_constraints, self, struct {
-            fn less(unifier: *const Self, a: StaticDispatchConstraint, b: StaticDispatchConstraint) bool {
-                return std.mem.order(u8, unifier.getTypeIdentText(a.fn_name), unifier.getTypeIdentText(b.fn_name)) == .lt;
-            }
-        }.less);
 
         // Get the start of index of the new range
         const a_constraints_start: u32 = @intCast(scratch.only_in_a_static_dispatch_constraints.len());
         const b_constraints_start: u32 = @intCast(scratch.only_in_b_static_dispatch_constraints.len());
         const both_constraints_start: u32 = @intCast(scratch.in_both_static_dispatch_constraints.len());
+        const a_indices_start: u32 = @intCast(scratch.a_static_dispatch_constraint_indices.len());
+        const b_indices_start: u32 = @intCast(scratch.b_static_dispatch_constraint_indices.len());
+        for (a_constraints, 0..) |_, i| {
+            _ = try scratch.a_static_dispatch_constraint_indices.append(scratch.gpa, @intCast(i));
+        }
+        for (b_constraints, 0..) |_, i| {
+            _ = try scratch.b_static_dispatch_constraint_indices.append(scratch.gpa, @intCast(i));
+        }
 
-        // Iterate over the fields in order, grouping them
-        var a_i: usize = 0;
-        var b_i: usize = 0;
-        while (a_i < a_constraints.len and b_i < b_constraints.len) {
-            const a_next = a_constraints[a_i];
-            const b_next = b_constraints[b_i];
-            const ord = std.mem.order(u8, self.getTypeIdentText(a_next.fn_name), self.getTypeIdentText(b_next.fn_name));
-            switch (ord) {
-                .eq => {
-                    _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, TwoStaticDispatchConstraints{
-                        .a = a_next,
-                        .b = b_next,
-                    });
-                    a_i = a_i + 1;
-                    b_i = b_i + 1;
-                },
+        const ConstraintOrder = struct {
+            unifier: *const Self,
+            constraints: []const StaticDispatchConstraint,
+
+            fn lessThan(context: @This(), a_index: u32, b_index: u32) bool {
+                const a = context.constraints[a_index];
+                const b = context.constraints[b_index];
+                switch (std.mem.order(u8, context.unifier.getTypeIdentText(a.fn_name), context.unifier.getTypeIdentText(b.fn_name))) {
+                    .lt => return true,
+                    .gt => return false,
+                    .eq => {},
+                }
+
+                // Put declarative/defaulting relations before independent
+                // dot-call relations so each same-name group can be matched
+                // with a linear scan.
+                const a_is_method_call = a.origin == .method_call;
+                const b_is_method_call = b.origin == .method_call;
+                if (a_is_method_call != b_is_method_call) return !a_is_method_call;
+
+                // Preserve producer order within each semantic class.
+                return a_index < b_index;
+            }
+        };
+
+        const a_indices = scratch.a_static_dispatch_constraint_indices.sliceRange(.{
+            .start = @enumFromInt(a_indices_start),
+            .count = @intCast(a_constraints.len),
+        });
+        const b_indices = scratch.b_static_dispatch_constraint_indices.sliceRange(.{
+            .start = @enumFromInt(b_indices_start),
+            .count = @intCast(b_constraints.len),
+        });
+        std.mem.sort(u32, a_indices, ConstraintOrder{
+            .unifier = self,
+            .constraints = a_constraints,
+        }, ConstraintOrder.lessThan);
+        std.mem.sort(u32, b_indices, ConstraintOrder{
+            .unifier = self,
+            .constraints = b_constraints,
+        }, ConstraintOrder.lessThan);
+
+        var a_group_start: usize = 0;
+        var b_group_start: usize = 0;
+        while (a_group_start < a_indices.len and b_group_start < b_indices.len) {
+            const a_name = self.getTypeIdentText(a_constraints[a_indices[a_group_start]].fn_name);
+            const b_name = self.getTypeIdentText(b_constraints[b_indices[b_group_start]].fn_name);
+            switch (std.mem.order(u8, a_name, b_name)) {
                 .lt => {
-                    _ = try scratch.only_in_a_static_dispatch_constraints.append(scratch.gpa, a_next);
-                    a_i = a_i + 1;
+                    _ = try scratch.only_in_a_static_dispatch_constraints.append(
+                        scratch.gpa,
+                        a_constraints[a_indices[a_group_start]],
+                    );
+                    a_group_start += 1;
+                    continue;
                 },
                 .gt => {
-                    _ = try scratch.only_in_b_static_dispatch_constraints.append(scratch.gpa, b_next);
-                    b_i = b_i + 1;
+                    _ = try scratch.only_in_b_static_dispatch_constraints.append(
+                        scratch.gpa,
+                        b_constraints[b_indices[b_group_start]],
+                    );
+                    b_group_start += 1;
+                    continue;
                 },
+                .eq => {},
             }
+
+            var a_group_end = a_group_start + 1;
+            while (a_group_end < a_indices.len and
+                std.mem.eql(u8, a_name, self.getTypeIdentText(a_constraints[a_indices[a_group_end]].fn_name)))
+            {
+                a_group_end += 1;
+            }
+            var b_group_end = b_group_start + 1;
+            while (b_group_end < b_indices.len and
+                std.mem.eql(u8, b_name, self.getTypeIdentText(b_constraints[b_indices[b_group_end]].fn_name)))
+            {
+                b_group_end += 1;
+            }
+
+            // A rank-1 method scheme has one fixed outer function shape. Its
+            // quantified types may instantiate differently at each call, but
+            // instantiation cannot change argument count or a known effect
+            // mode. Reject this impossible conjunction before carrying it into
+            // a scheme.
+            var common_arity: ?u32 = null;
+            var common_effectful: ?bool = null;
+            for (a_indices[a_group_start..a_group_end]) |constraint_index| {
+                if (self.staticDispatchCallableHead(a_constraints[constraint_index])) |head| {
+                    if (common_arity) |expected| {
+                        if (head.arity != expected) return error.TypeMismatch;
+                    } else {
+                        common_arity = head.arity;
+                    }
+                    if (head.effectful) |effectful| {
+                        if (common_effectful) |expected| {
+                            if (effectful != expected) return error.TypeMismatch;
+                        } else {
+                            common_effectful = effectful;
+                        }
+                    }
+                }
+            }
+            for (b_indices[b_group_start..b_group_end]) |constraint_index| {
+                if (self.staticDispatchCallableHead(b_constraints[constraint_index])) |head| {
+                    if (common_arity) |expected| {
+                        if (head.arity != expected) return error.TypeMismatch;
+                    } else {
+                        common_arity = head.arity;
+                    }
+                    if (head.effectful) |effectful| {
+                        if (common_effectful) |expected| {
+                            if (effectful != expected) return error.TypeMismatch;
+                        } else {
+                            common_effectful = effectful;
+                        }
+                    }
+                }
+            }
+
+            var a_non_method_end = a_group_start;
+            while (a_non_method_end < a_group_end and
+                a_constraints[a_indices[a_non_method_end]].origin != .method_call)
+            {
+                a_non_method_end += 1;
+            }
+            var b_non_method_end = b_group_start;
+            while (b_non_method_end < b_group_end and
+                b_constraints[b_indices[b_non_method_end]].origin != .method_call)
+            {
+                b_non_method_end += 1;
+            }
+
+            var a_non_method = a_group_start;
+            var b_non_method = b_group_start;
+            while (a_non_method < a_non_method_end and b_non_method < b_non_method_end) {
+                _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
+                    .a = a_constraints[a_indices[a_non_method]],
+                    .b = b_constraints[b_indices[b_non_method]],
+                });
+                a_non_method += 1;
+                b_non_method += 1;
+            }
+
+            var a_method = a_non_method_end;
+            var b_method = b_non_method_end;
+            while (a_non_method < a_non_method_end and b_method < b_group_end) {
+                _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
+                    .a = a_constraints[a_indices[a_non_method]],
+                    .b = b_constraints[b_indices[b_method]],
+                });
+                a_non_method += 1;
+                b_method += 1;
+            }
+            while (a_method < a_group_end and b_non_method < b_non_method_end) {
+                _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
+                    .a = a_constraints[a_indices[a_method]],
+                    .b = b_constraints[b_indices[b_non_method]],
+                });
+                a_method += 1;
+                b_non_method += 1;
+            }
+
+            // A written/defaulting requirement describes the method available
+            // to the body, so every independent call on the other side must
+            // satisfy it. Reuse one representative after the one-to-one matches;
+            // this checks every call without unifying independent inferred calls
+            // when neither side supplies a declaration.
+            if (a_non_method_end > a_group_start) {
+                const representative = a_constraints[a_indices[a_group_start]];
+                while (b_method < b_group_end) : (b_method += 1) {
+                    _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
+                        .a = representative,
+                        .b = b_constraints[b_indices[b_method]],
+                    });
+                }
+            }
+            if (b_non_method_end > b_group_start) {
+                const representative = b_constraints[b_indices[b_group_start]];
+                while (a_method < a_group_end) : (a_method += 1) {
+                    _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
+                        .a = a_constraints[a_indices[a_method]],
+                        .b = representative,
+                    });
+                }
+            }
+
+            while (a_non_method < a_non_method_end) : (a_non_method += 1) {
+                _ = try scratch.only_in_a_static_dispatch_constraints.append(
+                    scratch.gpa,
+                    a_constraints[a_indices[a_non_method]],
+                );
+            }
+            while (a_method < a_group_end) : (a_method += 1) {
+                _ = try scratch.only_in_a_static_dispatch_constraints.append(
+                    scratch.gpa,
+                    a_constraints[a_indices[a_method]],
+                );
+            }
+            while (b_non_method < b_non_method_end) : (b_non_method += 1) {
+                _ = try scratch.only_in_b_static_dispatch_constraints.append(
+                    scratch.gpa,
+                    b_constraints[b_indices[b_non_method]],
+                );
+            }
+            while (b_method < b_group_end) : (b_method += 1) {
+                _ = try scratch.only_in_b_static_dispatch_constraints.append(
+                    scratch.gpa,
+                    b_constraints[b_indices[b_method]],
+                );
+            }
+
+            a_group_start = a_group_end;
+            b_group_start = b_group_end;
         }
 
-        // If b was shorter, add the extra a elems
-        while (a_i < a_constraints.len) {
-            const a_next = a_constraints[a_i];
-            _ = try scratch.only_in_a_static_dispatch_constraints.append(scratch.gpa, a_next);
-            a_i = a_i + 1;
+        while (a_group_start < a_indices.len) : (a_group_start += 1) {
+            _ = try scratch.only_in_a_static_dispatch_constraints.append(
+                scratch.gpa,
+                a_constraints[a_indices[a_group_start]],
+            );
         }
-
-        // If a was shorter, add the extra b elems
-        while (b_i < b_constraints.len) {
-            const b_next = b_constraints[b_i];
-            _ = try scratch.only_in_b_static_dispatch_constraints.append(scratch.gpa, b_next);
-            b_i = b_i + 1;
+        while (b_group_start < b_indices.len) : (b_group_start += 1) {
+            _ = try scratch.only_in_b_static_dispatch_constraints.append(
+                scratch.gpa,
+                b_constraints[b_indices[b_group_start]],
+            );
         }
 
         // Return the ranges
@@ -3473,6 +3648,41 @@ const Unifier = struct {
             .only_in_b = scratch.only_in_b_static_dispatch_constraints.rangeToEnd(b_constraints_start),
             .in_both = scratch.in_both_static_dispatch_constraints.rangeToEnd(both_constraints_start),
         };
+    }
+
+    const StaticDispatchCallableHead = struct {
+        arity: u32,
+        /// Null is an effect-polymorphic callable.
+        effectful: ?bool,
+    };
+
+    fn staticDispatchCallableHead(
+        self: *const Self,
+        constraint: StaticDispatchConstraint,
+    ) ?StaticDispatchCallableHead {
+        var callable_var = constraint.fn_var;
+        var guard = types_mod.debug.IterationGuard.init("staticDispatchCallableHead");
+        while (true) {
+            guard.tick();
+            const resolved = self.types_store.resolveVar(callable_var);
+            switch (resolved.desc.content) {
+                .alias => |alias| callable_var = self.types_store.getAliasBackingVar(alias),
+                .structure => |flat_type| return switch (flat_type) {
+                    .fn_pure => |func| .{ .arity = func.args.len(), .effectful = false },
+                    .fn_effectful => |func| .{ .arity = func.args.len(), .effectful = true },
+                    .fn_unbound => |func| .{ .arity = func.args.len(), .effectful = null },
+                    .record,
+                    .record_unbound,
+                    .tuple,
+                    .nominal_type,
+                    .tag_union,
+                    .empty_record,
+                    .empty_tag_union,
+                    => null,
+                },
+                .flex, .rigid, .field_presence, .err => return null,
+            }
+        }
     }
 };
 
@@ -3680,6 +3890,8 @@ pub const Scratch = struct {
     only_in_a_static_dispatch_constraints: StaticDispatchConstraint.SafeList,
     only_in_b_static_dispatch_constraints: StaticDispatchConstraint.SafeList,
     in_both_static_dispatch_constraints: TwoStaticDispatchConstraints.SafeList,
+    a_static_dispatch_constraint_indices: MkSafeList(u32),
+    b_static_dispatch_constraint_indices: MkSafeList(u32),
 
     // occurs
     occurs_scratch: occurs.Scratch,
@@ -3736,6 +3948,8 @@ pub const Scratch = struct {
             .only_in_a_static_dispatch_constraints = try StaticDispatchConstraint.SafeList.initCapacity(gpa, 32),
             .only_in_b_static_dispatch_constraints = try StaticDispatchConstraint.SafeList.initCapacity(gpa, 32),
             .in_both_static_dispatch_constraints = try TwoStaticDispatchConstraints.SafeList.initCapacity(gpa, 32),
+            .a_static_dispatch_constraint_indices = try MkSafeList(u32).initCapacity(gpa, 32),
+            .b_static_dispatch_constraint_indices = try MkSafeList(u32).initCapacity(gpa, 32),
             .occurs_scratch = try occurs.Scratch.init(gpa),
             .visited_vars = try VarSafeList.initCapacity(gpa, 16),
             .open_var_map = std.AutoHashMap(types_mod.Var, types_mod.Var).init(gpa),
@@ -3763,6 +3977,8 @@ pub const Scratch = struct {
         self.only_in_a_static_dispatch_constraints.deinit(self.gpa);
         self.only_in_b_static_dispatch_constraints.deinit(self.gpa);
         self.in_both_static_dispatch_constraints.deinit(self.gpa);
+        self.a_static_dispatch_constraint_indices.deinit(self.gpa);
+        self.b_static_dispatch_constraint_indices.deinit(self.gpa);
         self.occurs_scratch.deinit();
         self.visited_vars.deinit(self.gpa);
         self.constraint_visited_vars.deinit(self.gpa);
@@ -3788,6 +4004,8 @@ pub const Scratch = struct {
         self.only_in_a_static_dispatch_constraints.items.clearRetainingCapacity();
         self.only_in_b_static_dispatch_constraints.items.clearRetainingCapacity();
         self.in_both_static_dispatch_constraints.items.clearRetainingCapacity();
+        self.a_static_dispatch_constraint_indices.items.clearRetainingCapacity();
+        self.b_static_dispatch_constraint_indices.items.clearRetainingCapacity();
         self.fresh_vars.items.clearRetainingCapacity();
         self.occurs_scratch.reset();
         self.visited_vars.items.clearRetainingCapacity();

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -3542,7 +3542,9 @@ const Unifier = struct {
                     a_constraints[a_indices[a_group_start]]
                 else
                     b_constraints[b_indices[b_group_start]];
-                const retained_group_start = scratch.only_in_a_static_dispatch_constraints.len();
+                const retained_group_start: usize = @intCast(
+                    scratch.only_in_a_static_dispatch_constraints.len(),
+                );
                 var a_declarative = a_group_start;
                 while (a_declarative < a_non_method_end) : (a_declarative += 1) {
                     try self.retainDeclarativeStaticDispatchConstraint(

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -3388,8 +3388,11 @@ const Unifier = struct {
     };
 
     /// Match relations that deliberately share one callable type while leaving
-    /// independent same-name method calls separate. Keeping those calls separate
-    /// lets each use instantiate a selected rank-1 method scheme independently.
+    /// independent same-name method calls separate. When a same-name group
+    /// contains any declarative relation (where clause, literal, or operator),
+    /// the whole group unifies through one representative declarative; a group
+    /// of dot calls alone stays separate so each use can instantiate a selected
+    /// rank-1 method scheme independently.
     fn partitionStaticDispatchConstraints(
         self: *const Self,
         a_constraints_range: StaticDispatchConstraint.SafeList.Range,
@@ -3546,83 +3549,53 @@ const Unifier = struct {
                 b_non_method_end += 1;
             }
 
-            var a_non_method = a_group_start;
-            var b_non_method = b_group_start;
-            while (a_non_method < a_non_method_end and b_non_method < b_non_method_end) {
-                _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
-                    .a = a_constraints[a_indices[a_non_method]],
-                    .b = b_constraints[b_indices[b_non_method]],
-                });
-                a_non_method += 1;
-                b_non_method += 1;
-            }
-
-            var a_method = a_non_method_end;
-            var b_method = b_non_method_end;
-            while (a_non_method < a_non_method_end and b_method < b_group_end) {
-                _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
-                    .a = a_constraints[a_indices[a_non_method]],
-                    .b = b_constraints[b_indices[b_method]],
-                });
-                a_non_method += 1;
-                b_method += 1;
-            }
-            while (a_method < a_group_end and b_non_method < b_non_method_end) {
-                _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
-                    .a = a_constraints[a_indices[a_method]],
-                    .b = b_constraints[b_indices[b_non_method]],
-                });
-                a_method += 1;
-                b_non_method += 1;
-            }
-
-            // A written/defaulting requirement describes the method available
-            // to the body, so every independent call on the other side must
-            // satisfy it. Reuse one representative after the one-to-one matches;
-            // this checks every call without unifying independent inferred calls
-            // when neither side supplies a declaration.
-            if (a_non_method_end > a_group_start) {
-                const representative = a_constraints[a_indices[a_group_start]];
-                while (b_method < b_group_end) : (b_method += 1) {
+            const a_has_declarative = a_non_method_end > a_group_start;
+            const b_has_declarative = b_non_method_end > b_group_start;
+            if (a_has_declarative or b_has_declarative) {
+                // A written/defaulting requirement describes the one method
+                // available to the body, so every same-name declarative must
+                // agree on a single callable type and every independent call
+                // on either side must satisfy it. Pair each constraint against
+                // one representative declarative: unification is transitive,
+                // so the whole group shares one callable type, and each pair
+                // keeps its second constraint, so the merged range keeps every
+                // constraint but the representative exactly once.
+                const representative = if (a_has_declarative)
+                    a_constraints[a_indices[a_group_start]]
+                else
+                    b_constraints[b_indices[b_group_start]];
+                var a_index = if (a_has_declarative) a_group_start + 1 else a_group_start;
+                while (a_index < a_group_end) : (a_index += 1) {
                     _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
                         .a = representative,
-                        .b = b_constraints[b_indices[b_method]],
+                        .b = a_constraints[a_indices[a_index]],
                     });
                 }
-            }
-            if (b_non_method_end > b_group_start) {
-                const representative = b_constraints[b_indices[b_group_start]];
-                while (a_method < a_group_end) : (a_method += 1) {
+                var b_index = if (a_has_declarative) b_group_start else b_group_start + 1;
+                while (b_index < b_group_end) : (b_index += 1) {
                     _ = try scratch.in_both_static_dispatch_constraints.append(scratch.gpa, .{
-                        .a = a_constraints[a_indices[a_method]],
-                        .b = representative,
+                        .a = representative,
+                        .b = b_constraints[b_indices[b_index]],
                     });
                 }
-            }
-
-            while (a_non_method < a_non_method_end) : (a_non_method += 1) {
-                _ = try scratch.only_in_a_static_dispatch_constraints.append(
-                    scratch.gpa,
-                    a_constraints[a_indices[a_non_method]],
-                );
-            }
-            while (a_method < a_group_end) : (a_method += 1) {
-                _ = try scratch.only_in_a_static_dispatch_constraints.append(
-                    scratch.gpa,
-                    a_constraints[a_indices[a_method]],
-                );
-            }
-            while (b_non_method < b_non_method_end) : (b_non_method += 1) {
-                _ = try scratch.only_in_b_static_dispatch_constraints.append(
-                    scratch.gpa,
-                    b_constraints[b_indices[b_non_method]],
-                );
-            }
-            while (b_method < b_group_end) : (b_method += 1) {
-                _ = try scratch.only_in_b_static_dispatch_constraints.append(
-                    scratch.gpa,
-                    b_constraints[b_indices[b_method]],
-                );
+            } else {
+                // Only independent dot-call relations: keep each side's calls
+                // separate so every use can instantiate the selected rank-1
+                // method scheme at its own type.
+                var a_index = a_group_start;
+                while (a_index < a_group_end) : (a_index += 1) {
+                    _ = try scratch.only_in_a_static_dispatch_constraints.append(
+                        scratch.gpa,
+                        a_constraints[a_indices[a_index]],
+                    );
+                }
+                var b_index = b_group_start;
+                while (b_index < b_group_end) : (b_index += 1) {
+                    _ = try scratch.only_in_b_static_dispatch_constraints.append(
+                        scratch.gpa,
+                        b_constraints[b_indices[b_index]],
+                    );
+                }
             }
 
             a_group_start = a_group_end;

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -3417,17 +3417,12 @@ const Unifier = struct {
         }
 
         const ConstraintOrder = struct {
-            unifier: *const Self,
             constraints: []const StaticDispatchConstraint,
 
             fn lessThan(context: @This(), a_index: u32, b_index: u32) bool {
                 const a = context.constraints[a_index];
                 const b = context.constraints[b_index];
-                switch (std.mem.order(u8, context.unifier.getTypeIdentText(a.fn_name), context.unifier.getTypeIdentText(b.fn_name))) {
-                    .lt => return true,
-                    .gt => return false,
-                    .eq => {},
-                }
+                if (!a.fn_name.eql(b.fn_name)) return a.fn_name.idx < b.fn_name.idx;
 
                 // Put declarative/defaulting relations before independent
                 // dot-call relations so each same-name group can be matched
@@ -3450,48 +3445,44 @@ const Unifier = struct {
             .count = @intCast(b_constraints.len),
         });
         std.mem.sort(u32, a_indices, ConstraintOrder{
-            .unifier = self,
             .constraints = a_constraints,
         }, ConstraintOrder.lessThan);
         std.mem.sort(u32, b_indices, ConstraintOrder{
-            .unifier = self,
             .constraints = b_constraints,
         }, ConstraintOrder.lessThan);
 
         var a_group_start: usize = 0;
         var b_group_start: usize = 0;
         while (a_group_start < a_indices.len and b_group_start < b_indices.len) {
-            const a_name = self.getTypeIdentText(a_constraints[a_indices[a_group_start]].fn_name);
-            const b_name = self.getTypeIdentText(b_constraints[b_indices[b_group_start]].fn_name);
-            switch (std.mem.order(u8, a_name, b_name)) {
-                .lt => {
+            const a_name = a_constraints[a_indices[a_group_start]].fn_name;
+            const b_name = b_constraints[b_indices[b_group_start]].fn_name;
+            if (!a_name.eql(b_name)) {
+                if (a_name.idx < b_name.idx) {
                     _ = try scratch.only_in_a_static_dispatch_constraints.append(
                         scratch.gpa,
                         a_constraints[a_indices[a_group_start]],
                     );
                     a_group_start += 1;
                     continue;
-                },
-                .gt => {
+                } else {
                     _ = try scratch.only_in_b_static_dispatch_constraints.append(
                         scratch.gpa,
                         b_constraints[b_indices[b_group_start]],
                     );
                     b_group_start += 1;
                     continue;
-                },
-                .eq => {},
+                }
             }
 
             var a_group_end = a_group_start + 1;
             while (a_group_end < a_indices.len and
-                std.mem.eql(u8, a_name, self.getTypeIdentText(a_constraints[a_indices[a_group_end]].fn_name)))
+                a_name.eql(a_constraints[a_indices[a_group_end]].fn_name))
             {
                 a_group_end += 1;
             }
             var b_group_end = b_group_start + 1;
             while (b_group_end < b_indices.len and
-                std.mem.eql(u8, b_name, self.getTypeIdentText(b_constraints[b_indices[b_group_end]].fn_name)))
+                b_name.eql(b_constraints[b_indices[b_group_end]].fn_name))
             {
                 b_group_end += 1;
             }

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2168,11 +2168,44 @@ test "issue 10529 open Try chain with named local callback stays bounded" {
     ;
 
     const counters = try monotypeCountersForModule(allocator, source);
-    try std.testing.expect(counters.template_misses <= 20);
-    // Generalized record fields retain distinct source-value/runtime-slot
-    // cells until specialization freeze. Keep that fixed linear bookkeeping
-    // bounded while guarding against the former exponential Try-chain growth.
-    try std.testing.expect(counters.nominal_backing_instantiations <= 325);
+    // Repeated calls retain independent callable relations while equivalent
+    // public requirements collapse to a fixed set at each helper boundary.
+    // Guard that linear bookkeeping against transitive requirement growth.
+    try std.testing.expect(counters.template_misses <= 60);
+    try std.testing.expect(counters.nominal_backing_instantiations <= 2000);
+}
+
+test "independent same-name helper requirements lower separately" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\take0 = |b| {
+        \\    to_end = |_| End
+        \\    Ok({ val: b.get(0).map_err(to_end)?, rest: b.drop_first(1) })
+        \\}
+        \\take1 = |b| Ok({ val: take0(b)?.val, rest: take0(b)?.rest })
+        \\take2 = |b| Ok({ val: take1(b)?.val, rest: take1(b)?.rest })
+        \\take3 = |b| Ok({ val: take2(b)?.val, rest: take2(b)?.rest })
+        \\take4 = |b| Ok({ val: take3(b)?.val, rest: take3(b)?.rest })
+        \\
+        \\main : {} -> Try({ val : U8, rest : List(U8) }, [End, ..])
+        \\main = |_| take4([1, 2, 3])
+    ;
+
+    _ = try monotypeCountersForModule(allocator, source);
+}
+
+test "independent same-name method requirements specialize separately" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\f1 = |list| list.map(|item| U32.to_u64(item))
+        \\f2 = |list| list.map(|item| U32.to_u128(item))
+        \\g = |list| (f1(list), f2(list))
+        \\
+        \\main : {} -> (List(U64), List(U128))
+        \\main = |_| g([1.U32, 2.U32])
+    ;
+
+    _ = try monotypeCountersForModule(allocator, source);
 }
 
 test "specialization interface replay follows returned local functions through wrappers" {

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2208,6 +2208,35 @@ test "independent same-name method requirements specialize separately" {
     _ = try monotypeCountersForModule(allocator, source);
 }
 
+test "independent same-name iterator requirements specialize separately" {
+    const allocator = std.testing.allocator;
+    // Empty.iter quantifies its element beyond the dispatcher, so the two
+    // loops instantiate the shared iter evidence at different element types.
+    const source =
+        \\Empty := [E].{
+        \\    iter : Empty -> Iter(item)
+        \\    iter = |_| List.iter([])
+        \\}
+        \\
+        \\g = |e| {
+        \\    var $a = 0.U64
+        \\    for x in e {
+        \\        $a = $a + x
+        \\    }
+        \\    var $b = 0.U128
+        \\    for x in e {
+        \\        $b = $b + x
+        \\    }
+        \\    ($a, $b)
+        \\}
+        \\
+        \\main : {} -> (U64, U128)
+        \\main = |_| g(Empty.E)
+    ;
+
+    _ = try monotypeCountersForModule(allocator, source);
+}
+
 test "specialization interface replay follows returned local functions through wrappers" {
     const allocator = std.testing.allocator;
     const source =

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2149,30 +2149,29 @@ test "specialization scheduling is deterministic across repeat runs" {
     }
 }
 
-test "issue 10529 open Try chain with named local callback stays bounded" {
+test "issue 10529 ten-level open Try chain with inline callback stays bounded" {
     const allocator = std.testing.allocator;
     const source =
-        \\take0 = |b| {
-        \\    to_end = |_| End
-        \\    Ok({ val: b.get(0).map_err(to_end)?, rest: b.drop_first(1) })
-        \\}
+        \\take0 = |b| Ok({ val: b.get(0).map_err(|_| End)?, rest: b.drop_first(1) })
         \\take1 = |b| Ok({ val: take0(b)?.val, rest: take0(b)?.rest })
         \\take2 = |b| Ok({ val: take1(b)?.val, rest: take1(b)?.rest })
         \\take3 = |b| Ok({ val: take2(b)?.val, rest: take2(b)?.rest })
         \\take4 = |b| Ok({ val: take3(b)?.val, rest: take3(b)?.rest })
         \\take5 = |b| Ok({ val: take4(b)?.val, rest: take4(b)?.rest })
         \\take6 = |b| Ok({ val: take5(b)?.val, rest: take5(b)?.rest })
+        \\take7 = |b| Ok({ val: take6(b)?.val, rest: take6(b)?.rest })
+        \\take8 = |b| Ok({ val: take7(b)?.val, rest: take7(b)?.rest })
+        \\take9 = |b| Ok({ val: take8(b)?.val, rest: take8(b)?.rest })
         \\
         \\main : {} -> Try({ val : U8, rest : List(U8) }, [End, ..])
-        \\main = |_| take6([1, 2, 3])
+        \\main = |_| take9([1, 2, 3])
     ;
 
     const counters = try monotypeCountersForModule(allocator, source);
-    // Repeated calls retain independent callable relations while equivalent
-    // public requirements collapse to a fixed set at each helper boundary.
-    // Guard that linear bookkeeping against transitive requirement growth.
-    try std.testing.expect(counters.template_misses <= 60);
-    try std.testing.expect(counters.nominal_backing_instantiations <= 2000);
+    // Each helper adds a fixed amount of work: completed transitive interface
+    // summaries replay without coupling the two independent calls.
+    try std.testing.expect(counters.template_misses <= 75);
+    try std.testing.expect(counters.nominal_backing_instantiations <= 2250);
 }
 
 test "independent same-name helper requirements lower separately" {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -13241,7 +13241,10 @@ const InterfaceReplayEntry = struct {
     evidence: StoredConstFnEvidence,
     provisional_ty: Type.TypeId,
     representative: NodeId,
-    duplicates: std.ArrayList(NodeId) = .empty,
+    /// Immutable result of expanding the representative. Instantiating this
+    /// snapshot gives each independent request fresh variables while replaying
+    /// the complete transitive interface constraints.
+    summary_ty: ?Type.TypeId = null,
     status: InterfaceReplayStatus = .expanding,
 };
 
@@ -13257,7 +13260,6 @@ const InterfaceReplayState = struct {
     }
 
     fn deinit(self: *InterfaceReplayState, allocator: Allocator) void {
-        for (self.entries.items) |*entry| entry.duplicates.deinit(allocator);
         self.entries.deinit(allocator);
         var buckets = self.buckets.valueIterator();
         while (buckets.next()) |bucket| bucket.deinit(allocator);
@@ -17362,7 +17364,6 @@ const BodyContext = struct {
             &active_local_scopes,
             &replay_state,
         );
-        try self.finishCheckedTemplateInterfaceReplay(&replay_state);
     }
 
     fn applyCheckedTemplateInterfaceScopeRelations(
@@ -17585,13 +17586,16 @@ const BodyContext = struct {
                     request_fn_node,
                 ),
                 .ready => {
-                    // Alpha-equivalent provisional views can still contain
-                    // different live variables that acquire incompatible
-                    // structure later. Reuse is safe when the requests are
-                    // already the same graph interface: later refinements then
-                    // reach the same argument and result classes.
-                    if (!self.graph.sameFunctionInterface(entry.representative, request_fn_node)) continue;
-                    try entry.duplicates.append(self.allocator, request_fn_node);
+                    // Never join an independent request to the completed live
+                    // graph. Its variables may subsequently be refined by its
+                    // caller. Instantiating the immutable summary preserves its
+                    // internal sharing while allocating fresh request variables.
+                    try relateFunctionRequestInterface(
+                        self.graph,
+                        try self.graph.instantiateProvisionalTypeView(entry.summary_ty orelse
+                            Common.invariant("ready interface replay had no summary")),
+                        request_fn_node,
+                    );
                 },
             }
             return;
@@ -17642,30 +17646,9 @@ const BodyContext = struct {
             &active_local_scopes,
             replay_state,
         );
-        replay_state.entries.items[replay_index].status = .ready;
-    }
-
-    fn finishCheckedTemplateInterfaceReplay(
-        self: *BodyContext,
-        replay_state: *InterfaceReplayState,
-    ) Allocator.Error!void {
-        const final_types = try self.allocator.alloc(Type.TypeId, replay_state.entries.items.len);
-        defer self.allocator.free(final_types);
-        for (replay_state.entries.items, final_types) |entry, *final_ty| {
-            if (entry.status != .ready) {
-                Common.invariant("checked specialization interface replay did not finish");
-            }
-            final_ty.* = try self.graph.provisionalTypeViewForNode(entry.representative);
-        }
-        for (replay_state.entries.items, final_types) |entry, final_ty| {
-            for (entry.duplicates.items) |duplicate| {
-                try relateFunctionRequestInterface(
-                    self.graph,
-                    try self.graph.instantiateProvisionalTypeView(final_ty),
-                    duplicate,
-                );
-            }
-        }
+        const entry = &replay_state.entries.items[replay_index];
+        entry.summary_ty = try self.graph.provisionalTypeViewForNode(entry.representative);
+        entry.status = .ready;
     }
 
     fn lowerEntryWrapperAtCell(

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -47211,7 +47211,14 @@ const BodyContext = struct {
                 .target => |target| .{
                     .view = target.view,
                     .target = target.target,
-                    .instantiation = target.instantiation,
+                    // Shared evidence carries the callable instantiation of
+                    // whichever same-name relation the caller materialized.
+                    // An independent relation supplies only the target
+                    // identity and instantiates against its own plan.
+                    .instantiation = if (dependent.independent_callable)
+                        null
+                    else
+                        target.instantiation,
                     .local_proc_context = target.local_proc_context,
                 },
                 .structural, .unreachable_value, .checked_error => Common.invariant("iterator dispatch evidence was not a callable target"),

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -17064,7 +17064,15 @@ const BodyContext = struct {
                     entry.representative,
                     request_fn_node,
                 ),
-                .ready => try entry.duplicates.append(self.allocator, request_fn_node),
+                .ready => {
+                    // Alpha-equivalent provisional views can still contain
+                    // different live variables that acquire incompatible
+                    // structure later. Reuse is safe when the requests are
+                    // already the same graph interface: later refinements then
+                    // reach the same argument and result classes.
+                    if (!self.graph.sameFunctionInterface(entry.representative, request_fn_node)) continue;
+                    try entry.duplicates.append(self.allocator, request_fn_node);
+                },
             }
             return;
         };
@@ -35504,9 +35512,24 @@ const BodyContext = struct {
                 return .{ .target = try self.materializeEvidenceTarget(node, purpose) };
             },
             .constraint => |constraint_ref| {
-                const entry = self.evidence.at(constraint_ref) orelse
+                const entry = self.evidence.at(constraint_ref.index) orelse
                     Common.invariant("checked evidence reference was absent from its lexical chain");
-                return entry;
+                if (!constraint_ref.independent_callable) return entry;
+                return switch (entry) {
+                    .target => |target| blk: {
+                        const arena = self.builder.evidence_arena.allocator();
+                        const independent = try arena.create(SpecEvidenceTarget);
+                        independent.* = .{
+                            .view = target.view,
+                            .target = target.target,
+                            .instantiation = null,
+                            .local_proc_context = target.local_proc_context,
+                            .nested = .synthesize,
+                        };
+                        break :blk .{ .target = independent };
+                    },
+                    .structural, .unreachable_value, .checked_error => entry,
+                };
             },
             .structural => |evidence| return .{ .structural = .{
                 .derivation = evidence.derivation,
@@ -35712,11 +35735,13 @@ const BodyContext = struct {
                     .from_callable => .synthesize,
                 };
             },
-            .evidence_dependent => |constraint_ref| {
-                const entry = self.evidence.at(constraint_ref) orelse
+            .evidence_dependent => |dependent| {
+                const entry = self.evidence.at(dependent.index) orelse
                     Common.invariant("method target evidence was absent from its lexical chain");
                 return switch (entry) {
-                    .target => |target| switch (target.nested) {
+                    .target => |target| if (dependent.independent_callable)
+                        .synthesize
+                    else switch (target.nested) {
                         .resolved => |nested| .{ .resolved = nested },
                         .synthesize => .synthesize,
                     },
@@ -35739,11 +35764,13 @@ const BodyContext = struct {
                     .from_callable => .synthesize,
                 };
             },
-            .evidence_dependent => |constraint_ref| {
-                const entry = self.evidence.at(constraint_ref) orelse
+            .evidence_dependent => |dependent| {
+                const entry = self.evidence.at(dependent.index) orelse
                     Common.invariant("iterator target evidence was absent from its lexical chain");
                 return switch (entry) {
-                    .target => |target| switch (target.nested) {
+                    .target => |target| if (dependent.independent_callable)
+                        .synthesize
+                    else switch (target.nested) {
                         .resolved => |nested| .{ .resolved = nested },
                         .synthesize => .synthesize,
                     },
@@ -35775,16 +35802,21 @@ const BodyContext = struct {
                 };
                 return .{ .target = lookup };
             },
-            .evidence_dependent => |constraint_ref| {
-                const entry = self.evidence.at(constraint_ref) orelse
+            .evidence_dependent => |dependent| {
+                const entry = self.evidence.at(dependent.index) orelse
                     Common.invariant("dispatch resolution evidence was absent from its lexical chain");
                 return switch (entry) {
-                    .target => |target| .{ .target = .{
-                        .view = target.view,
-                        .target = target.target,
-                        .instantiation = target.instantiation,
-                        .local_proc_context = target.local_proc_context,
-                    } },
+                    .target => |target| .{
+                        .target = .{
+                            .view = target.view,
+                            .target = target.target,
+                            .instantiation = if (dependent.independent_callable)
+                                null
+                            else
+                                target.instantiation,
+                            .local_proc_context = target.local_proc_context,
+                        },
+                    },
                     .structural => |derivation| .{ .structural = derivation },
                     // Unreachable and checked-error dispatches crash before
                     // target resolution.
@@ -35863,7 +35895,7 @@ const BodyContext = struct {
         return switch (resolution) {
             .@"unreachable" => .unreachable_value,
             .checked_error => .checked_error,
-            .evidence_dependent => |constraint_ref| if (self.evidence.at(constraint_ref)) |entry| switch (entry) {
+            .evidence_dependent => |dependent| if (self.evidence.at(dependent.index)) |entry| switch (entry) {
                 .unreachable_value => .unreachable_value,
                 .checked_error => .checked_error,
                 .target, .structural => null,
@@ -46898,7 +46930,7 @@ const BodyContext = struct {
                 };
                 break :blk lookup;
             },
-            .evidence_dependent => |constraint_ref| if (self.evidence.at(constraint_ref)) |entry| switch (entry) {
+            .evidence_dependent => |dependent| if (self.evidence.at(dependent.index)) |entry| switch (entry) {
                 .target => |target| .{
                     .view = target.view,
                     .target = target.target,

--- a/test/snapshots/can_list_number_doesnt_fit.md
+++ b/test/snapshots/can_list_number_doesnt_fit.md
@@ -41,9 +41,9 @@ NO CHANGE
 ~~~clojure
 (e-list
 	(elems
-		(e-runtime-error (tag "erroneous_value_expr"))
+		(e-typed-int (value "1") (type "U8"))
 		(e-typed-int (value "2") (type "U8"))
-		(e-num (value "300"))))
+		(e-runtime-error (tag "erroneous_value_expr"))))
 ~~~
 # TYPES
 ~~~clojure

--- a/test/snapshots/fuzz_crash/fuzz_crash_027.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_027.md
@@ -942,13 +942,11 @@ ist
         Ok(123) => 121000
     }
 
-In the second pattern, lue is:
+The type involved is:
 
     [Red, ..]
 
-But in the first pattern, lue is:
-
-    [Red, ..]
+The difference is inside this type, but it is not visible in this display.
 
 A name shared across | patterns in the same match branch must have one
 compatible type.

--- a/test/snapshots/fuzz_crash/fuzz_crash_028.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_028.md
@@ -1504,13 +1504,11 @@ ar: 2,
         Ok(123) => 12
     }
 
-In the second pattern, lue is:
+The type involved is:
 
     [Red, ..]
 
-But in the first pattern, lue is:
-
-    [Red, ..]
+The difference is inside this type, but it is not visible in this display.
 
 A name shared across | patterns in the same match branch must have one
 compatible type.

--- a/test/snapshots/lambda_multi_arg_mismatch.md
+++ b/test/snapshots/lambda_multi_arg_mismatch.md
@@ -27,7 +27,7 @@ result = multi_arg_fn(
 UNUSED VARIABLE - lambda_multi_arg_mismatch.md:3:25:3:27
 UNUSED VARIABLE - lambda_multi_arg_mismatch.md:3:33:3:35
 UNUSED VARIABLE - lambda_multi_arg_mismatch.md:3:41:3:43
-MISSING METHOD - lambda_multi_arg_mismatch.md:13:5:13:9
+MISSING METHOD - lambda_multi_arg_mismatch.md:9:5:9:7
 MISSING METHOD - lambda_multi_arg_mismatch.md:11:5:11:12
 # PROBLEMS
 ── ● unused variable ───────────────────────── lambda_multi_arg_mismatch.md:3:25
@@ -60,13 +60,13 @@ multi_arg_fn = |x1, x2, x3, x4, x5, x6, x7, x8|
 If you don't need this variable, prefix it with an underscore like _x7 to
 suppress this warning.
 
-── ✗ missing method ────────────────────────── lambda_multi_arg_mismatch.md:13:5
+── ✗ missing method ─────────────────────────── lambda_multi_arg_mismatch.md:9:5
 
 This from_numeral method is being called on a value whose type doesn't have
 that method.
 
-3.14,      # x5: F64 (should be 'a' = U64) - MISMATCH
-^^^^
+42,        # x1: U64 (type 'a')
+^^
 
 The value's type, which does not have a method named from_numeral, is:
 

--- a/test/snapshots/static_dispatch/conflicting_same_method_arities.md
+++ b/test/snapshots/static_dispatch/conflicting_same_method_arities.md
@@ -1,0 +1,77 @@
+# META
+~~~ini
+description=Rejects same-name method requirements whose outer call arities cannot share one method scheme
+type=file
+~~~
+# SOURCE
+~~~roc
+f = |value| (value.convert(), value.convert(1))
+~~~
+# EXPECTED
+TYPE MISMATCH - conflicting_same_method_arities.md:1:31:1:36
+# PROBLEMS
+── ✗ type mismatch ───────────────────── conflicting_same_method_arities.md:1:31
+
+This expression is used in an unexpected way.
+
+f = |value| (value.convert(), value.convert(1))
+                              ^^^^^
+
+It has the type:
+
+    a where [a.convert : a -> _ret]
+
+But you are trying to use it as:
+
+    _a
+      where [
+        _b.convert : c, d -> _ret,
+        c.convert : c -> _ret2,
+        d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)]),
+      ]
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenRound,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,Comma,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args
+					(p-ident (raw "value")))
+				(e-tuple
+					(e-method-call (method ".convert")
+						(receiver
+							(e-ident (raw "value")))
+						(args))
+					(e-method-call (method ".convert")
+						(receiver
+							(e-ident (raw "value")))
+						(args
+							(e-int (raw "1")))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "f"))
+		(e-runtime-error (tag "erroneous_value_expr"))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error -> (_field, _field2)")))
+	(expressions
+		(expr (type "Error -> (_field, _field2)"))))
+~~~

--- a/test/snapshots/static_dispatch/duplicate_where_requirements_share_one_callable.md
+++ b/test/snapshots/static_dispatch/duplicate_where_requirements_share_one_callable.md
@@ -1,0 +1,101 @@
+# META
+~~~ini
+description=Repeated same-name where requirements describe one method, so they must agree on one callable type; conflicting duplicates are rejected.
+type=file
+~~~
+# SOURCE
+~~~roc
+process : a -> U64 where [a.convert : a -> U64, a.convert : a -> Str]
+process = |x| x.convert()
+~~~
+# EXPECTED
+TYPE MISMATCH - duplicate_where_requirements_share_one_callable.md:1:49:1:69
+# PROBLEMS
+── ✗ type mismatch ───── duplicate_where_requirements_share_one_callable.md:1:49
+
+This expression is used in an unexpected way.
+
+process : a -> U64 where [a.convert : a -> U64, a.convert : a -> Str]
+                                                ^^^^^^^^^^^^^^^^^^^^
+
+It has the type:
+
+    a -> Str where [a.convert : a -> U64]
+
+But you are trying to use it as:
+
+    a -> U64 where [a.convert : a -> U64]
+
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,Comma,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,CloseSquare,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-anno (name "process")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty (name "U64")))
+			(where
+				(method (mod-of "a") (name "convert")
+					(args
+						(ty-var (raw "a")))
+					(ty (name "U64")))
+				(method (mod-of "a") (name "convert")
+					(args
+						(ty-var (raw "a")))
+					(ty (name "Str")))))
+		(s-decl
+			(p-ident (raw "process"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-method-call (method ".convert")
+					(receiver
+						(e-ident (raw "x")))
+					(args))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "process"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-dispatch-call (method "convert") (constraint-fn-var 240)
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "x"))))
+				(args)))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-lookup (name "U64") (builtin)))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "convert")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-lookup (name "U64") (builtin)))
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "convert")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-lookup (name "Str") (builtin)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> U64 where [a.convert : a -> U64]")))
+	(expressions
+		(expr (type "a -> U64 where [a.convert : a -> U64]"))))
+~~~

--- a/test/snapshots/static_dispatch/equivalent_same_method_requirements_deduplicate.md
+++ b/test/snapshots/static_dispatch/equivalent_same_method_requirements_deduplicate.md
@@ -1,0 +1,95 @@
+# META
+~~~ini
+description=Deduplicates same-name method requirements whose callable differences are private to the inferred function
+type=file
+~~~
+# SOURCE
+~~~roc
+f = |value| {
+    _first = value.convert()
+    _second = value.convert()
+
+    {}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+NamedUnderscore,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+NamedUnderscore,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+OpenCurly,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args
+					(p-ident (raw "value")))
+				(e-block
+					(statements
+						(s-decl
+							(p-ident (raw "_first"))
+							(e-method-call (method ".convert")
+								(receiver
+									(e-ident (raw "value")))
+								(args)))
+						(s-decl
+							(p-ident (raw "_second"))
+							(e-method-call (method ".convert")
+								(receiver
+									(e-ident (raw "value")))
+								(args)))
+						(e-record)))))))
+~~~
+# FORMATTED
+~~~roc
+f = |value| {
+	_first = value.convert()
+	_second = value.convert()
+
+	{}
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "f"))
+		(e-lambda
+			(args
+				(p-assign (ident "value")))
+			(e-block
+				(s-let
+					(p-assign (ident "_first"))
+					(e-dispatch-call (method "convert") (constraint-fn-var 214)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "value"))))
+						(args)))
+				(s-let
+					(p-assign (ident "_second"))
+					(e-dispatch-call (method "convert") (constraint-fn-var 216)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "value"))))
+						(args)))
+				(e-empty_record)))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> {} where [a.convert : a -> _ret]")))
+	(expressions
+		(expr (type "a -> {} where [a.convert : a -> _ret]"))))
+~~~

--- a/test/snapshots/static_dispatch/every_interpolation_occurrence_checks_parts.md
+++ b/test/snapshots/static_dispatch/every_interpolation_occurrence_checks_parts.md
@@ -1,0 +1,190 @@
+# META
+~~~ini
+description=Same-receiver interpolations share a callable relation but retain occurrence-specific part checks.
+type=file
+~~~
+# SOURCE
+~~~roc
+Rendered := [Rendered].{
+    from_interpolation : Str, Iter((U64, Str)) -> Rendered
+    from_interpolation = |_, _| Rendered.Rendered
+}
+
+build = |good, bad| ["${good}", "${bad}"]
+
+main : List(Rendered)
+main = build(1.U64, "not a number")
+~~~
+# EXPECTED
+TYPE MISMATCH - every_interpolation_occurrence_checks_parts.md:9:21:9:35
+# PROBLEMS
+── ✗ type mismatch ───────── every_interpolation_occurrence_checks_parts.md:9:21
+
+This string literal is being used where a non-string type is needed.
+
+main = build(1.U64, "not a number")
+                    ^^^^^^^^^^^^^^
+
+The type was determined to be:
+
+    U64
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,CloseSquare,Dot,OpenCurly,
+LowerIdent,OpColon,UpperIdent,Comma,UpperIdent,NoSpaceOpenRound,NoSpaceOpenRound,UpperIdent,Comma,UpperIdent,CloseRound,CloseRound,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,Underscore,Comma,Underscore,OpBar,UpperIdent,NoSpaceDotUpperIdent,
+CloseCurly,
+LowerIdent,OpAssign,OpBar,LowerIdent,Comma,LowerIdent,OpBar,OpenSquare,StringStart,StringPart,OpenStringInterpolation,LowerIdent,CloseStringInterpolation,StringPart,StringEnd,Comma,StringStart,StringPart,OpenStringInterpolation,LowerIdent,CloseStringInterpolation,StringPart,StringEnd,CloseSquare,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,Int,NoSpaceDotUpperIdent,Comma,StringStart,StringPart,StringEnd,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-decl
+			(header (name "Rendered")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty (name "Rendered"))))
+			(associated
+				(s-type-anno (name "from_interpolation")
+					(ty-fn
+						(ty (name "Str"))
+						(ty-apply
+							(ty (name "Iter"))
+							(ty-tuple
+								(ty (name "U64"))
+								(ty (name "Str"))))
+						(ty (name "Rendered"))))
+				(s-decl
+					(p-ident (raw "from_interpolation"))
+					(e-lambda
+						(args
+							(p-underscore)
+							(p-underscore))
+						(e-tag (raw "Rendered.Rendered"))))))
+		(s-decl
+			(p-ident (raw "build"))
+			(e-lambda
+				(args
+					(p-ident (raw "good"))
+					(p-ident (raw "bad")))
+				(e-list
+					(e-string
+						(e-string-part (raw ""))
+						(e-ident (raw "good"))
+						(e-string-part (raw "")))
+					(e-string
+						(e-string-part (raw ""))
+						(e-ident (raw "bad"))
+						(e-string-part (raw ""))))))
+		(s-type-anno (name "main")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Rendered"))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-apply
+				(e-ident (raw "build"))
+				(e-typed-int (raw "1") (type "U64"))
+				(e-string
+					(e-string-part (raw "not a number")))))))
+~~~
+# FORMATTED
+~~~roc
+Rendered := [Rendered].{
+	from_interpolation : Str, Iter((U64, Str)) -> Rendered
+	from_interpolation = |_, _| Rendered.Rendered
+}
+
+build = |good, bad| ["${good}", "${bad}"]
+
+main : List(Rendered)
+main = build(1.U64, "not a number")
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "every_interpolation_occurrence_checks_parts.Rendered.from_interpolation"))
+		(e-lambda
+			(args
+				(p-underscore)
+				(p-underscore))
+			(e-nominal (nominal "Rendered")
+				(e-tag (name "Rendered"))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "Str") (builtin))
+				(ty-apply (name "Iter") (builtin)
+					(ty-tuple
+						(ty-lookup (name "U64") (builtin))
+						(ty-lookup (name "Str") (builtin))))
+				(ty-lookup (name "Rendered") (local)))))
+	(d-let
+		(p-assign (ident "build"))
+		(e-lambda
+			(args
+				(p-assign (ident "good"))
+				(p-assign (ident "bad")))
+			(e-list
+				(elems
+					(e-block
+						(s-let
+							(p-assign (ident "#interp_0"))
+							(e-lookup-local
+								(p-assign (ident "good"))))
+						(e-interpolation (constraint-fn-var 305) (dispatcher-var 30)
+							(first
+								(e-literal (string "")))
+							(parts
+								(e-lookup-local
+									(p-assign (ident "#interp_0")))
+								(e-literal (string "")))))
+					(e-block
+						(s-let
+							(p-assign (ident "#interp_1"))
+							(e-lookup-local
+								(p-assign (ident "bad"))))
+						(e-interpolation (constraint-fn-var 323) (dispatcher-var 38)
+							(first
+								(e-literal (string "")))
+							(parts
+								(e-lookup-local
+									(p-assign (ident "#interp_1")))
+								(e-literal (string "")))))))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-call (constraint-fn-var 354)
+			(e-lookup-local
+				(p-assign (ident "build")))
+			(e-typed-int (value "1") (type "U64"))
+			(e-runtime-error (tag "erroneous_value_expr")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Rendered") (local)))))
+	(s-nominal-decl
+		(ty-header (name "Rendered"))
+		(ty-tag-union
+			(ty-tag-name (name "Rendered")))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Str, Iter((U64, Str)) -> Rendered"))
+		(patt (type "_arg, _arg2 -> List(a) where [a.from_interpolation : Str, Iter((b, Str)) -> a, a.from_interpolation : Str, Iter((b, Str)) -> a]"))
+		(patt (type "List(Rendered)")))
+	(type_decls
+		(nominal (type "Rendered")
+			(ty-header (name "Rendered"))))
+	(expressions
+		(expr (type "Str, Iter((U64, Str)) -> Rendered"))
+		(expr (type "_arg, _arg2 -> List(a) where [a.from_interpolation : Str, Iter((b, Str)) -> a, a.from_interpolation : Str, Iter((b, Str)) -> a]"))
+		(expr (type "List(Rendered)"))))
+~~~

--- a/test/snapshots/static_dispatch/independent_same_method_requirements.md
+++ b/test/snapshots/static_dispatch/independent_same_method_requirements.md
@@ -1,0 +1,195 @@
+# META
+~~~ini
+description=Infers independent same-name method requirements and discharges them against one concrete method scheme
+type=file
+~~~
+# SOURCE
+~~~roc
+f1 = |l| l.map(|i| U32.to_u64(i))
+f2 = |l| l.map(|i| U32.to_u128(i))
+
+g = |l| {
+    _a1 = f1(l)
+    _a2 = f2(l)
+
+    0
+}
+
+main = g([1.U32, 2.U32])
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpBar,LowerIdent,OpBar,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpBar,LowerIdent,OpBar,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+NamedUnderscore,OpAssign,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+NamedUnderscore,OpAssign,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+Int,
+CloseCurly,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenSquare,Int,NoSpaceDotUpperIdent,Comma,Int,NoSpaceDotUpperIdent,CloseSquare,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "f1"))
+			(e-lambda
+				(args
+					(p-ident (raw "l")))
+				(e-method-call (method ".map")
+					(receiver
+						(e-ident (raw "l")))
+					(args
+						(e-lambda
+							(args
+								(p-ident (raw "i")))
+							(e-apply
+								(e-ident (raw "U32.to_u64"))
+								(e-ident (raw "i"))))))))
+		(s-decl
+			(p-ident (raw "f2"))
+			(e-lambda
+				(args
+					(p-ident (raw "l")))
+				(e-method-call (method ".map")
+					(receiver
+						(e-ident (raw "l")))
+					(args
+						(e-lambda
+							(args
+								(p-ident (raw "i")))
+							(e-apply
+								(e-ident (raw "U32.to_u128"))
+								(e-ident (raw "i"))))))))
+		(s-decl
+			(p-ident (raw "g"))
+			(e-lambda
+				(args
+					(p-ident (raw "l")))
+				(e-block
+					(statements
+						(s-decl
+							(p-ident (raw "_a1"))
+							(e-apply
+								(e-ident (raw "f1"))
+								(e-ident (raw "l"))))
+						(s-decl
+							(p-ident (raw "_a2"))
+							(e-apply
+								(e-ident (raw "f2"))
+								(e-ident (raw "l"))))
+						(e-int (raw "0"))))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-apply
+				(e-ident (raw "g"))
+				(e-list
+					(e-typed-int (raw "1") (type "U32"))
+					(e-typed-int (raw "2") (type "U32")))))))
+~~~
+# FORMATTED
+~~~roc
+f1 = |l| l.map(|i| U32.to_u64(i))
+
+f2 = |l| l.map(|i| U32.to_u128(i))
+
+g = |l| {
+	_a1 = f1(l)
+	_a2 = f2(l)
+
+	0
+}
+
+main = g([1.U32, 2.U32])
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "f1"))
+		(e-lambda
+			(args
+				(p-assign (ident "l")))
+			(e-dispatch-call (method "map") (constraint-fn-var 252)
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "l"))))
+				(args
+					(e-lambda
+						(args
+							(p-assign (ident "i")))
+						(e-call (constraint-fn-var 251)
+							(e-lookup-external
+								(builtin))
+							(e-lookup-local
+								(p-assign (ident "i")))))))))
+	(d-let
+		(p-assign (ident "f2"))
+		(e-lambda
+			(args
+				(p-assign (ident "l")))
+			(e-dispatch-call (method "map") (constraint-fn-var 261)
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "l"))))
+				(args
+					(e-lambda
+						(args
+							(p-assign (ident "i")))
+						(e-call (constraint-fn-var 260)
+							(e-lookup-external
+								(builtin))
+							(e-lookup-local
+								(p-assign (ident "i")))))))))
+	(d-let
+		(p-assign (ident "g"))
+		(e-lambda
+			(args
+				(p-assign (ident "l")))
+			(e-block
+				(s-let
+					(p-assign (ident "_a1"))
+					(e-call (constraint-fn-var 270)
+						(e-lookup-local
+							(p-assign (ident "f1")))
+						(e-lookup-local
+							(p-assign (ident "l")))))
+				(s-let
+					(p-assign (ident "_a2"))
+					(e-call (constraint-fn-var 278)
+						(e-lookup-local
+							(p-assign (ident "f2")))
+						(e-lookup-local
+							(p-assign (ident "l")))))
+				(e-num (value "0")))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-call (constraint-fn-var 321)
+			(e-lookup-local
+				(p-assign (ident "g")))
+			(e-list
+				(elems
+					(e-typed-int (value "1") (type "U32"))
+					(e-typed-int (value "2") (type "U32")))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "c -> d where [c.map : c, (U32 -> U64) -> d]"))
+		(patt (type "c -> d where [c.map : c, (U32 -> U128) -> d]"))
+		(patt (type "c -> d where [c.map : c, (U32 -> U128) -> _ret, c.map : c, (U32 -> U64) -> _ret2, d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
+		(patt (type "Dec")))
+	(expressions
+		(expr (type "c -> d where [c.map : c, (U32 -> U64) -> d]"))
+		(expr (type "c -> d where [c.map : c, (U32 -> U128) -> d]"))
+		(expr (type "c -> d where [c.map : c, (U32 -> U128) -> _ret, c.map : c, (U32 -> U64) -> _ret2, d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
+		(expr (type "Dec"))))
+~~~

--- a/test/snapshots/static_dispatch/public_same_method_results_remain_independent.md
+++ b/test/snapshots/static_dispatch/public_same_method_results_remain_independent.md
@@ -1,0 +1,71 @@
+# META
+~~~ini
+description=Keeps same-name requirements separate when their results are independently visible in the inferred type
+type=file
+~~~
+# SOURCE
+~~~roc
+f = |value| (value.convert(), value.convert())
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenRound,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,Comma,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args
+					(p-ident (raw "value")))
+				(e-tuple
+					(e-method-call (method ".convert")
+						(receiver
+							(e-ident (raw "value")))
+						(args))
+					(e-method-call (method ".convert")
+						(receiver
+							(e-ident (raw "value")))
+						(args)))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "f"))
+		(e-lambda
+			(args
+				(p-assign (ident "value")))
+			(e-tuple
+				(elems
+					(e-dispatch-call (method "convert") (constraint-fn-var 209)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "value"))))
+						(args))
+					(e-dispatch-call (method "convert") (constraint-fn-var 211)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "value"))))
+						(args)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> (b, c) where [a.convert : a -> c, a.convert : a -> b]")))
+	(expressions
+		(expr (type "a -> (b, c) where [a.convert : a -> c, a.convert : a -> b]"))))
+~~~

--- a/test/snapshots/static_dispatch/where_requirement_checks_every_same_method_call.md
+++ b/test/snapshots/static_dispatch/where_requirement_checks_every_same_method_call.md
@@ -1,0 +1,133 @@
+# META
+~~~ini
+description=Checks every same-name body call against the callable type promised by a where requirement
+type=file
+~~~
+# SOURCE
+~~~roc
+f : a -> {} where [a.convert : a, Str -> U64]
+f = |value| {
+    _first = value.convert("ok")
+    _second = value.convert(1.U64)
+
+    {}
+}
+~~~
+# EXPECTED
+TYPE MISMATCH - where_requirement_checks_every_same_method_call.md:4:21:4:28
+# PROBLEMS
+── ✗ type mismatch ───── where_requirement_checks_every_same_method_call.md:4:21
+
+This expression is used in an unexpected way.
+
+_second = value.convert(1.U64)
+                ^^^^^^^
+
+It has the type:
+
+    a, U64 -> _ret where [a.convert : a, Str -> U64]
+
+But you are trying to use it as:
+
+    a, Str -> U64 where [a.convert : a, Str -> U64]
+
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,OpArrow,OpenCurly,CloseCurly,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,Comma,UpperIdent,OpArrow,UpperIdent,CloseSquare,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+NamedUnderscore,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,
+NamedUnderscore,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,NoSpaceDotUpperIdent,CloseRound,
+OpenCurly,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-anno (name "f")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty-record))
+			(where
+				(method (mod-of "a") (name "convert")
+					(args
+						(ty-var (raw "a"))
+						(ty (name "Str")))
+					(ty (name "U64")))))
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args
+					(p-ident (raw "value")))
+				(e-block
+					(statements
+						(s-decl
+							(p-ident (raw "_first"))
+							(e-method-call (method ".convert")
+								(receiver
+									(e-ident (raw "value")))
+								(args
+									(e-string
+										(e-string-part (raw "ok"))))))
+						(s-decl
+							(p-ident (raw "_second"))
+							(e-method-call (method ".convert")
+								(receiver
+									(e-ident (raw "value")))
+								(args
+									(e-typed-int (raw "1") (type "U64")))))
+						(e-record)))))))
+~~~
+# FORMATTED
+~~~roc
+f : a -> {} where [a.convert : a, Str -> U64]
+f = |value| {
+	_first = value.convert("ok")
+	_second = value.convert(1.U64)
+
+	{}
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "f"))
+		(e-lambda
+			(args
+				(p-assign (ident "value")))
+			(e-block
+				(s-let
+					(p-assign (ident "_first"))
+					(e-dispatch-call (method "convert") (constraint-fn-var 256)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "value"))))
+						(args
+							(e-string
+								(e-literal (string "ok"))))))
+				(s-let
+					(p-assign (ident "_second"))
+					(e-runtime-error (tag "erroneous_value_expr")))
+				(e-empty_record)))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-record))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "convert")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a")))
+						(ty-lookup (name "Str") (builtin)))
+					(ty-lookup (name "U64") (builtin)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> {} where [a.convert : Error]")))
+	(expressions
+		(expr (type "a -> {} where [a.convert : Error]"))))
+~~~


### PR DESCRIPTION
## Summary

- keep independent same-name method-call constraints as a conjunction, so each call can instantiate the selected rank-1 method scheme at its own callable type
- unify all same-name declarative requirements and check every body call against that shared callable relation; reject impossible outer arity/effect combinations early
- deduplicate equivalent generalized requirements using public identity anchors, with per-pass callable-shape memoization to avoid rehashing shared callable graphs
- share one runtime evidence target per dispatcher/method while preserving whether each use has an exact or independent callable relation through checked artifacts and Monotype lowering
- improve diagnostics when a mismatch's two types render identically

## Validation

- `zig build run-test-zig -- --test-filter "independent same-name" --test-filter "issue 10529" --test-filter "issue 10021" --test-filter "SERIALIZED_VERSION_HASH"`
- `zig build run-snapshot-tool`
- `zig build run-check-snapshots`
- `zig build run-check-zig-format run-check-zig-lints run-check-tidy run-check-type-checker-patterns run-check-postcheck-architecture`
- `typos`
- full `zig build run-test-zig`: all tests pass except the unrelated existing `rc_conformance_test` / `list_sort_with` failure
