### PR TITLE
Add regression coverage for nested nominal digest caching

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -53,6 +53,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Repro for issue 10770: a nominal's phantom parameter survives a call boundary",
     },
     .{
+        .roc_file = "test/fx/issue_10843_nested_nominal_digest.roc",
+        .io_spec = "1>0",
+        .description = "Regression test: deeply nested parameterized nominals do not bypass the Monotype digest cache (issue #10843)",
+    },
+    .{
         .roc_file = "test/fx/subdir/app.roc",
         .io_spec = "1>Hello from stdout!|1>Line 1 to stdout|2>Line 2 to stderr|1>Line 3 to stdout|2>Error from stderr!",
         .description = "Relative paths starting with ..",

--- a/test/fx/issue_10843_nested_nominal_digest.roc
+++ b/test/fx/issue_10843_nested_nominal_digest.roc
@@ -1,0 +1,21 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+W(a) := [W(a)].{
+    mk : a -> W(a)
+    mk = |x| W(x)
+
+    get : W(a) -> a
+    get = |w| match w {
+        W(x) => x
+    }
+}
+
+peel : W(W(W(W(W(W(W(W(U64)))))))) -> U64
+peel = |v| W.get(W.get(W.get(W.get(W.get(W.get(W.get(W.get(v))))))))
+
+main! = || {
+    nested = W.mk(W.mk(W.mk(W.mk(W.mk(W.mk(W.mk(W.mk(0.U64))))))))
+    Stdout.line!(peel(nested).to_str())
+}


### PR DESCRIPTION
## Summary

- add the NEST=8 parameterized-nominal reproducer from #10843 to the fx suite
- verify its runtime result while keeping the pathological Monotype digest shape under CI coverage
- document that the cache-first `DigestEngine` merged in #10914 eliminated the original uncached `typeDigest` re-entry path

The original root cause was `cachedDigestInner -> openNamedCyclePosition -> namedIdentityMatches -> typeDigest`: cycle identity checking started a fresh uncached digest at every node before the outer cache lookup. Current `main` no longer has that split walk; `computeDigest` checks the cache first and its graph reducer visits each uncached `(TypeId, mode)` once, caching every settled node.

Closes #10843.

## Verification

- `zig build`
- exact reproducer: `roc build --no-cache test/fx/issue_10843_nested_nominal_digest.roc` (417ms compiler time, 0.74s wall, versus >200s in the issue)
- `zig build run-test-zig-fx-platform`
- `zig build minici`: 75/76 phases passed; the only failure is the unrelated existing #10999 pathless constraint-callable CLI test, reproduced independently with its exact filter
