### PR TITLE
Fix Wasm lossy UTF-8 string ownership

### DIFF
--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -18377,22 +18377,32 @@ fn emitStrFromUtf8Lossy(self: *Self, list_arg: ProcLocalId) Allocator.Error!void
     self.currentCode().append(self.allocator, Op.@"else") catch return error.OutOfMemory;
     {
         const data_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-        const list_cap = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
 
         try self.emitLocalGet(list_ptr);
         try self.emitLoadOp(.i32, 0);
         try self.emitLocalSet(data_ptr);
 
-        try self.emitLocalGet(list_ptr);
-        try self.emitLoadOp(.i32, 8);
-        try self.emitLocalSet(list_cap);
+        // `str_from_utf8_lossy` is an allocating primitive in LIR. Keep the
+        // Wasm lowering faithful to that contract instead of reinterpreting
+        // the input List allocation as the returned Str. ARC releases the
+        // input independently after this operation.
+        try self.emitHeapAllocWithRefcount(len, 1, false);
+        const result_data = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitLocalSet(result_data);
+
+        const zero = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitI32Const(0);
+        try self.emitLocalSet(zero);
+        try self.emitMemCopyLoop(result_data, zero, data_ptr, len);
 
         try self.emitLocalGet(result_ptr);
-        try self.emitLocalGet(data_ptr);
+        try self.emitLocalGet(result_data);
         try self.emitStoreOp(.i32, 0);
 
         try self.emitLocalGet(result_ptr);
-        try self.emitLocalGet(list_cap);
+        try self.emitLocalGet(len);
+        try self.emitI32Const(1);
+        self.currentCode().append(self.allocator, Op.i32_shl) catch return error.OutOfMemory;
         try self.emitStoreOp(.i32, 4);
 
         try self.emitLocalGet(result_ptr);

--- a/src/eval/test/eval_regression_repros.zig
+++ b/src/eval/test/eval_regression_repros.zig
@@ -5,6 +5,23 @@ const TestCase = @import("parallel_runner.zig").TestCase;
 /// Eval regression cases.
 pub const tests = [_]TestCase{
     .{
+        // `Str.from_utf8_lossy` returns independently owned storage. The Wasm
+        // lowering must not reinterpret the consumed List allocation as the
+        // returned Str, because ARC releases the List independently.
+        .name = "wasm Str.from_utf8_lossy result remains owned after its input is released",
+        .source_kind = .module,
+        .source =
+        \\main : U64
+        \\main = {
+        \\    bytes = List.repeat(97.U8, 64)
+        \\    decoded = Str.from_utf8_lossy(bytes)
+        \\    copies = [decoded, decoded]
+        \\    Str.count_utf8_bytes(decoded) + List.len(copies)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "66" },
+    },
+    .{
         // One statement consuming the same list in two argument positions.
         // Both consumes happen whenever the statement runs, so the value has
         // two live references and the write must not land in place: doing so


### PR DESCRIPTION
## Summary

- make the Wasm lowering of Str.from_utf8_lossy allocate independent backing storage, matching its LIR RcEffect
- encode the returned big-string capacity correctly
- add a cross-backend regression covering release of the input List while the returned Str remains owned

## Root cause

The Wasm backend reinterpreted a non-small List(U8) allocation as the returned Str. LIR declares Str.from_utf8_lossy as allocating, so ARC independently releases the input List. The returned Str consequently referenced released storage. This surfaced in dev builds as invalid frees during roc-signals application teardown.

## Validation

- zig build run-test-eval -- --filter "wasm Str.from_utf8_lossy result remains owned" --threads 1 --verbose
- roc-signals full Wasm application receipt suite using --opt=dev: 29 passed, 0 regressed
