### PR TITLE
Preserve external borrows across recursive tail calls

### DIFF
--- a/design.md
+++ b/design.md
@@ -9271,11 +9271,22 @@ emitting any release for the group.
 Tail calls need one rule so that borrow inference never blocks backend
 tail-call lowering. LIR has no tail-call statement; a call is in tail
 position when the next statement returns the call result. Call-graph SCCs
-(computed once, iteratively) feed exactly this rule: a tail-position call to
-a proc in the same SCC demands ownership of its refcounted arguments, so
-emission never places a release after the call on that path. Calls that
-leave the SCC keep borrowed positions, since the caller's drops precede the
-tail call there only when the values genuinely die earlier.
+(computed once, iteratively) feed exactly this rule: every refcounted argument
+of a tail-position call within the same SCC has to outlive replacement of the
+caller frame. This is an exact lifetime constraint, not an ownership demand.
+After parameter modes and borrowed-return lenders settle, the solver records
+the caller entry parameter that anchors each such argument. The argument stays
+borrowed exactly when that parameter is borrowed in the current emission; its
+entry lifetime then contains every recursive frame in the SCC. With no such
+borrowed entry anchor, emission materializes the argument's exact ownership
+carrier, selects a mandatory owned callee variant, and moves any remaining
+caller releases before the call. Normal callee-parameter mode dependencies are
+recorded for tail calls just as for every other direct call. The callee return
+mode must also match the caller return mode; emission selects a mandatory
+owned-return variant when forwarding a borrowed result would otherwise require
+a retain after the call. Calls that leave the SCC keep their ordinary lifetime
+and mode constraints because they cannot participate in unbounded recursive
+frame growth.
 
 ### RC Planning and Materialization
 

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -2985,14 +2985,17 @@ const Inserter = struct {
         result: LIR.LocalId,
         releases: *std.ArrayList(ReleaseDecision),
     ) ResourceError!void {
-        var index = owned.domain.resource_locals.len;
-        while (index > 0) {
-            index -= 1;
-            const local = owned.domain.resourceLocalAt(index);
-            if (local == result or !owned.contains(local)) continue;
+        const result_bit = owned.domain.resourceBitOf(result);
+        const keep_result = if (result_bit) |bit| owned.bits.isSet(bit) else false;
+        var iter = owned.bits.iterator(.{ .direction = .reverse });
+        while (iter.next()) |bit| {
+            if (result_bit != null and bit == result_bit.?) continue;
+            const local = owned.domain.resourceLocalAt(bit);
             try releases.append(self.emission_allocator, self.releaseDecisionFrom(owned, local));
-            owned.unset(local);
+            owned.residual_masks[bit] = 0;
         }
+        owned.bits.unsetAll();
+        if (keep_result) owned.bits.set(result_bit.?);
     }
 
     fn addRestitutionKeep(
@@ -13074,9 +13077,14 @@ test "RC interprocedural: tail self-call transfers an SCC-local argument" {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();
 
+    const id_param = try f.local(.str);
+    const id_ret = try f.ret(id_param);
+    const identity = try f.addProc(&.{id_param}, id_ret, .str);
+
     const text = try f.local(.str);
     const counter = try f.local(.i64);
     const base_result = try f.local(.i64);
+    const local_lender = try f.local(.str);
     const next_text = try f.local(.str);
     const next_counter = try f.local(.i64);
     const tail_result = try f.local(.i64);
@@ -13092,8 +13100,14 @@ test "RC interprocedural: tail self-call transfers an SCC-local argument" {
         .args = try f.span(&.{ next_text, next_counter }),
         .next = tail_ret,
     } });
-    const make_next_text = try f.assignStr(next_text, "inside-the-scc", tail_call);
-    const recursive_body = try f.assignI64(next_counter, 0, make_next_text);
+    const borrow_local = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = next_text,
+        .proc = identity,
+        .args = try f.span(&.{local_lender}),
+        .next = tail_call,
+    } });
+    const make_local_lender = try f.assignStr(local_lender, "inside-the-scc", borrow_local);
+    const recursive_body = try f.assignI64(next_counter, 0, make_local_lender);
     f.store.setProcSpecBody(recurse, try f.switchStmt(counter, base_body, recursive_body, null));
 
     const value = try f.local(.str);
@@ -13115,15 +13129,20 @@ test "RC interprocedural: tail self-call transfers an SCC-local argument" {
     try f.run();
 
     // The public recursive entry still borrows its external argument. The
-    // locally created value instead moves into one mandatory owned variant,
-    // whose recursive edge targets itself with no cleanup after the call.
+    // borrowed result backed by a locally created lender instead materializes
+    // a unit and moves it into one mandatory owned variant, whose recursive
+    // edge targets itself with no cleanup after the call.
     try testing.expectEqual(base_proc_count + 1, f.store.procSpecCount());
     const owned_variant: LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(base_proc_count)));
     const base_switch = f.walkToSwitch(f.store.getProcSpec(recurse).body.?);
-    const base_call = f.walkToDirectCall(base_switch.default_branch);
+    const base_borrow_call = f.walkToDirectCall(base_switch.default_branch);
+    try testing.expectEqual(identity, base_borrow_call.proc);
+    const base_call = f.walkToDirectCall(base_borrow_call.next);
     try testing.expectEqual(owned_variant, base_call.proc);
     const variant_switch = f.walkToSwitch(f.store.getProcSpec(owned_variant).body.?);
-    const variant_call = f.walkToDirectCall(variant_switch.default_branch);
+    const variant_borrow_call = f.walkToDirectCall(variant_switch.default_branch);
+    try testing.expectEqual(identity, variant_borrow_call.proc);
+    const variant_call = f.walkToDirectCall(variant_borrow_call.next);
     try testing.expectEqual(owned_variant, variant_call.proc);
     const after_variant_call = f.store.getCFStmt(variant_call.next);
     try testing.expect(after_variant_call == .ret and after_variant_call.ret.value == variant_call.target);
@@ -13131,7 +13150,10 @@ test "RC interprocedural: tail self-call transfers an SCC-local argument" {
     // The owned variant releases its entry value on either branch: at the
     // base return, or before the recursive tail edge replaces its frame.
     try f.expectRc(text, 0, 2, 0);
-    try f.expectRc(next_text, 0, 0, 0);
+    // Both emitted recursive bodies retain the borrowed identity result into
+    // its tail-call unit and release the SCC-local lender before the edge.
+    try f.expectRc(next_text, 2, 0, 0);
+    try f.expectRc(local_lender, 0, 2, 0);
     try f.expectRc(value, 0, 1, 0);
 }
 

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -7,10 +7,12 @@
 //! decisions: borrowed bindings emit nothing, owned final occurrences move,
 //! and lifetime-ending releases land right after the last use of a binding's
 //! borrow group. Optimized builds also emit
