### PR TITLE
Write exact return sizes through result pointers in the dev backend

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -15883,11 +15883,11 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 if (inner_layout.tag == .tag_union) {
                     const box_ptr_reg = try self.ensureInGeneralReg(raw_value_loc);
                     const dest_offset = self.codegen.allocStackSlot(payload_size);
-                    var copied: u32 = 0;
-                    while (copied < payload_size) : (copied += 8) {
+                    // The box allocation holds exactly payload_size bytes, so a
+                    // word-rounded copy would read past the heap allocation.
+                    if (payload_size > 0) {
                         const temp_reg = try self.allocTempGeneral();
-                        try self.emitLoad(.w64, temp_reg, box_ptr_reg, @intCast(copied));
-                        try self.emitStore(.w64, frame_ptr, dest_offset + @as(i32, @intCast(copied)), temp_reg);
+                        try self.copyChunked(temp_reg, box_ptr_reg, 0, frame_ptr, dest_offset, payload_size);
                         self.codegen.freeGeneral(temp_reg);
                     }
                     self.codegen.freeGeneral(box_ptr_reg);
@@ -19139,38 +19139,26 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                                 const tuple_data = ls.getStructData(tuple_layout.getStruct().idx);
                                 const total_size = tuple_data.size.get(ls.targetUsize());
 
-                                // Copy entire tuple as 8-byte chunks
-                                const temp_reg = try self.allocTempGeneral();
-                                var copied: u32 = 0;
-
-                                while (copied < total_size) {
-                                    const stack_offset = base_offset + @as(i32, @intCast(copied));
-                                    const buf_offset: i32 = @as(i32, @intCast(copied));
-
-                                    // Load from stack
-                                    try self.emitLoad(.w64, temp_reg, frame_ptr, stack_offset);
-
-                                    // Store to result buffer
-                                    try self.emitStore(.w64, saved_ptr_reg, buf_offset, temp_reg);
-
-                                    copied += 8;
+                                // The result buffer holds exactly total_size
+                                // bytes of caller-owned storage, so the copy
+                                // must not round up to whole words.
+                                if (total_size > 0) {
+                                    const temp_reg = try self.allocTempGeneral();
+                                    try self.copyChunked(temp_reg, frame_ptr, base_offset, saved_ptr_reg, 0, total_size);
+                                    self.codegen.freeGeneral(temp_reg);
                                 }
-
-                                self.codegen.freeGeneral(temp_reg);
                                 return;
                             }
                         }
 
-                        // Fallback: copy tuple_len * 8 bytes
-                        const temp_reg = try self.allocTempGeneral();
-                        for (0..tuple_len) |i| {
-                            const stack_offset = base_offset + @as(i32, @intCast(i)) * 8;
-                            const buf_offset: i32 = @as(i32, @intCast(i)) * 8;
-
-                            try self.emitLoad(.w64, temp_reg, frame_ptr, stack_offset);
-                            try self.emitStore(.w64, saved_ptr_reg, buf_offset, temp_reg);
+                        // Non-struct tuple layouts still copy exactly the
+                        // layout's byte count into the caller-owned buffer.
+                        const total_size = self.getLayoutSize(result_layout);
+                        if (total_size > 0) {
+                            const temp_reg = try self.allocTempGeneral();
+                            try self.copyChunked(temp_reg, frame_ptr, base_offset, saved_ptr_reg, 0, total_size);
+                            self.codegen.freeGeneral(temp_reg);
                         }
-                        self.codegen.freeGeneral(temp_reg);
                         return;
                     },
                     .general_reg,
@@ -20010,6 +19998,15 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             }
         }
 
