### PR TITLE
Add RC conformance coverage for List.sort_with

### DIFF
--- a/src/eval/test/rc_conformance_tests.zig
+++ b/src/eval/test/rc_conformance_tests.zig
@@ -240,6 +240,30 @@ const cases = [_]Case{
         ,
     },
     .{
+        .name = "list sort copy-on-write, unique and shared inputs",
+        .source =
+        \\{
+        \\    shared = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    holder = [shared, shared]
+        \\    unique_sorted = List.sort_with(
+        \\        List.concat(
+        \\            ["a list element long enough to allocate", "another list element long enough"],
+        \\            ["a fourth list element long enough to allocate"],
+        \\        ),
+        \\        |a, b| a.count_utf8_bytes().order_relative_to(b.count_utf8_bytes()),
+        \\    )
+        \\    shared_sorted = List.sort_with(
+        \\        shared,
+        \\        |a, b| a.count_utf8_bytes().order_relative_to(b.count_utf8_bytes()),
+        \\    )
+        \\    List.len(unique_sorted) + List.len(shared_sorted) + List.len(holder)
+        \\}
+        ,
+    },
+    .{
         .name = "list element ops move ownership in and out",
         .source =
         \\{


### PR DESCRIPTION
## Summary
- exercise `list_sort_with` in the RC-effect conformance sweep
- cover both unique and shared list inputs so both copy-on-write paths are verified

Fixes the failure in nightly run https://github.com/roc-lang/roc/actions/runs/33294793235.

## Validation
- `zig build run-test-zig -- --test-filter "rc effect conformance"`
- `zig fmt --check src/eval/test/rc_conformance_tests.zig`
- `zig build run-check-snapshots`
- `zig build run-test-zig` (all 4,810 tests passed)