-//! mode-specialized proc variants for call sites that can move arguments into
-//! positions the solved signature borrows, or that prove a dying argument
-//! statically unique so the variant elides the runtime uniqueness checks
-//! that parameter reaches. Debug builds re-check the output
+//! optional mode-specialized proc variants for call sites that can move
+//! arguments into positions the solved signature borrows, or that prove a
+//! dying argument statically unique so the variant elides the runtime
+//! uniqueness checks that parameter reaches. Same-SCC tail edges select
+//! mandatory mode variants when frame replacement requires an ownership
+//! transfer. Debug builds re-check the output
 //! with the borrow certifier (`arc_certify`). Backends consume explicit RC
 //! statements without doing reference-counting analysis.
 
@@ -42,8 +44,9 @@ pub const InsertOptions = struct {
     roots: []const LIR.LirProcSpecId = &.{},
     /// Emit mode-specialized proc variants for call sites that demand more
     /// ownership than a callee's solved signature provides. Optimized builds
-    /// enable this; dev builds and compile-time evaluation use the solved
-    /// single variant per proc.
+    /// enable this; dev builds and compile-time evaluation otherwise use the
+    /// solved single variant per proc. Exact tail-call and field-take
+    /// ownership schedules can still require mandatory variants.
     specialize: bool = false,
     /// Select consuming Box.unbox when its lender is dead. Compiled backends
     /// enable this; the value-model interpreter keeps an explicit borrow.
@@ -445,6 +448,18 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
             }
             if ((emit_sig.unique_params & bit) != 0) {
                 unique_param_override.set(param);
+            }
+        }
+        // A recursive tail argument can borrow across frame replacement only
+        // from a borrowed entry parameter of this exact emission. Otherwise
+        // its solved carrier must materialize a unit for the mandatory owned
+        // callee variant. Re-evaluate the recorded anchor against `emit_sig`
+        // so an owned variant recursively calls the matching owned variant.
+        for (solution.tailCallsOf(source_proc)) |*tail_call| {
+            for (0..arc_sig.tracked_param_count) |position| {
+                const carrier = tail_call.carrier(position) orelse continue;
+                if (tail_call.argumentOutlivesScc(position, emit_sig)) continue;
+                owned_binding_override.set(carrier);
             }
         }
         for (domain.frame_locals) |local| {
@@ -2290,21 +2305,31 @@ const Inserter = struct {
                 .assign_call => |assign| {
                     const step = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
                     const unique_demand = self.variants.enabled and !self.solution.isPinnedProc(assign.proc);
-                    const transfer = try self.transferForCall(&segment.owned, segment.cursor, assign.proc, self.solution.sigOf(assign.proc), unique_demand, assign.args, assign.next, assign.target, null, segment.ctx.loop_keep);
+                    const tail_call = self.solution.tailCallAt(self.current_source_proc, segment.cursor);
+                    const transfer = try self.transferForCall(&segment.owned, segment.cursor, tail_call, assign.proc, self.solution.sigOf(assign.proc), unique_demand, assign.args, assign.next, assign.target, null, segment.ctx.loop_keep);
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     try step.pre_retain.appendSlice(self.solve_allocator, transfer.args.retain_args);
                     step.retain_call_result = transfer.retain_call_result;
                     step.call_callee = assign.proc;
                     step.call_demanded = transfer.args.demanded;
                     self.death_scratch.clearRetainingCapacity();
-                    try self.noteCallResultDeathIfUnused(&segment.owned, assign.target, transfer.args.demanded.ret_mode, assign.next, segment.ctx.loop_keep, self.death_scratch);
-                    try self.postStmtDeaths(&segment.owned, &.{}, assign.args, assign.next, segment.ctx.loop_keep, self.death_scratch);
-                    try self.copyDeathScratchToStep(step);
+                    if (tail_call != null) {
+                        // The recursive frame is replaced at this call. The
+                        // call result is not produced until afterwards; every
+                        // other unit still in the exact state belongs to the
+                        // disappearing caller frame and must end first.
+                        try self.releaseTailCallerFrame(&segment.owned, assign.target, self.death_scratch);
+                        try step.pre_release_extra.appendSlice(self.solve_allocator, self.death_scratch.items);
+                    } else {
+                        try self.noteCallResultDeathIfUnused(&segment.owned, assign.target, transfer.args.demanded.ret_mode, assign.next, segment.ctx.loop_keep, self.death_scratch);
+                        try self.postStmtDeaths(&segment.owned, &.{}, assign.args, assign.next, segment.ctx.loop_keep, self.death_scratch);
+                        try self.copyDeathScratchToStep(step);
+                    }
                     segment.cursor = assign.next;
                 },
                 .assign_call_erased => |assign| {
                     const step = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
-                    const transfer = try self.transferForCall(&segment.owned, null, null, arc_sig.RcSig.all_owned, false, assign.args, assign.next, assign.target, assign.closure, segment.ctx.loop_keep);
+                    const transfer = try self.transferForCall(&segment.owned, null, null, null, arc_sig.RcSig.all_owned, false, assign.args, assign.next, assign.target, assign.closure, segment.ctx.loop_keep);
                     var preserve_reuse_source = false;
                     if (assign.reuse_closure) {
                         if (assign.closure == assign.target) arcInvariant("owned erased call cannot consume and rebind the same local");
@@ -2948,6 +2973,25 @@ const Inserter = struct {
         while (iter.next()) |bit| {
             const local = owned.domain.resourceLocalAt(bit);
             try releases.append(self.solve_allocator, self.releaseDecisionFrom(owned, local));
+        }
+    }
+
+    /// Ends the exact ownership state of a caller frame before a same-SCC
+    /// tail call replaces it. `result` is the fresh unit produced by the call,
+    /// so it remains in the state for the immediately following return.
+    fn releaseTailCallerFrame(
+        self: *Inserter,
+        owned: *OwnedSet,
+        result: LIR.LocalId,
+        releases: *std.ArrayList(ReleaseDecision),
+    ) ResourceError!void {
+        var index = owned.domain.resource_locals.len;
+        while (index > 0) {
+            index -= 1;
+            const local = owned.domain.resourceLocalAt(index);
+            if (local == result or !owned.contains(local)) continue;
+            try releases.append(self.emission_allocator, self.releaseDecisionFrom(owned, local));
+            owned.unset(local);
         }
     }
 
@@ -4210,6 +4254,7 @@ const Inserter = struct {
         self: *Inserter,
         owned: *OwnedSet,
         call_stmt: ?LIR.CFStmtId,
+        tail_call: ?*const arc_solve.TailCallLifetime,
         callee: ?LIR.LirProcSpecId,
         callee_sig: arc_sig.RcSig,
         unique_demand: bool,
@@ -4219,7 +4264,7 @@ const Inserter = struct {
         extra_use: ?LIR.LocalId,
         loop_keep: ?LoopKeep,
     ) ResourceError!CallTransfer {
-        const arg_ownership = try self.callArgOwnership(call_stmt, callee, owned, callee_sig, unique_demand, args, next, target, loop_keep);
+        const arg_ownership = try self.callArgOwnership(call_stmt, tail_call, callee, owned, callee_sig, unique_demand, args, next, target, loop_keep);
         const target_feeds_call = self.spanUsesLocal(args, target) or
             (extra_use != null and extra_use.? == target);
         const release_old_target = if (target_feeds_call)
@@ -5226,6 +5271,7 @@ const Inserter = struct {
     fn callArgOwnership(
         self: *Inserter,
         call_stmt: ?LIR.CFStmtId,
+        tail_call: ?*const arc_solve.TailCallLifetime,
         callee: ?LIR.LirProcSpecId,
         owned: *OwnedSet,
         callee_sig: arc_sig.RcSig,
@@ -5238,6 +5284,13 @@ const Inserter = struct {
         self.retain_arg_scratch.clearRetainingCapacity();
         var demanded = callee_sig;
         const locals = self.store.getLocalSpan(span);
+        if (tail_call != null and self.current_sig.ret_mode == .owned and demanded.ret_mode == .borrowed) {
+            // A recursive tail edge must use the caller's return ABI. Asking
+            // an owned-return caller to forward a borrowed result would put a
+            // retain after the call and destroy tail position.
+            demanded.ret_mode = .owned;
+            demanded.ret_lenders = 0;
+        }
         var outcome_sig = callee_sig;
         if (callee) |direct| outcome_sig.outcomes = self.solution.availableOutcomeSpanOf(direct);
         const outcome_places_distinct = !outcome_sig.outcomes.isEmpty() and
@@ -5316,33 +5369,30 @@ const Inserter = struct {
             if (!self.localContainsRefcounted(local)) continue;
             if (callee_sig.paramMode(position) == .borrowed) {
                 // Borrowed positions keep the caller's ownership untouched.
-                // With specialization enabled, a final-use argument only
-                // moves into an owned-demanding variant when that changes
-                // runtime work inside the callee. Merely moving the caller's
-                // post-call release into a clone preserves the same RC work
-                // while growing live code.
                 const bit = arc_sig.paramBit(position) orelse continue;
+                const requires_tail_transfer = if (tail_call) |fact|
+                    !fact.argumentOutlivesScc(position, self.current_sig)
+                else
+                    false;
                 const enables_field_take = if (callee) |direct|
                     (self.dismantles.ownedOnlyParamBenefits(direct) & bit) != 0
                 else
                     false;
-                // Field-take variants are a correctness-preserving ownership
-                // schedule, not optional optimization work: without
-                // them a complete payload move is forced to manufacture a
-                // second unit and defeats runtime uniqueness. General return
-                // and born-unique variants remain opt-in.
-                if (!self.variants.enabled and !enables_field_take) continue;
+                // Recursive tail transfer and field takes are exact ownership
+                // schedules, so their variants are mandatory. General return
+                // and born-unique specialization remains opt-in.
+                if (!self.variants.enabled and !enables_field_take and !requires_tail_transfer) continue;
                 const used_after_call = local != target and try self.groupUsedInPath(next, local, loop_keep);
                 const owner = self.unitOf(local);
                 const projected_alias_conflict = self.dismantles.projectionUnitOf(local) != null and
                     self.groupSharesOtherOperand(locals, position, local);
                 const can_transfer = owned.contains(owner) and !used_after_call and !projected_alias_conflict;
-                if (!can_transfer) continue;
                 const return_borrows_param = callee_sig.ret_mode == .borrowed and (callee_sig.ret_lenders & bit) != 0;
                 const seed_can_reach_check = if (callee) |direct| self.procParamCanUseUniqueSeed(direct, position) else false;
-                const seeds_unique_param = unique_demand and seed_can_reach_check and self.isLocalUniqueHere(local) and
+                const seeds_unique_param = can_transfer and unique_demand and seed_can_reach_check and self.isLocalUniqueHere(local) and
                     !self.groupSharesOtherOperand(locals, position, local);
-                if (!return_borrows_param and !seeds_unique_param and !enables_field_take) continue;
+                if (!can_transfer and !requires_tail_transfer) continue;
+                if (!return_borrows_param and !seeds_unique_param and !enables_field_take and !requires_tail_transfer) continue;
                 demanded.borrowed_params &= ~bit;
                 if (return_borrows_param) {
                     demanded.ret_mode = .owned;
@@ -5351,7 +5401,14 @@ const Inserter = struct {
                 if (seeds_unique_param) {
                     demanded.unique_params |= bit;
                 }
-                owned.unset(owner);
+                if (can_transfer) {
+                    owned.unset(owner);
+                } else {
+                    // The original carrier cannot move (for example, two
+                    // positions name it). Manufacture the callee's unit, then
+                    // the tail boundary releases the carrier before the call.
+                    try self.retain_arg_scratch.append(self.emission_allocator, local);
+                }
                 continue;
             }
 
@@ -5416,6 +5473,10 @@ const Inserter = struct {
             } else {
                 try self.retain_arg_scratch.append(self.emission_allocator, local);
             }
+        }
+
+        if (tail_call != null and demanded.ret_mode != self.current_sig.ret_mode) {
+            arcInvariant("ARC recursive tail edge could not match the caller return ownership mode");
         }
 
         return .{
@@ -7303,6 +7364,19 @@ const ArcTest = struct {
     }
 
     fn addProc(self: *ArcTest, args: []const LIR.LocalId, body: LIR.CFStmtId, ret_layout: layout_mod.Idx) Allocator.Error!LIR.LirProcSpecId {
+        return try self.addProcWithBody(args, body, ret_layout);
+    }
+
+    /// Registers a proc whose body is installed afterwards with
+    /// `LirStore.setProcSpecBody`. A recursive fixture needs this ordering:
+    /// the call statement in the body names the proc the body belongs to.
+    /// Allocate the proc's locals before calling this, since the frame
+    /// inventory covers every local allocated so far.
+    fn addProcPendingBody(self: *ArcTest, args: []const LIR.LocalId, ret_layout: layout_mod.Idx) Allocator.Error!LIR.LirProcSpecId {
+        return try self.addProcWithBody(args, null, ret_layout);
+    }
+
+    fn addProcWithBody(self: *ArcTest, args: []const LIR.LocalId, body: ?LIR.CFStmtId, ret_layout: layout_mod.Idx) Allocator.Error!LIR.LirProcSpecId {
         // Fixtures build the body before registering its proc. Supplying all
         // locals allocated so far keeps the inventory explicitly complete;
         // production lowering supplies the exact per-proc subset.
@@ -7589,6 +7663,64 @@ const ArcTest = struct {
             }
         }
         arcInvariant("ARC test fixture cycled while walking to a switch_stmt");
+    }
+
+    /// Follows a linear fixture path to its first direct call.
+    fn walkToDirectCall(self: *const ArcTest, start: LIR.CFStmtId) @FieldType(LIR.CFStmt, "assign_call") {
+        var cursor = start;
+        var remaining: usize = self.store.cfStmtCount() + 1;
+        while (remaining > 0) : (remaining -= 1) {
+            switch (self.store.getCFStmt(cursor)) {
+                .assign_call => |assign| return assign,
+                inline .assign_ref,
+                .assign_literal,
+                .init_uninitialized,
+                .incref,
+                .decref,
+                .decref_if_initialized,
+                .free,
+                => |linear| cursor = linear.next,
+                .assign_call_erased,
+                .assign_packed_erased_fn,
+                .assign_boxy_desc_ref,
+                .assign_boxy_dict_ref,
+                .assign_boxy_box,
+                .assign_boxy_reuse_box,
+                .assign_boxy_unbox,
+                .assign_boxy_adapt,
+                .assign_boxy_inspect,
+                .assign_boxy_eq,
+                .assign_boxy_tag,
+                .assign_boxy_tag_payload,
+                .boxy_tag_match,
+                .assign_call_dict,
+                .assign_low_level,
+                .assign_list,
+                .assign_struct,
+                .assign_tag,
+                .store_struct,
+                .store_tag,
+                .set_local,
+                .debug,
+                .expect,
+                .comptime_branch_taken,
+                .expect_err,
+                .runtime_error,
+                .comptime_exhaustiveness_failed,
+                .switch_stmt,
+                .switch_initialized_payload,
+                .str_match,
+                .str_match_set,
+                .loop_continue,
+                .loop_break,
+                .join,
+                .jump,
+                .ret,
+                .crash,
+                => arcInvariant("ARC test fixture expected a direct call on the linear path"),
+            }
+        }
+        arcInvariant("ARC test fixture cycled while walking to a direct call");
     }
 
     fn procBody(self: *const ArcTest) LIR.CFStmtId {
@@ -12873,6 +13005,304 @@ test "RC interprocedural: borrowed return borrows the argument in the caller" {
     try f.expectRc(alias, 0, 0, 0);
     try f.expectRc(value, 0, 1, 0);
 }
+
+// Repro for https://github.com/roc-lang/roc/issues/10920
+test "RC interprocedural: tail self-call keeps a read-only parameter borrowed" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    // Recursive proc: reads its string parameter in the base case and passes
+    // it along unchanged in a tail self-call. Nothing consumes the string, so
+    // position 0 admits a borrow.
+    const text = try f.local(.str);
+    const counter = try f.local(.i64);
+    const base_result = try f.local(.i64);
+    const next_counter = try f.local(.i64);
+    const tail_result = try f.local(.i64);
+    const recurse = try f.addProcPendingBody(&.{ text, counter }, .i64);
+
+    const base_ret = try f.ret(base_result);
+    const base_assign = try f.assignI64(base_result, 0, base_ret);
+    const base_body = try f.expectStmt(text, base_assign);
+
+    // The call result is returned directly, which is what puts the self-call
+    // in tail position.
+    const tail_ret = try f.ret(tail_result);
+    const tail_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = tail_result,
+        .proc = recurse,
+        .args = try f.span(&.{ text, next_counter }),
+        .next = tail_ret,
+    } });
+    const recursive_body = try f.assignI64(next_counter, 0, tail_call);
+    f.store.setProcSpecBody(recurse, try f.switchStmt(counter, base_body, recursive_body, null));
+
+    // Caller outside the recursive group: it owns the string, lends it to the
+    // recursion, and reads it again afterwards.
+    const value = try f.local(.str);
+    const start = try f.local(.i64);
+    const call_result = try f.local(.i64);
+    const caller_ret = try f.ret(call_result);
+    const use_after_call = try f.expectStmt(value, caller_ret);
+    const caller_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = call_result,
+        .proc = recurse,
+        .args = try f.span(&.{ value, start }),
+        .next = use_after_call,
+    } });
+    const start_assign = try f.assignI64(start, 3, caller_call);
+    const caller_body = try f.assignStr(value, "outside-the-scc", start_assign);
+    _ = try f.addProc(&.{}, caller_body, .i64);
+
+    try f.run();
+
+    // The tail call requires the argument to stay live across the call, which
+    // a lender outside the recursive group already guarantees. That liveness
+    // requirement is not an ownership requirement, so position 0 stays
+    // borrowed and the parameter's read-only uses emit nothing.
+    const solved: arc_sig.RcSig = .{
+        .borrowed_params = @intCast(f.store.getProcSpec(recurse).rc_borrowed_params),
+    };
+    try testing.expectEqual(arc_sig.Mode.borrowed, solved.paramMode(0));
+    try f.expectRc(text, 0, 0, 0);
+    // The caller lends its string rather than handing over a unit, so it pays
+    // no retain for the call and releases after its own last use.
+    try f.expectRc(value, 0, 1, 0);
+}
+
+test "RC interprocedural: tail self-call transfers an SCC-local argument" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    const text = try f.local(.str);
+    const counter = try f.local(.i64);
+    const base_result = try f.local(.i64);
+    const next_text = try f.local(.str);
+    const next_counter = try f.local(.i64);
+    const tail_result = try f.local(.i64);
+    const recurse = try f.addProcPendingBody(&.{ text, counter }, .i64);
+
+    const base_ret = try f.ret(base_result);
+    const base_assign = try f.assignI64(base_result, 0, base_ret);
+    const base_body = try f.expectStmt(text, base_assign);
+    const tail_ret = try f.ret(tail_result);
+    const tail_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = tail_result,
+        .proc = recurse,
+        .args = try f.span(&.{ next_text, next_counter }),
+        .next = tail_ret,
+    } });
+    const make_next_text = try f.assignStr(next_text, "inside-the-scc", tail_call);
+    const recursive_body = try f.assignI64(next_counter, 0, make_next_text);
+    f.store.setProcSpecBody(recurse, try f.switchStmt(counter, base_body, recursive_body, null));
+
+    const value = try f.local(.str);
+    const start = try f.local(.i64);
+    const call_result = try f.local(.i64);
+    const caller_ret = try f.ret(call_result);
+    const use_after_call = try f.expectStmt(value, caller_ret);
+    const caller_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = call_result,
+        .proc = recurse,
+        .args = try f.span(&.{ value, start }),
+        .next = use_after_call,
+    } });
+    const start_assign = try f.assignI64(start, 1, caller_call);
+    const caller_body = try f.assignStr(value, "outside-the-scc", start_assign);
+    _ = try f.addProc(&.{}, caller_body, .i64);
+
+    const base_proc_count = f.store.procSpecCount();
+    try f.run();
+
+    // The public recursive entry still borrows its external argument. The
+    // locally created value instead moves into one mandatory owned variant,
+    // whose recursive edge targets itself with no cleanup after the call.
+    try testing.expectEqual(base_proc_count + 1, f.store.procSpecCount());
+    const owned_variant: LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(base_proc_count)));
+    const base_switch = f.walkToSwitch(f.store.getProcSpec(recurse).body.?);
+    const base_call = f.walkToDirectCall(base_switch.default_branch);
+    try testing.expectEqual(owned_variant, base_call.proc);
+    const variant_switch = f.walkToSwitch(f.store.getProcSpec(owned_variant).body.?);
+    const variant_call = f.walkToDirectCall(variant_switch.default_branch);
+    try testing.expectEqual(owned_variant, variant_call.proc);
+    const after_variant_call = f.store.getCFStmt(variant_call.next);
+    try testing.expect(after_variant_call == .ret and after_variant_call.ret.value == variant_call.target);
+    try f.expectReachableRcBefore(variant_switch.default_branch, .decref, text, .ret);
+    // The owned variant releases its entry value on either branch: at the
+    // base return, or before the recursive tail edge replaces its frame.
+    try f.expectRc(text, 0, 2, 0);
+    try f.expectRc(next_text, 0, 0, 0);
+    try f.expectRc(value, 0, 1, 0);
+}
+
+test "RC interprocedural: mutual tail calls preserve an SCC-entry borrow" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    const left_text = try f.local(.str);
+    const left_counter = try f.local(.i64);
+    const left_result = try f.local(.i64);
+    const left_next = try f.local(.i64);
+    const right_text = try f.local(.str);
+    const right_counter = try f.local(.i64);
+    const right_result = try f.local(.i64);
+    const right_next = try f.local(.i64);
+    const left = try f.addProcPendingBody(&.{ left_text, left_counter }, .i64);
+    const right = try f.addProcPendingBody(&.{ right_text, right_counter }, .i64);
+
+    const left_ret = try f.ret(left_result);
+    const left_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = left_result,
+        .proc = right,
+        .args = try f.span(&.{ left_text, left_next }),
+        .next = left_ret,
+    } });
+    const left_recursive = try f.assignI64(left_next, 0, left_call);
+    const left_base_result = try f.assignI64(left_result, 0, left_ret);
+    const left_base = try f.expectStmt(left_text, left_base_result);
+    f.store.setProcSpecBody(left, try f.switchStmt(left_counter, left_base, left_recursive, null));
+
+    const right_ret = try f.ret(right_result);
+    const right_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = right_result,
+        .proc = left,
+        .args = try f.span(&.{ right_text, right_next }),
+        .next = right_ret,
+    } });
+    const right_recursive = try f.assignI64(right_next, 0, right_call);
+    const right_base_result = try f.assignI64(right_result, 0, right_ret);
+    const right_base = try f.expectStmt(right_text, right_base_result);
+    f.store.setProcSpecBody(right, try f.switchStmt(right_counter, right_base, right_recursive, null));
+
+    const value = try f.local(.str);
+    const start = try f.local(.i64);
+    const result = try f.local(.i64);
+    const caller_ret = try f.ret(result);
+    const use_after = try f.expectStmt(value, caller_ret);
+    const call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = result,
+        .proc = left,
+        .args = try f.span(&.{ value, start }),
+        .next = use_after,
+    } });
+    const start_assign = try f.assignI64(start, 2, call);
+    const caller_body = try f.assignStr(value, "outside-the-mutual-scc", start_assign);
+    _ = try f.addProc(&.{}, caller_body, .i64);
+
+    const base_proc_count = f.store.procSpecCount();
+    try f.run();
+
+    try testing.expectEqual(base_proc_count, f.store.procSpecCount());
+    const left_sig: arc_sig.RcSig = .{ .borrowed_params = @intCast(f.store.getProcSpec(left).rc_borrowed_params) };
+    const right_sig: arc_sig.RcSig = .{ .borrowed_params = @intCast(f.store.getProcSpec(right).rc_borrowed_params) };
+    try testing.expectEqual(arc_sig.Mode.borrowed, left_sig.paramMode(0));
+    try testing.expectEqual(arc_sig.Mode.borrowed, right_sig.paramMode(0));
+    try f.expectRc(left_text, 0, 0, 0);
+    try f.expectRc(right_text, 0, 0, 0);
+    try f.expectRc(value, 0, 1, 0);
+}
+
+test "RC interprocedural: tail call matches the caller return ownership" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    const caller_text = try f.local(.str);
+    const caller_counter = try f.local(.i64);
+    const owned_base = try f.local(.str);
+    const caller_next = try f.local(.i64);
+    const caller_result = try f.local(.str);
+    const lender_text = try f.local(.str);
+    const lender_counter = try f.local(.i64);
+    const ignored_owned = try f.local(.str);
+    const caller = try f.addProcPendingBody(&.{ caller_text, caller_counter }, .str);
+    const lender = try f.addProcPendingBody(&.{ lender_text, lender_counter }, .str);
+
+    // The caller has an owned return because one path creates a fresh string.
+    // Its recursive path tail-calls a proc whose ordinary return borrows its
+    // parameter, so that edge needs an owned-return variant even though the
+    // argument itself can remain borrowed from outside the SCC.
+    const caller_ret = try f.ret(caller_result);
+    const caller_tail_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = caller_result,
+        .proc = lender,
+        .args = try f.span(&.{ caller_text, caller_next }),
+        .next = caller_ret,
+    } });
+    const caller_recursive = try f.assignI64(caller_next, 0, caller_tail_call);
+    const owned_base_ret = try f.ret(owned_base);
+    const caller_base = try f.assignStr(owned_base, "owned-base", owned_base_ret);
+    f.store.setProcSpecBody(caller, try f.switchStmt(caller_counter, caller_base, caller_recursive, null));
+
+    // This non-tail edge closes the call-graph SCC, then the proc returns its
+    // borrowed entry parameter. Its owned-return variant retains at its own
+    // return boundary, before the caller's tail edge begins.
+    const lender_ret = try f.ret(lender_text);
+    const lender_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = ignored_owned,
+        .proc = caller,
+        .args = try f.span(&.{ lender_text, lender_counter }),
+        .next = lender_ret,
+    } });
+    f.store.setProcSpecBody(lender, lender_call);
+
+    const base_proc_count = f.store.procSpecCount();
+    try f.run();
+
+    try testing.expect(!f.store.getProcSpec(caller).rc_ret_borrowed);
+    try testing.expect(f.store.getProcSpec(lender).rc_ret_borrowed);
+    try testing.expectEqual(base_proc_count + 1, f.store.procSpecCount());
+    const owned_return_variant: LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(base_proc_count)));
+    try testing.expect(!f.store.getProcSpec(owned_return_variant).rc_ret_borrowed);
+    const caller_switch = f.walkToSwitch(f.store.getProcSpec(caller).body.?);
+    const rewritten_tail_call = f.walkToDirectCall(caller_switch.default_branch);
+    try testing.expectEqual(owned_return_variant, rewritten_tail_call.proc);
+    const after_tail_call = f.store.getCFStmt(rewritten_tail_call.next);
+    try testing.expect(after_tail_call == .ret and after_tail_call.ret.value == rewritten_tail_call.target);
+    try f.expectRc(caller_text, 0, 0, 0);
+}
+
+test "RC interprocedural: borrowed call result anchors a recursive tail argument" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    const id_param = try f.local(.str);
+    const id_ret = try f.ret(id_param);
+    const identity = try f.addProc(&.{id_param}, id_ret, .str);
+
+    const text = try f.local(.str);
+    const counter = try f.local(.i64);
+    const borrowed_result = try f.local(.str);
+    const base_result = try f.local(.i64);
+    const next_counter = try f.local(.i64);
+    const tail_result = try f.local(.i64);
+    const recurse = try f.addProcPendingBody(&.{ text, counter }, .i64);
+    const base_ret = try f.ret(base_result);
+    const base_assign = try f.assignI64(base_result, 0, base_ret);
+    const base_body = try f.expectStmt(text, base_assign);
+    const tail_ret = try f.ret(tail_result);
+    const tail_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = tail_result,
+        .proc = recurse,
+        .args = try f.span(&.{ borrowed_result, next_counter }),
+        .next = tail_ret,
+    } });
+    const borrow_call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = borrowed_result,
+        .proc = identity,
+        .args = try f.span(&.{text}),
+        .next = tail_call,
+    } });
+    const recursive_body = try f.assignI64(next_counter, 0, borrow_call);
+    f.store.setProcSpecBody(recurse, try f.switchStmt(counter, base_body, recursive_body, null));
+
+    try f.run();
+
+    const recurse_sig: arc_sig.RcSig = .{ .borrowed_params = @intCast(f.store.getProcSpec(recurse).rc_borrowed_params) };
+    try testing.expectEqual(arc_sig.Mode.borrowed, recurse_sig.paramMode(0));
+    try f.expectRc(text, 0, 0, 0);
+    try f.expectRc(borrowed_result, 0, 0, 0);
+}
+
 test "RC borrow survives the lender moving into an aggregate" {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -26,12 +26,14 @@
 //! reverse dependencies to take parameter modes to a fixpoint with returns
 //! pessimistically owned: parameters start borrowed and flip to owned when
 //! any occurrence demands a unit, so every parameter bit is queued at most
-//! once. Calls in tail position to procs in the same call-graph
-//! strongly-connected component demand ownership of their arguments so
-//! emission never needs a statement after the call. Phase B then marks
-//! returns borrowed when every returned value is a borrow anchored on a
-//! borrowed parameter, and re-solves binding modes so callers may borrow such
-//! results. After signatures settle,
+//! once. Phase B then marks returns borrowed when every returned value is a
+//! borrow anchored on a borrowed parameter, and re-solves binding modes so
+//! callers may borrow such results. Same-SCC tail calls retain their ordinary
+//! mode constraints and record the exact borrowed caller parameter, if any,
+//! whose entry lifetime contains each argument occurrence. Emission transfers
+//! ownership only when that anchor is absent or owned in the current variant,
+//! so frame replacement preserves external borrows without leaving cleanup
+//! after the call. After signatures settle,
 //! unique returns solve to a fixpoint with the born-unique analysis: a
 //! proc's return is unique when every `ret` returns a born-unique value
 //! surviving to the return with no other holder, and a direct-call result
@@ -83,6 +85,40 @@ pub const JoinBody = struct {
     jump_count: u32 = 0,
 };
 
+const no_param_anchor: u8 = std.math.maxInt(u8);
+
+/// Exact lifetime fact for one direct call whose result is immediately
+/// returned to a callee in the same call-graph SCC. Each represented argument
+/// either names the caller parameter whose borrowed entry lifetime contains
+/// the recursive call, or has no such anchor and must transfer an ownership
+/// unit before the caller frame can be replaced.
+pub const TailCallLifetime = struct {
+    stmt: LIR.CFStmtId,
+    anchor_params: [arc_sig.tracked_param_count]u8,
+    carriers: [arc_sig.tracked_param_count]u32,
+
+    pub fn anchorParam(self: *const TailCallLifetime, position: usize) ?usize {
+        if (position >= arc_sig.tracked_param_count) return null;
+        const anchor = self.anchor_params[position];
+        return if (anchor == no_param_anchor) null else anchor;
+    }
+
+    pub fn carrier(self: *const TailCallLifetime, position: usize) ?LIR.LocalId {
+        if (position >= arc_sig.tracked_param_count) return null;
+        const local = self.carriers[position];
+        return if (local == no_local) null else @enumFromInt(local);
+    }
+
+    pub fn argumentOutlivesScc(
+        self: *const TailCallLifetime,
+        position: usize,
+        caller_sig: arc_sig.RcSig,
+    ) bool {
+        const anchor = self.anchorParam(position) orelse return false;
+        return caller_sig.paramMode(anchor) == .borrowed;
+    }
+};
+
 /// Per-local binding-mode solution, liveness groups, and per-proc ownership
 /// signatures. A group is one leader local together with every borrowed
 /// local whose liveness anchors on it; emission keeps the leader's ownership
@@ -116,6 +152,12 @@ pub const Solution = struct {
     /// Parameter positions whose values can reach a consuming low-level
     /// runtime uniqueness check in this proc's ownership-neutral body.
     unique_seed_masks: []arc_sig.ParamMask,
+    /// Same-SCC tail-call lifetime facts, partitioned by source proc. These
+    /// preserve the exact SCC-entry lender for each represented argument so
+    /// variants can re-evaluate the constraint under their demanded ABI.
+    tail_call_offsets: []u32,
+    tail_call_lens: []u32,
+    tail_calls: []TailCallLifetime,
     /// Flat join-body facts per source proc, indexed through the adjacent
     /// offsets and lengths.
     join_body_offsets: []u32,
@@ -168,6 +210,9 @@ pub const Solution = struct {
         self.allocator.free(self.available_outcome_spans);
         self.allocator.free(self.restitution_params_by_stmt);
         self.allocator.free(self.unique_seed_masks);
+        self.allocator.free(self.tail_call_offsets);
+        self.allocator.free(self.tail_call_lens);
+        self.allocator.free(self.tail_calls);
         self.allocator.free(self.join_body_offsets);
         self.allocator.free(self.join_body_lens);
         self.allocator.free(self.join_bodies);
@@ -294,6 +339,33 @@ pub const Solution = struct {
         const index = @intFromEnum(stmt);
         if (index >= self.restitution_params_by_stmt.len) return 0;
         return self.restitution_params_by_stmt[index];
+    }
+
+    pub fn tailCallsOf(self: *const Solution, proc: LIR.LirProcSpecId) []const TailCallLifetime {
+        const index = @intFromEnum(proc);
+        if (index >= self.tail_call_offsets.len) return &.{};
+        const offset = self.tail_call_offsets[index];
+        const len = self.tail_call_lens[index];
+        return self.tail_calls[offset..][0..len];
+    }
+
+    pub fn tailCallAt(self: *const Solution, proc: LIR.LirProcSpecId, stmt: LIR.CFStmtId) ?*const TailCallLifetime {
+        const tail_calls = self.tailCallsOf(proc);
+        const stmt_index = @intFromEnum(stmt);
+        var left: usize = 0;
+        var right = tail_calls.len;
+        while (left < right) {
+            const middle = left + (right - left) / 2;
+            const middle_index = @intFromEnum(tail_calls[middle].stmt);
+            if (middle_index < stmt_index) {
+                left = middle + 1;
+            } else if (middle_index > stmt_index) {
+                right = middle;
+            } else {
+                return &tail_calls[middle];
+            }
+        }
+        return null;
     }
 
     pub fn joinBodiesOf(self: *const Solution, proc: LIR.LirProcSpecId) []const JoinBody {
@@ -483,6 +555,7 @@ const ArcLocalDomain = struct {
 
 const DirectCallFact = struct {
     caller: u32,
+    stmt: LIR.CFStmtId,
     callee: LIR.LirProcSpecId,
     args: LIR.LocalSpan,
     target: LIR.LocalId,
@@ -786,6 +859,10 @@ pub fn solve(
         }
     }
 
+    var tail_call_table = try buildTailCallTable(&solver, &binding);
+    var tail_call_table_kept = false;
+    defer if (!tail_call_table_kept) tail_call_table.deinit(allocator);
+
     var visible = try computeVisibilityFromFacts(allocator, &solver);
     errdefer visible.deinit(allocator);
     if (builtin.mode == .Debug) {
@@ -895,6 +972,9 @@ pub fn solve(
         .available_outcome_spans = try allocator.alloc(arc_sig.OutcomeSpan, proc_count),
         .restitution_params_by_stmt = try allocator.alloc(arc_sig.ParamMask, store.cfStmtCount()),
         .unique_seed_masks = solver.unique_seed_masks,
+        .tail_call_offsets = tail_call_table.offsets,
+        .tail_call_lens = tail_call_table.lens,
+        .tail_calls = tail_call_table.facts,
         .join_body_offsets = join_body_offsets,
         .join_body_lens = join_body_lens,
         .join_bodies = join_bodies,
@@ -916,6 +996,7 @@ pub fn solve(
     @memset(solution.available_outcome_spans, .empty);
     solver_sigs_kept = true;
     solver_join_indices_kept = true;
+    tail_call_table_kept = true;
     errdefer {
         solution.borrowed.deinit(allocator);
         solution.borrowed_call_result.deinit(allocator);
@@ -926,6 +1007,9 @@ pub fn solve(
         allocator.free(solution.available_outcome_spans);
         allocator.free(solution.restitution_params_by_stmt);
         allocator.free(solution.unique_seed_masks);
+        allocator.free(solution.tail_call_offsets);
+        allocator.free(solution.tail_call_lens);
+        allocator.free(solution.tail_calls);
         allocator.free(solution.join_body_offsets);
         allocator.free(solution.join_body_lens);
         allocator.free(solution.join_bodies);
@@ -1566,6 +1650,18 @@ const BindingResult = struct {
     }
 };
 
+const TailCallTable = struct {
+    offsets: []u32,
+    lens: []u32,
+    facts: []TailCallLifetime,
+
+    fn deinit(self: *TailCallTable, allocator: Allocator) void {
+        allocator.free(self.offsets);
+        allocator.free(self.lens);
+        allocator.free(self.facts);
+    }
+};
+
 /// Resolves each local's lender chain against the current defs/demands.
 /// A chain link stays borrowed only if the link itself qualifies and the
 /// chain bottoms out at a once-bound leader that is either owned or a
@@ -1638,6 +1734,94 @@ fn resolveBindings(solver: *Solver) SolveError!BindingResult {
     }
 
     return .{ .borrowed = borrowed, .leader = leader };
+}
+
+/// Builds the exact lifetime boundary facts for recursive tail calls after
+/// parameter modes and borrowed-return lenders are final. A borrowed argument
+/// outlives frame replacement exactly when its solved lender is a borrowed
+/// entry parameter of this caller. Every other represented RC argument names
+/// the local that must carry an ownership unit into a mandatory callee
+/// variant.
+fn buildTailCallTable(
+    solver: *const Solver,
+    binding: *const BindingResult,
+) SolveError!TailCallTable {
+    const allocator = solver.allocator;
+    const proc_count = solver.sigs.len;
+    const offsets = try allocator.alloc(u32, proc_count);
+    errdefer allocator.free(offsets);
+    const lens = try allocator.alloc(u32, proc_count);
+    errdefer allocator.free(lens);
+    @memset(lens, 0);
+
+    for (solver.direct_calls.items) |call| {
+        if (!call.tail) continue;
+        if (solver.scc[call.caller] != solver.scc[@intFromEnum(call.callee)]) continue;
+        lens[call.caller] += 1;
+    }
+
+    var fact_count: u32 = 0;
+    for (lens, 0..) |len, proc_index| {
+        offsets[proc_index] = fact_count;
+        fact_count += len;
+    }
+    const facts = try allocator.alloc(TailCallLifetime, fact_count);
+    errdefer allocator.free(facts);
+    const fill = try allocator.dupe(u32, offsets);
+    defer allocator.free(fill);
+
+    for (solver.direct_calls.items) |call| {
+        if (!call.tail) continue;
+        if (solver.scc[call.caller] != solver.scc[@intFromEnum(call.callee)]) continue;
+
+        var fact = TailCallLifetime{
+            .stmt = call.stmt,
+            .anchor_params = [_]u8{no_param_anchor} ** arc_sig.tracked_param_count,
+            .carriers = [_]u32{no_local} ** arc_sig.tracked_param_count,
+        };
+        const args = solver.store.getLocalSpan(call.args);
+        for (0..@min(GuardedList.borrowLen(args), arc_sig.tracked_param_count)) |position| {
+            const argument = solver.domain.indexOf(GuardedList.at(args, position)) orelse continue;
+            fact.carriers[position] = tailArgumentCarrier(solver, binding, argument);
+            if (!binding.borrowed.isSet(argument)) continue;
+            const leader = binding.leader[argument];
+            if (!paramIsBorrowed(solver, leader)) continue;
+            if (solver.param_proc[leader] != call.caller) continue;
+            const anchor = solver.param_position[leader];
+            if (anchor >= arc_sig.tracked_param_count) continue;
+            fact.anchor_params[position] = @intCast(anchor);
+        }
+
+        facts[fill[call.caller]] = fact;
+        fill[call.caller] += 1;
+    }
+
+    for (offsets, lens) |offset, len| {
+        const start: usize = @intCast(offset);
+        const count: usize = @intCast(len);
+        std.mem.sort(TailCallLifetime, facts[start..][0..count], {}, tailCallLifetimeLessThan);
+    }
+
+    return .{ .offsets = offsets, .lens = lens, .facts = facts };
+}
+
+fn tailCallLifetimeLessThan(_: void, left: TailCallLifetime, right: TailCallLifetime) bool {
+    return @intFromEnum(left.stmt) < @intFromEnum(right.stmt);
+}
+
+/// Mirrors `Solution.unitLocalOf` in the dense solver domain. Borrowed pure
+/// aliases transfer their source's unit; other borrowed definitions need an
+/// owned override on their own binding when a tail-call lifetime escapes.
+fn tailArgumentCarrier(solver: *const Solver, binding: *const BindingResult, argument: u32) u32 {
+    if (!binding.borrowed.isSet(argument)) return solver.domain.localAt(argument);
+    var cursor = argument;
+    var steps: usize = 0;
+    while (solver.alias_source[cursor] != no_local) {
+        cursor = solver.alias_source[cursor];
+        steps += 1;
+        if (steps > solver.alias_source.len) solveInvariant("ARC tail-call carrier alias chain contained a cycle");
+    }
+    return solver.domain.localAt(cursor);
 }
 
 fn paramIsBorrowed(solver: *const Solver, local_index: u32) bool {
@@ -1989,6 +2173,7 @@ fn liftProcStmtFacts(
     switch (solver.store.getCFStmt(current)) {
         .assign_call => |assign| try solver.direct_calls.append(solver.allocator, .{
             .caller = proc_index,
+            .stmt = current,
             .callee = assign.proc,
             .args = assign.args,
             .target = assign.target,
@@ -2281,23 +2466,23 @@ fn collectAll(solver: *Solver) SolveError!void {
     };
 
     // Direct-call demands are the only binding facts that depend on the
-    // solved call SCCs and the current optimistic parameter signatures.
+    // current optimistic parameter signatures. Tailness never changes the
+    // ownership relation: same-SCC tail arguments get a separate exact
+    // lifetime fact after borrowed-return lenders settle.
     for (solver.direct_calls.items) |call| {
         const callee_sig = solver.sigs[@intFromEnum(call.callee)];
         const args = solver.store.getLocalSpan(call.args);
-        const same_scc = solver.scc[@intFromEnum(call.callee)] == solver.scc[call.caller];
-        const tail_call = same_scc and call.tail;
         for (0..GuardedList.borrowLen(args)) |position| {
             const arg = GuardedList.at(args, position);
             const argument = solver.domain.indexOf(arg) orelse continue;
-            if (!tail_call and position < arc_sig.tracked_param_count) {
+            if (position < arc_sig.tracked_param_count) {
                 const key = @intFromEnum(call.callee) * arc_sig.tracked_param_count + position;
                 try solver.param_uses.append(solver.allocator, .{
                     .key = @intCast(key),
                     .argument = argument,
                 });
             }
-            if (!tail_call and callee_sig.paramMode(position) == .borrowed) continue;
+            if (callee_sig.paramMode(position) == .borrowed) continue;
             noteDemand(solver, arg);
         }
     }

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -87,11 +87,11 @@ pub const JoinBody = struct {
 
 const no_param_anchor: u8 = std.math.maxInt(u8);
 
-/// Exact lifetime fact for one direct call whose result is immediately
-/// returned to a callee in the same call-graph SCC. Each represented argument
-/// either names the caller parameter whose borrowed entry lifetime contains
-/// the recursive call, or has no such anchor and must transfer an ownership
-/// unit before the caller frame can be replaced.
+/// Exact lifetime fact for one direct call to a callee in the same call-graph
+/// SCC whose result is immediately returned by the caller. Each represented
+/// argument either names the caller parameter whose borrowed entry lifetime
+/// contains the recursive call, or has no such anchor and must transfer an
+/// ownership unit before the caller frame can be replaced.
 pub const TailCallLifetime = struct {
     stmt: LIR.CFStmtId,
     anchor_params: [arc_sig.tracked_param_count]u8,
@@ -1782,8 +1782,8 @@ fn buildTailCallTable(
         const args = solver.store.getLocalSpan(call.args);
         for (0..@min(GuardedList.borrowLen(args), arc_sig.tracked_param_count)) |position| {
             const argument = solver.domain.indexOf(GuardedList.at(args, position)) orelse continue;
-            fact.carriers[position] = tailArgumentCarrier(solver, binding, argument);
             if (!binding.borrowed.isSet(argument)) continue;
+            fact.carriers[position] = tailArgumentCarrier(solver, argument);
             const leader = binding.leader[argument];
             if (!paramIsBorrowed(solver, leader)) continue;
             if (solver.param_proc[leader] != call.caller) continue;
@@ -1812,8 +1812,7 @@ fn tailCallLifetimeLessThan(_: void, left: TailCallLifetime, right: TailCallLife
 /// Mirrors `Solution.unitLocalOf` in the dense solver domain. Borrowed pure
 /// aliases transfer their source's unit; other borrowed definitions need an
 /// owned override on their own binding when a tail-call lifetime escapes.
-fn tailArgumentCarrier(solver: *const Solver, binding: *const BindingResult, argument: u32) u32 {
-    if (!binding.borrowed.isSet(argument)) return solver.domain.localAt(argument);
+fn tailArgumentCarrier(solver: *const Solver, argument: u32) u32 {
     var cursor = argument;
     var steps: usize = 0;
     while (solver.alias_source[cursor] != no_local) {


### PR DESCRIPTION
Same-SCC tail-call arguments now carry their exact SCC-entry lifetime anchors instead of being forced owned. ARC keeps externally anchored borrows, selects mandatory ownership and return-mode variants for values local to the recursive group, and discharges the replaced caller frame before the tail edge so no RC work remains after the call.\n\nFixes #10920.