+        /// Copy exactly `size` bytes from [src_base + src_offset] to
+        /// [dst_base + dst_offset], never a byte more, so it is safe for
+        /// buffers whose exact extent someone else owns (heap allocations,
+        /// caller-owned result storage). Any codegen that writes through a
+        /// pointer it did not size itself must use this instead of a
+        /// word-rounded copy loop. Sizes above 8 that are not word multiples
+        /// finish with an 8-byte copy of the final `size - 8` tail, which
+        /// re-copies up to 7 earlier bytes; source and destination therefore
+        /// must not overlap.
         fn copyChunked(self: *Self, temp_reg: GeneralReg, src_base: GeneralReg, src_offset: i32, dst_base: GeneralReg, dst_offset: i32, size: u32) Allocator.Error!void {
             std.debug.assert(size > 0);
             if (size == 8) {
@@ -22172,17 +22169,49 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const runtime_ret_layout = self.runtimeRepresentationLayoutIdx(ret_layout);
             const layout_val = ls.getLayout(runtime_ret_layout);
             const ret_size = ls.layoutSizeAlign(layout_val).size;
+            if (ret_size == 0) return;
 
-            // Ensure result is on stack
+            // The return buffer is caller-owned storage of exactly ret_size
+            // bytes. Erased-callable and hosted results land in buffers sized
+            // by compiled Zig code (e.g. a comparator's `var ordering: u8`),
+            // so writing even one byte past ret_size corrupts the caller's
+            // frame.
+            const ptr_reg: GeneralReg = scratch_reg;
+            const temp_reg: GeneralReg = if (comptime target.toCpuArch() == .aarch64) .X10 else .RAX;
+
+            // Register and immediate scalars store their exact width straight
+            // through the return pointer instead of bouncing through a spill
+            // slot; every other location spills to stack and copies from
+            // there.
             const result_offset: i32 = switch (result_loc) {
                 .stack => |s| s.offset,
                 .list_stack => |info| info.struct_offset,
                 .stack_str => |off| off,
                 .stack_i128 => |off| off,
-                .general_reg,
+                .general_reg => |reg| switch (ret_size) {
+                    1, 2, 4, 8 => {
+                        // On aarch64 the register allocator can hand out the
+                        // scratch register, so the result may already be in
+                        // ptr_reg; address through temp_reg in that case.
+                        const addr_reg: GeneralReg = if (reg == ptr_reg) temp_reg else ptr_reg;
+                        try self.emitLoad(.w64, addr_reg, frame_ptr, ret_ptr_stack_slot);
+                        try self.emitStoreScalarToPtr(addr_reg, reg, ret_size);
+                        self.codegen.freeGeneral(reg);
+                        return;
+                    },
+                    else => try self.ensureOnStack(result_loc, ret_size),
+                },
+                .immediate_i64 => |val| switch (ret_size) {
+                    1, 2, 4, 8 => {
+                        try self.emitLoad(.w64, ptr_reg, frame_ptr, ret_ptr_stack_slot);
+                        try self.codegen.emitLoadImm(temp_reg, val);
+                        try self.emitStoreScalarToPtr(ptr_reg, temp_reg, ret_size);
+                        return;
+                    },
+                    else => try self.ensureOnStack(result_loc, ret_size),
+                },
                 .float_reg,
                 .vector_reg,
-                .immediate_i64,
                 .immediate_f32,
                 .immediate_f64,
                 .immediate_i128,
@@ -22191,18 +22220,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             };
 
             // Load the return pointer from the saved stack slot
-            const ptr_reg: GeneralReg = scratch_reg;
             try self.emitLoad(.w64, ptr_reg, frame_ptr, ret_ptr_stack_slot);
-
-            // The return buffer is caller-owned storage of exactly ret_size
-            // bytes. Erased-callable and hosted results land in buffers sized
-            // by compiled Zig code (e.g. a comparator's `var ordering: u8`),
-            // so writing even one byte past ret_size corrupts the caller's
-            // frame. copyChunked copies the exact byte count.
-            const temp_reg: GeneralReg = if (comptime target.toCpuArch() == .aarch64) .X10 else .RAX;
-            if (ret_size > 0) {
-                try self.copyChunked(temp_reg, frame_ptr, result_offset, ptr_reg, 0, ret_size);
-            }
+            try self.copyChunked(temp_reg, frame_ptr, result_offset, ptr_reg, 0, ret_size);
         }
 
         fn copyValueToPointer(self: *Self, value_loc: ValueLocation, value_layout: layout.Idx, ptr_local: LocalId) Allocator.Error!void {

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -22194,13 +22194,14 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const ptr_reg: GeneralReg = scratch_reg;
             try self.emitLoad(.w64, ptr_reg, frame_ptr, ret_ptr_stack_slot);
 
-            // Copy data in 8-byte chunks from local stack to return buffer
+            // The return buffer is caller-owned storage of exactly ret_size
+            // bytes. Erased-callable and hosted results land in buffers sized
+            // by compiled Zig code (e.g. a comparator's `var ordering: u8`),
+            // so writing even one byte past ret_size corrupts the caller's
+            // frame. copyChunked copies the exact byte count.
             const temp_reg: GeneralReg = if (comptime target.toCpuArch() == .aarch64) .X10 else .RAX;
-            const num_words = (ret_size + 7) / 8;
-            for (0..num_words) |w| {
-                const off: i32 = @intCast(w * 8);
-                try self.emitLoad(.w64, temp_reg, frame_ptr, result_offset + off);
-                try self.emitStore(.w64, ptr_reg, off, temp_reg);
+            if (ret_size > 0) {
+                try self.copyChunked(temp_reg, frame_ptr, result_offset, ptr_reg, 0, ret_size);
             }
         }
 

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -1539,12 +1539,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// - Second arg (RSI/X1) contains the pointer to RocOps
         /// - The function writes the result to the result buffer and returns
         ///
-        /// For tuples, pass tuple_len > 1 to copy all elements to the result buffer.
         pub fn generateCode(
             self: *Self,
             root_proc_id: lir.LIR.LirProcSpecId,
             result_layout: layout.Idx,
-            tuple_len: usize,
         ) Allocator.Error!CodeResult {
             // Clear any leftover state from compileAllProcSpecs
             self.clearLocalLocationsRetainingCapacity();
@@ -1628,7 +1626,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             if (final_result != .noreturn) {
                 const ret_size = self.getLayoutSize(actual_ret_layout);
                 if (ret_size > 0) {
-                    try self.storeResultToSavedPtr(final_result, actual_ret_layout, result_ptr_save_reg, tuple_len);
+                    try self.storeResultToSavedPtr(final_result, actual_ret_layout, result_ptr_save_reg);
                 }
             }
 
@@ -15883,13 +15881,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 if (inner_layout.tag == .tag_union) {
                     const box_ptr_reg = try self.ensureInGeneralReg(raw_value_loc);
                     const dest_offset = self.codegen.allocStackSlot(payload_size);
-                    // The box allocation holds exactly payload_size bytes, so a
-                    // word-rounded copy would read past the heap allocation.
-                    if (payload_size > 0) {
-                        const temp_reg = try self.allocTempGeneral();
-                        try self.copyChunked(temp_reg, box_ptr_reg, 0, frame_ptr, dest_offset, payload_size);
-                        self.codegen.freeGeneral(temp_reg);
-                    }
+                    // The box allocation holds the inner tag union layout's
+                    // size, which can be smaller than a word-rounded payload
+                    // copy, so the copy must read exactly payload_size bytes.
+                    const temp_reg = try self.allocTempGeneral();
+                    try self.copyChunked(temp_reg, box_ptr_reg, 0, frame_ptr, dest_offset, payload_size);
+                    self.codegen.freeGeneral(temp_reg);
                     self.codegen.freeGeneral(box_ptr_reg);
                     const raw_payload_loc = self.fieldLocationFromLayout(dest_offset, payload_size, payload_layout_idx);
                     return self.requireExactValueLocationToLayout(raw_payload_loc, payload_layout_idx, tps.target_layout, "tag_payload_struct_access.boxed");
@@ -19125,59 +19122,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         /// Store the result to the output buffer pointed to by a saved register
         /// This is used when the original result pointer (X0/RDI) may have been clobbered
-        fn storeResultToSavedPtr(self: *Self, loc: ValueLocation, result_layout: layout.Idx, saved_ptr_reg: GeneralReg, tuple_len: usize) Allocator.Error!void {
-            // Handle tuples specially - copy all elements from stack to result buffer
-            if (tuple_len > 1) {
-                switch (loc) {
-                    .stack => |s| {
-                        const base_offset = s.offset;
-                        // Use layout store for accurate element offsets and sizes
-                        {
-                            const ls = self.layout_store;
-                            const tuple_layout = ls.getLayout(result_layout);
-                            if (tuple_layout.tag == .struct_) {
-                                const tuple_data = ls.getStructData(tuple_layout.getStruct().idx);
-                                const total_size = tuple_data.size.get(ls.targetUsize());
-
-                                // The result buffer holds exactly total_size
-                                // bytes of caller-owned storage, so the copy
-                                // must not round up to whole words.
-                                if (total_size > 0) {
-                                    const temp_reg = try self.allocTempGeneral();
-                                    try self.copyChunked(temp_reg, frame_ptr, base_offset, saved_ptr_reg, 0, total_size);
-                                    self.codegen.freeGeneral(temp_reg);
-                                }
-                                return;
-                            }
-                        }
-
-                        // Non-struct tuple layouts still copy exactly the
-                        // layout's byte count into the caller-owned buffer.
-                        const total_size = self.getLayoutSize(result_layout);
-                        if (total_size > 0) {
-                            const temp_reg = try self.allocTempGeneral();
-                            try self.copyChunked(temp_reg, frame_ptr, base_offset, saved_ptr_reg, 0, total_size);
-                            self.codegen.freeGeneral(temp_reg);
-                        }
-                        return;
-                    },
-                    .general_reg,
-                    .float_reg,
-                    .vector_reg,
-                    .stack_i128,
-                    .stack_str,
-                    .list_stack,
-                    .immediate_i64,
-                    .immediate_f32,
-                    .immediate_f64,
-                    .immediate_i128,
-                    .noreturn,
-                    => {
-                        // Fallback - just store the single value
-                    },
-                }
-            }
-
+        fn storeResultToSavedPtr(self: *Self, loc: ValueLocation, result_layout: layout.Idx, saved_ptr_reg: GeneralReg) Allocator.Error!void {
             switch (result_layout) {
                 .i64, .u64 => {
                     const reg = try self.ensureInGeneralReg(loc);
@@ -20003,36 +19948,41 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// buffers whose exact extent someone else owns (heap allocations,
         /// caller-owned result storage). Any codegen that writes through a
         /// pointer it did not size itself must use this instead of a
-        /// word-rounded copy loop. Sizes above 8 that are not word multiples
-        /// finish with an 8-byte copy of the final `size - 8` tail, which
-        /// re-copies up to 7 earlier bytes; source and destination therefore
-        /// must not overlap.
+        /// word-rounded copy loop. Sizes that are not chunk multiples finish
+        /// with an overlapping copy of the tail, which re-copies earlier
+        /// bytes; source and destination therefore must not overlap.
         fn copyChunked(self: *Self, temp_reg: GeneralReg, src_base: GeneralReg, src_offset: i32, dst_base: GeneralReg, dst_offset: i32, size: u32) Allocator.Error!void {
-            std.debug.assert(size > 0);
+            if (size == 0) return;
             if (size == 8) {
                 try self.emitLoad(.w64, temp_reg, src_base, src_offset);
                 try self.emitStore(.w64, dst_base, dst_offset, temp_reg);
                 return;
             }
             if (size < 8) {
-                var remaining = size;
-                var off: i32 = 0;
-                if (remaining >= 4) {
-                    try self.emitLoad(.w32, temp_reg, src_base, src_offset + off);
-                    try self.emitStore(.w32, dst_base, dst_offset + off, temp_reg);
-                    remaining -= 4;
-                    off += 4;
+                // A leading chunk plus an overlapping tail chunk of the same
+                // width cover any sub-word size in at most two copies.
+                if (size >= 4) {
+                    const tail: i32 = @intCast(size - 4);
+                    try self.emitLoad(.w32, temp_reg, src_base, src_offset);
+                    try self.emitStore(.w32, dst_base, dst_offset, temp_reg);
+                    if (tail > 0) {
+                        try self.emitLoad(.w32, temp_reg, src_base, src_offset + tail);
+                        try self.emitStore(.w32, dst_base, dst_offset + tail, temp_reg);
+                    }
+                    return;
                 }
-                if (remaining >= 2) {
-                    try self.emitLoadW16(temp_reg, src_base, src_offset + off);
-                    try self.emitStoreW16(dst_base, dst_offset + off, temp_reg);
-                    remaining -= 2;
-                    off += 2;
+                if (size >= 2) {
+                    const tail: i32 = @intCast(size - 2);
+                    try self.emitLoadW16(temp_reg, src_base, src_offset);
+                    try self.emitStoreW16(dst_base, dst_offset, temp_reg);
+                    if (tail > 0) {
+                        try self.emitLoadW16(temp_reg, src_base, src_offset + tail);
+                        try self.emitStoreW16(dst_base, dst_offset + tail, temp_reg);
+                    }
+                    return;
                 }
-                if (remaining >= 1) {
-                    try self.emitLoadW8(temp_reg, src_base, src_offset + off);
-                    try self.emitStoreW8(dst_base, dst_offset + off, temp_reg);
-                }
+                try self.emitLoadW8(temp_reg, src_base, src_offset);
+                try self.emitStoreW8(dst_base, dst_offset, temp_reg);
                 return;
             }
 
@@ -22190,16 +22140,26 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .stack_i128 => |off| off,
                 .general_reg => |reg| switch (ret_size) {
                     1, 2, 4, 8 => {
-                        // On aarch64 the register allocator can hand out the
-                        // scratch register, so the result may already be in
-                        // ptr_reg; address through temp_reg in that case.
-                        const addr_reg: GeneralReg = if (reg == ptr_reg) temp_reg else ptr_reg;
-                        try self.emitLoad(.w64, addr_reg, frame_ptr, ret_ptr_stack_slot);
-                        try self.emitStoreScalarToPtr(addr_reg, reg, ret_size);
+                        // The register allocator never hands out scratch_reg
+                        // (both x86_64 masks exclude R11 and the aarch64 mask
+                        // excludes X9), so the result value cannot alias
+                        // ptr_reg.
+                        try self.emitLoad(.w64, ptr_reg, frame_ptr, ret_ptr_stack_slot);
+                        try self.emitStoreScalarToPtr(ptr_reg, reg, ret_size);
                         self.codegen.freeGeneral(reg);
                         return;
                     },
-                    else => try self.ensureOnStack(result_loc, ret_size),
+                    else => blk: {
+                        // A general register holds at most 8 bytes; a wider
+                        // return value can never be materialized here.
+                        if (builtin.mode == .Debug and ret_size > 8) {
+                            std.debug.panic(
+                                "LIR/codegen invariant violated: general-register return value has size {d}",
+                                .{ret_size},
+                            );
+                        }
+                        break :blk try self.ensureOnStack(result_loc, ret_size);
+                    },
                 },
                 .immediate_i64 => |val| switch (ret_size) {
                     1, 2, 4, 8 => {
@@ -24399,7 +24359,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             if (self.getLayoutSize(proc_spec.ret_layout) > 0) {
                 const ret_ptr_reg = try self.allocTempGeneral();
                 try self.emitLoad(.w64, ret_ptr_reg, frame_ptr, ret_ptr_slot);
-                try self.storeResultToSavedPtr(result_loc, proc_spec.ret_layout, ret_ptr_reg, 1);
+                try self.storeResultToSavedPtr(result_loc, proc_spec.ret_layout, ret_ptr_reg);
                 self.codegen.freeGeneral(ret_ptr_reg);
             }
 
@@ -24929,7 +24889,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .none => {},
                 .indirect => {
                     if (self.getLayoutSize(ret_layout) > 0) {
-                        try self.storeResultToSavedPtr(result_loc, ret_layout, sret_reg, 1);
+                        try self.storeResultToSavedPtr(result_loc, ret_layout, sret_reg);
                     }
                     // Both SysV and Win64 require the sret pointer back in RAX.
                     if (comptime target.toCpuArch() == .x86_64) {
@@ -25069,7 +25029,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const arg_infos = try self.materializeEntrypointArgInfos(arg_layouts, args_ptr_reg);
             const result_loc = try self.callCompiledOffsetWithArgInfos(compiled, arg_infos, ret_layout, null);
             if (self.getLayoutSize(ret_layout) > 0) {
-                try self.storeResultToSavedPtr(result_loc, ret_layout, ret_ptr_reg, 1);
+                try self.storeResultToSavedPtr(result_loc, ret_layout, ret_ptr_reg);
             }
         }
 
@@ -25436,7 +25396,7 @@ fn compileRootWithFloatNanMode(
     defer codegen.deinit();
     try codegen.compileAllProcSpecs(store.getProcSpecs());
 
-    const result = try codegen.generateCode(root_proc, ret_layout, 1);
+    const result = try codegen.generateCode(root_proc, ret_layout);
     errdefer allocator.free(result.code);
     const unwind_functions = try allocator.dupe(coff.FunctionInfo, codegen.getUnwindFunctions());
     return .{

--- a/src/backend/dev/aarch64/Call.zig
+++ b/src/backend/dev/aarch64/Call.zig
@@ -126,7 +126,13 @@ pub const DEFAULT_FREE_FLOAT_REGS = [_]FloatReg{
 };
 
 /// Bitmask of caller-saved general registers (for fast allocation)
-/// X0-X15, IP0 (X16), IP1 (X17) - excludes X18 (platform register)
+/// X0-X8, X10-X15 - excludes X18 (platform register)
+/// Note: X9 is excluded because it is reserved as SCRATCH_REG for the
+/// calling convention (the code generator addresses through it while
+/// allocated values are live, e.g. when storing a result through a return
+/// pointer). Including it here would allow allocTempGeneral() to assign it,
+/// which gets clobbered whenever the emitter uses X9 as scratch. This
+/// mirrors the R11 exclusion in the x86_64 masks.
 pub const CALLER_SAVED_GENERAL_MASK: u32 =
     (1 << @intFromEnum(GeneralReg.X0)) |
     (1 << @intFromEnum(GeneralReg.X1)) |
@@ -137,7 +143,6 @@ pub const CALLER_SAVED_GENERAL_MASK: u32 =
     (1 << @intFromEnum(GeneralReg.X6)) |
     (1 << @intFromEnum(GeneralReg.X7)) |
     (1 << @intFromEnum(GeneralReg.XR)) |
-    (1 << @intFromEnum(GeneralReg.X9)) |
     (1 << @intFromEnum(GeneralReg.X10)) |
     (1 << @intFromEnum(GeneralReg.X11)) |
     (1 << @intFromEnum(GeneralReg.X12)) |

--- a/src/backend/mod.zig
+++ b/src/backend/mod.zig
@@ -231,6 +231,11 @@ test "issue 10993: erased callable ABI writes exactly ret_size bytes through the
     // `listSortWith` comparators return a 1-byte ordering into a
     // `var ordering: u8` stack slot, so any wider store smashes the caller's
     // frame and segfaults `List.sort` under the machine-code shim.
+    //
+    // The three return layouts cover every copy shape: a register-sized
+    // scalar (1 byte), a sub-word aggregate (3 bytes: 2-byte + 1-byte
+    // chunks), and a non-word-multiple aggregate above 8 bytes (12 bytes:
+    // one whole word plus an overlapping 8-byte tail).
     const std = @import("std");
     const layout = @import("layout");
     const lir = @import("lir");
@@ -242,54 +247,149 @@ test "issue 10993: erased callable ABI writes exactly ret_size bytes through the
     var layout_store = try layout.Store.init(allocator, .u64);
     defer layout_store.deinit();
 
-    const capture_arg = try store.addLocal(.{ .layout_idx = .opaque_ptr });
-    const reuse_arg = try store.addLocal(.{ .layout_idx = .opaque_ptr });
-    const args = try store.addLocalSpan(&.{ capture_arg, reuse_arg });
-    const arg_plan = try store.internErasedCallArgsPlan(&layout_store, &.{});
+    const helpers = struct {
+        fn addErasedProc(
+            s: *lir.LirStore,
+            ls: *layout.Store,
+            body: lir.CFStmtId,
+            ret_layout: layout.Idx,
+        ) std.mem.Allocator.Error!lir.LIR.LirProcSpecId {
+            const capture_arg = try s.addLocal(.{ .layout_idx = .opaque_ptr });
+            const reuse_arg = try s.addLocal(.{ .layout_idx = .opaque_ptr });
+            const args = try s.addLocalSpan(&.{ capture_arg, reuse_arg });
+            const arg_plan = try s.internErasedCallArgsPlan(ls, &.{});
+            return s.addProcSpec(.{
+                .name = s.freshSyntheticSymbol(),
+                .args = args,
+                .body = body,
+                .ret_layout = ret_layout,
+                .abi = .erased_callable,
+                .erased_capture_arg = capture_arg,
+                .erased_reuse_arg = reuse_arg,
+                .erased_call_args = arg_plan,
+            });
+        }
 
-    const result = try store.addLocal(.{ .layout_idx = .u8 });
-    const ret = try store.addCFStmt(.{ .ret = .{ .value = result } });
-    const assign = try store.addCFStmt(.{ .assign_literal = .{
-        .target = result,
+        fn addStructBody(
+            s: *lir.LirStore,
+            struct_layout: layout.Idx,
+            field_layout: layout.Idx,
+            field_values: []const i64,
+        ) std.mem.Allocator.Error!lir.CFStmtId {
+            var field_locals: [3]lir.LIR.LocalId = undefined;
+            for (field_values, 0..) |_, i| {
+                field_locals[i] = try s.addLocal(.{ .layout_idx = field_layout });
+            }
+            const result = try s.addLocal(.{ .layout_idx = struct_layout });
+            const ret = try s.addCFStmt(.{ .ret = .{ .value = result } });
+            const fields = try s.addLocalSpan(field_locals[0..field_values.len]);
+            var body = try s.addCFStmt(.{ .assign_struct = .{
+                .target = result,
+                .fields = fields,
+                .next = ret,
+            } });
+            for (field_values, 0..) |value, i| {
+                body = try s.addCFStmt(.{ .assign_literal = .{
+                    .target = field_locals[i],
+                    .value = .{ .i64_literal = .{ .value = value, .layout_idx = field_layout } },
+                    .next = body,
+                } });
+            }
+            return body;
+        }
+
+        fn abort(_: *builtins.host_abi.RocOps, _: [*]const u8, _: usize) callconv(.c) void {
+            @panic("erased callable ret-size test must not reach RocOps");
+        }
+        fn abortAlloc(_: *builtins.host_abi.RocOps, _: usize, _: usize) callconv(.c) ?*anyopaque {
+            @panic("erased callable ret-size test must not allocate");
+        }
+        fn abortDealloc(_: *builtins.host_abi.RocOps, _: *anyopaque, _: usize) callconv(.c) void {
+            @panic("erased callable ret-size test must not deallocate");
+        }
+        fn abortRealloc(_: *builtins.host_abi.RocOps, _: *anyopaque, _: usize, _: usize) callconv(.c) ?*anyopaque {
+            @panic("erased callable ret-size test must not reallocate");
+        }
+    };
+
+    // u8 scalar returning 2 (an Ordering-sized result, the List.sort shape).
+    const scalar_result = try store.addLocal(.{ .layout_idx = .u8 });
+    const scalar_ret = try store.addCFStmt(.{ .ret = .{ .value = scalar_result } });
+    const scalar_body = try store.addCFStmt(.{ .assign_literal = .{
+        .target = scalar_result,
         .value = .{ .i64_literal = .{ .value = 2, .layout_idx = .u8 } },
-        .next = ret,
+        .next = scalar_ret,
     } });
+    const scalar_proc = try helpers.addErasedProc(&store, &layout_store, scalar_body, .u8);
 
-    const proc_id = try store.addProcSpec(.{
-        .name = store.freshSyntheticSymbol(),
-        .args = args,
-        .body = assign,
-        .ret_layout = .u8,
-        .abi = .erased_callable,
-        .erased_capture_arg = capture_arg,
-        .erased_reuse_arg = reuse_arg,
-        .erased_call_args = arg_plan,
+    const u8x3_layout = try layout_store.putStructFields(&.{
+        .{ .index = 0, .layout = .u8 },
+        .{ .index = 1, .layout = .u8 },
+        .{ .index = 2, .layout = .u8 },
     });
+    const u8x3_body = try helpers.addStructBody(&store, u8x3_layout, .u8, &.{ 0x11, 0x22, 0x33 });
+    const u8x3_proc = try helpers.addErasedProc(&store, &layout_store, u8x3_body, u8x3_layout);
+
+    const u32x3_layout = try layout_store.putStructFields(&.{
+        .{ .index = 0, .layout = .u32 },
+        .{ .index = 1, .layout = .u32 },
+        .{ .index = 2, .layout = .u32 },
+    });
+    const u32x3_body = try helpers.addStructBody(&store, u32x3_layout, .u32, &.{ 0x01020304, 0x05060708, 0x090A0B0C });
+    const u32x3_proc = try helpers.addErasedProc(&store, &layout_store, u32x3_body, u32x3_layout);
 
     var codegen = try dev.HostLirCodeGen.init(allocator, &store, &layout_store, &.{}, .preserve, roc_target.host_cpu.level());
     defer codegen.deinit();
     try codegen.compileAllProcSpecs(store.getProcSpecs());
 
-    const compiled = codegen.proc_registry.get(@intFromEnum(proc_id)) orelse return error.TestUnexpectedResult;
+    // This test jumps straight into the shared code buffer, so it can only
+    // execute code with no unapplied relocations. If the erased-callable
+    // prologue ever grows a relocation-backed call, resolve the relocations
+    // here instead of deleting this check.
+    try std.testing.expectEqual(@as(usize, 0), codegen.codegen.relocations.items.len);
+
     var executable = try dev.ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
         codegen.codegen.getCode(),
-        compiled.code_start,
+        0,
         codegen.getUnwindFunctions(),
     );
     defer executable.deinit();
 
-    // Sentinel bytes on both sides of the 1-byte result slot; the callee owns
-    // only ret_buf[4].
-    var ret_buf align(16) = [_]u8{0xAA} ** 16;
-    var out_desc: ?*const anyopaque = null;
-    var dummy_roc_ops: builtins.erased_callable.RocOps = undefined;
-    const callable: builtins.erased_callable.ErasedCallableFn = @ptrCast(@alignCast(executable.entryPtr()));
-    callable(&dummy_roc_ops, ret_buf[4..].ptr, null, null, null, &out_desc);
+    var roc_ops = builtins.host_abi.RocOps{
+        .env = undefined,
+        .roc_alloc = &helpers.abortAlloc,
+        .roc_dealloc = &helpers.abortDealloc,
+        .roc_realloc = &helpers.abortRealloc,
+        .roc_dbg = &helpers.abort,
+        .roc_expect_failed = &helpers.abort,
+        .roc_crashed = &helpers.abort,
+        .hosted_fns = builtins.host_abi.emptyHostedFunctions(),
+    };
 
-    try std.testing.expectEqual(@as(u8, 2), ret_buf[4]);
-    for (ret_buf, 0..) |byte, i| {
-        if (i == 4) continue;
-        try std.testing.expectEqual(@as(u8, 0xAA), byte);
+    const cases = [_]struct {
+        proc_id: lir.LIR.LirProcSpecId,
+        expected: []const u8,
+    }{
+        .{ .proc_id = scalar_proc, .expected = &.{2} },
+        .{ .proc_id = u8x3_proc, .expected = &.{ 0x11, 0x22, 0x33 } },
+        .{ .proc_id = u32x3_proc, .expected = &.{ 0x04, 0x03, 0x02, 0x01, 0x08, 0x07, 0x06, 0x05, 0x0C, 0x0B, 0x0A, 0x09 } },
+    };
+
+    for (cases) |case| {
+        const compiled = codegen.proc_registry.get(@intFromEnum(case.proc_id)) orelse return error.TestUnexpectedResult;
+        const callable: builtins.erased_callable.ErasedCallableFn = @ptrCast(@alignCast(executable.codePtr() + compiled.code_start));
+
+        // Sentinel bytes on both sides of the result slot; the callee owns
+        // only ret_buf[8 .. 8 + expected.len].
+        var ret_buf align(16) = [_]u8{0xAA} ** 32;
+        var out_desc: ?*const anyopaque = null;
+        callable(&roc_ops, ret_buf[8..].ptr, null, null, null, &out_desc);
+
+        try std.testing.expectEqualSlices(u8, case.expected, ret_buf[8 .. 8 + case.expected.len]);
+        for (ret_buf, 0..) |byte, i| {
+            if (i >= 8 and i < 8 + case.expected.len) continue;
+            try std.testing.expectEqual(@as(u8, 0xAA), byte);
+        }
     }
 }
 

--- a/src/backend/mod.zig
+++ b/src/backend/mod.zig
@@ -219,6 +219,80 @@ test "issue 10295: nested list equality has bounded register pressure" {
     try std.testing.expectEqual(@as(u8, 1), actual);
 }
 
+test "issue 10993: erased callable ABI writes exactly ret_size bytes through the return pointer" {
+    if (comptime !dev.host_lir_codegen_available) return error.SkipZigTest;
+
+    // https://github.com/roc-lang/roc/issues/10993
+    //
+    // The uniform erased-callable ABI hands the callee a pointer to
+    // caller-owned result storage of exactly the return layout's size (see
+    // builtins/erased_callable.zig). A callee that stores past that size
+    // corrupts whatever the caller keeps next to the result slot:
+    // `listSortWith` comparators return a 1-byte ordering into a
+    // `var ordering: u8` stack slot, so any wider store smashes the caller's
+    // frame and segfaults `List.sort` under the machine-code shim.
+    const std = @import("std");
+    const layout = @import("layout");
+    const lir = @import("lir");
+    const builtins = @import("builtins");
+
+    const allocator = std.testing.allocator;
+    var store = lir.LirStore.init(allocator);
+    defer store.deinit();
+    var layout_store = try layout.Store.init(allocator, .u64);
+    defer layout_store.deinit();
+
+    const capture_arg = try store.addLocal(.{ .layout_idx = .opaque_ptr });
+    const reuse_arg = try store.addLocal(.{ .layout_idx = .opaque_ptr });
+    const args = try store.addLocalSpan(&.{ capture_arg, reuse_arg });
+    const arg_plan = try store.internErasedCallArgsPlan(&layout_store, &.{});
+
+    const result = try store.addLocal(.{ .layout_idx = .u8 });
+    const ret = try store.addCFStmt(.{ .ret = .{ .value = result } });
+    const assign = try store.addCFStmt(.{ .assign_literal = .{
+        .target = result,
+        .value = .{ .i64_literal = .{ .value = 2, .layout_idx = .u8 } },
+        .next = ret,
+    } });
+
+    const proc_id = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = args,
+        .body = assign,
+        .ret_layout = .u8,
+        .abi = .erased_callable,
+        .erased_capture_arg = capture_arg,
+        .erased_reuse_arg = reuse_arg,
+        .erased_call_args = arg_plan,
+    });
+
+    var codegen = try dev.HostLirCodeGen.init(allocator, &store, &layout_store, &.{}, .preserve, roc_target.host_cpu.level());
+    defer codegen.deinit();
+    try codegen.compileAllProcSpecs(store.getProcSpecs());
+
+    const compiled = codegen.proc_registry.get(@intFromEnum(proc_id)) orelse return error.TestUnexpectedResult;
+    var executable = try dev.ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
+        codegen.codegen.getCode(),
+        compiled.code_start,
+        codegen.getUnwindFunctions(),
+    );
+    defer executable.deinit();
+
+    // Sentinel bytes on both sides of the 1-byte result slot; the callee owns
+    // only ret_buf[4].
+    var ret_buf align(16) = [_]u8{0xAA} ** 16;
+    var out_desc: ?*const anyopaque = null;
+    var dummy_roc_ops: builtins.erased_callable.RocOps = undefined;
+    const callable: builtins.erased_callable.ErasedCallableFn = @ptrCast(@alignCast(executable.entryPtr()));
+    callable(&dummy_roc_ops, ret_buf[4..].ptr, null, null, null, &out_desc);
+
+    try std.testing.expectEqual(@as(u8, 2), ret_buf[4]);
+    for (ret_buf, 0..) |byte, i| {
+        if (i == 4) continue;
+        try std.testing.expectEqual(@as(u8, 0xAA), byte);
+    }
+}
+
 test "x86_64 Windows hosted U128 return stores all 16 bytes from XMM0" {
     const std = @import("std");
     const layout = @import("layout");

--- a/src/backend/mod.zig
+++ b/src/backend/mod.zig
@@ -131,7 +131,7 @@ test "issue 10295: dev backend preserves deep structural equality under register
     var codegen = try dev.HostLirCodeGen.init(allocator, &store, &layout_store, &.{}, .preserve, roc_target.host_cpu.level());
     defer codegen.deinit();
     try codegen.compileAllProcSpecs(store.getProcSpecs());
-    const generated = try codegen.generateCode(root, .bool, 1);
+    const generated = try codegen.generateCode(root, .bool);
     defer allocator.free(generated.code);
 
     var executable = try dev.ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
@@ -202,7 +202,7 @@ test "issue 10295: nested list equality has bounded register pressure" {
     var codegen = try dev.HostLirCodeGen.init(allocator, &store, &layout_store, &.{}, .preserve, roc_target.host_cpu.level());
     defer codegen.deinit();
     try codegen.compileAllProcSpecs(store.getProcSpecs());
-    const generated = try codegen.generateCode(root, .bool, 1);
+    const generated = try codegen.generateCode(root, .bool);
     defer allocator.free(generated.code);
 
     var executable = try dev.ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
@@ -232,10 +232,10 @@ test "issue 10993: erased callable ABI writes exactly ret_size bytes through the
     // `var ordering: u8` stack slot, so any wider store smashes the caller's
     // frame and segfaults `List.sort` under the machine-code shim.
     //
-    // The three return layouts cover every copy shape: a register-sized
-    // scalar (1 byte), a sub-word aggregate (3 bytes: 2-byte + 1-byte
-    // chunks), and a non-word-multiple aggregate above 8 bytes (12 bytes:
-    // one whole word plus an overlapping 8-byte tail).
+    // The four return layouts cover every copy shape: a register-sized
+    // scalar (1 byte), sub-word aggregates with and without an overlapping
+    // tail chunk (3 and 7 bytes), and a non-word-multiple aggregate above
+    // 8 bytes (12 bytes: one whole word plus an overlapping 8-byte tail).
     const std = @import("std");
     const layout = @import("layout");
     const lir = @import("lir");
@@ -276,7 +276,7 @@ test "issue 10993: erased callable ABI writes exactly ret_size bytes through the
             field_layout: layout.Idx,
             field_values: []const i64,
         ) std.mem.Allocator.Error!lir.CFStmtId {
-            var field_locals: [3]lir.LIR.LocalId = undefined;
+            var field_locals: [7]lir.LIR.LocalId = undefined;
             for (field_values, 0..) |_, i| {
                 field_locals[i] = try s.addLocal(.{ .layout_idx = field_layout });
             }
@@ -330,6 +330,18 @@ test "issue 10993: erased callable ABI writes exactly ret_size bytes through the
     const u8x3_body = try helpers.addStructBody(&store, u8x3_layout, .u8, &.{ 0x11, 0x22, 0x33 });
     const u8x3_proc = try helpers.addErasedProc(&store, &layout_store, u8x3_body, u8x3_layout);
 
+    const u8x7_layout = try layout_store.putStructFields(&.{
+        .{ .index = 0, .layout = .u8 },
+        .{ .index = 1, .layout = .u8 },
+        .{ .index = 2, .layout = .u8 },
+        .{ .index = 3, .layout = .u8 },
+        .{ .index = 4, .layout = .u8 },
+        .{ .index = 5, .layout = .u8 },
+        .{ .index = 6, .layout = .u8 },
+    });
+    const u8x7_body = try helpers.addStructBody(&store, u8x7_layout, .u8, &.{ 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47 });
+    const u8x7_proc = try helpers.addErasedProc(&store, &layout_store, u8x7_body, u8x7_layout);
+
     const u32x3_layout = try layout_store.putStructFields(&.{
         .{ .index = 0, .layout = .u32 },
         .{ .index = 1, .layout = .u32 },
@@ -372,6 +384,7 @@ test "issue 10993: erased callable ABI writes exactly ret_size bytes through the
     }{
         .{ .proc_id = scalar_proc, .expected = &.{2} },
         .{ .proc_id = u8x3_proc, .expected = &.{ 0x11, 0x22, 0x33 } },
+        .{ .proc_id = u8x7_proc, .expected = &.{ 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47 } },
         .{ .proc_id = u32x3_proc, .expected = &.{ 0x04, 0x03, 0x02, 0x01, 0x08, 0x07, 0x06, 0x05, 0x0C, 0x0B, 0x0A, 0x09 } },
     };
 


### PR DESCRIPTION
Fixes #10993. `roc test` (and the REPL) segfaulted on any `List.sort` call on x86_64 Linux with release builds of the compiler, while Debug builds and arm64 appeared fine. The cause was in the dev backend's `copyResultToReturnPointer`, which copied a proc's return value through the caller's result pointer in whole 8-byte words, rounding the write up to a multiple of 8. Callers inside dev-generated code never noticed because their stack slots are rounded up too, but the erased-callable ABI hands in exactly-sized buffers owned by compiled Zig code: a sort comparator returns its 1-byte ordering into a `var ordering: u8`, so the generated code wrote 8 bytes into a 1-byte slot and wiped 7 bytes of the caller's frame. In release builds of the compiler those bytes hold the sort's spilled element pointers, which produced the segfault; Debug frames happened to have padding there, which is why the crash only showed up in nightlies.

This makes every write into a buffer the generated code did not size itself copy exactly the layout's byte count: the return-pointer path and the boxed tag-union payload copy (which word-rounded a read past the heap allocation). Register-sized scalar returns now store their exact width directly through the return pointer instead of bouncing through a spill slot, since the sort comparator hits that path once per comparison. Review of the surrounding code also surfaced two related latent hazards that this fixes: aarch64's register allocator could hand out X9 even though the emitters use it as the address scratch register (x86_64 already excludes R11 from its allocatable mask for exactly this reason), and `generateCode`'s `tuple_len > 1` result-store branch was dead in-tree while still word-rounding its writes, so it is deleted. A regression test runs generated erased callables for 1-, 3-, 7-, and 12-byte return layouts against sentinel-guarded, exactly-sized result buffers.
