### PR TITLE
Keep constrained checked rows open

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -7953,10 +7953,11 @@ fn appendCheckedTypeRootWithRowDefault(
     store: *CheckedTypeStore,
     active: *CheckedSourceTypeRoots,
     var_: Var,
-    row_default: ?RowDefault,
+    row_default_candidate: ?RowDefault,
 ) Allocator.Error!CheckedTypeId {
     const resolved = module.typeStoreConst().resolveVar(var_);
     const resolved_var = resolved.var_;
+    const row_default = checkedTypeVariableRowDefault(resolved.desc.content, row_default_candidate);
 
     // The checker explicitly marks an otherwise-unresolved identity when it
     // closes that identity to `[]`. Preserve the surviving root as a checked
@@ -8104,6 +8105,22 @@ fn appendCheckedTypeRootWithRowDefault(
     store.payloads.items[@intFromEnum(id)] = stored;
     applyCheckedTypeRowDefault(store, id, row_default);
     return id;
+}
+
+/// A row-tail occurrence supplies a close-to-empty default only when its
+/// variable has no static-dispatch requirements. A constrained row must stay
+/// open so each use can instantiate both the row and its evidence together.
+fn checkedTypeVariableRowDefault(
+    content: types.Content,
+    candidate: ?RowDefault,
+) ?RowDefault {
+    const default = candidate orelse return null;
+    const constraints = switch (content) {
+        .flex => |flex| flex.constraints,
+        .rigid => |rigid| rigid.constraints,
+        .err, .alias, .field_presence, .structure => return null,
+    };
+    return if (constraints.len() == 0) default else null;
 }
 
 fn applyCheckedTypeRowDefault(
@@ -9113,6 +9130,31 @@ const EmptyTagCheckedOutputTestError = @import("test/TestEnv.zig").TestEnvError 
     ExpectedFlexIdentity,
     ExpectedFunctionPayload,
 };
+
+test "checked row defaults apply only to unconstrained type variables" {
+    const no_constraints = types.StaticDispatchConstraint.SafeList.Range.empty();
+    const one_constraint = types.StaticDispatchConstraint.SafeList.Range{
+        .start = @enumFromInt(0),
+        .count = 1,
+    };
+
+    try std.testing.expectEqual(
+        RowDefault.empty_record,
+        checkedTypeVariableRowDefault(.{ .flex = .{ .name = null, .constraints = no_constraints } }, .empty_record).?,
+    );
+    try std.testing.expectEqual(
+        RowDefault.empty_tag_union,
+        checkedTypeVariableRowDefault(.{ .rigid = .{ .name = Ident.Idx.NONE, .constraints = no_constraints } }, .empty_tag_union).?,
+    );
+    try std.testing.expectEqual(
+        null,
+        checkedTypeVariableRowDefault(.{ .flex = .{ .name = null, .constraints = one_constraint } }, .empty_record),
+    );
+    try std.testing.expectEqual(
+        null,
+        checkedTypeVariableRowDefault(.{ .rigid = .{ .name = Ident.Idx.NONE, .constraints = one_constraint } }, .empty_tag_union),
+    );
+}
 
 fn withEmptyTagCheckedOutputForTest(
     allocator: Allocator,

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -9134,7 +9134,8 @@ const EmptyTagCheckedOutputTestError = @import("test/TestEnv.zig").TestEnvError 
 test "checked row defaults apply only to unconstrained type variables" {
     const no_constraints = types.StaticDispatchConstraint.SafeList.Range.empty();
     const one_constraint = types.StaticDispatchConstraint.SafeList.Range{
-        .start = @enumFromInt(0),
+        // The helper inspects only the range count, so no backing-list index is read.
+        .start = undefined,
         .count = 1,
     };
 

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1090,6 +1090,11 @@ const subcommand_cases = [_]CliCase{
     // Repro for https://github.com/roc-lang/roc/issues/10824: rank-1 platform
     // inference must retain the complete generated encoder contract after its row closes.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10824: inferred platform model with custom codec checks cleanly", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10824_generated_codec_contract/app.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{ .{ .stream = .stderr, .text = "checked generated codec contract was missing its subject method call" }, .{ .stream = .stderr, .text = "postcheck invariant violated" }, .{ .stream = .stderr, .text = "Segmentation fault" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    // Repro for https://github.com/roc-lang/roc/issues/10956: the extension
+    // variable of an open record annotation can also carry a where-clause
+    // method requirement, so publishing that function type must keep the
+    // constrained row open instead of assigning its contextual row default.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10956: constrained open record row publishes without a default", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10956_open_record_ext_where_clause.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{ .{ .stream = .stderr, .text = "checked row default was assigned to a constrained type variable" }, .{ .stream = .stderr, .text = "checked artifact invariant violated" }, .{ .stream = .stderr, .text = "Segmentation fault" }, .{ .stream = .stderr, .text = "panic" } } } } },
     // Repro for https://github.com/roc-lang/roc/issues/10832: the list element
     // contains an erased Box allocation even though its unresolved closure
     // layout is otherwise non-refcounted, so list allocation and drop must use

--- a/test/cli/issue_10956_open_record_ext_where_clause.roc
+++ b/test/cli/issue_10956_open_record_ext_where_clause.roc
@@ -1,0 +1,7 @@
+# repro for https://github.com/roc-lang/roc/issues/10956
+# An open record whose extension variable also carries a where-clause method
+# requirement must reach the end of `roc check` without crashing the compiler.
+blub : { ..a } -> {} where [a.const : a -> U8]
+blub = |_| {}
+
+main! = |_| Ok({})


### PR DESCRIPTION
Checked type publication treated every open row extension as eligible for a close-to-empty default, even when the extension variable carried static-dispatch requirements. This keeps constrained row variables open so their row and evidence are instantiated together, while preserving the existing fast defaulting path for unconstrained rows. Closes #10956.