### PR TITLE
Remove unused Monotype row parent tracking

### DIFF
--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -18989,7 +18989,7 @@ const BodyContext = struct {
             .numeral, .str_from_quote => {
                 const expr_node = try self.lowerExprTypeNode(expr_id);
                 if (!try self.graph.typeIsResolved(expr_node)) {
-                    try self.graph.materializeLiteralDefault(expr_node);
+                    self.graph.materializeLiteralDefault(expr_node);
                 }
                 const expr_ty = try self.resolvedTypeViewForNode(expr_node);
                 return try self.lowerExprWithType(expr_id, expr_ty);

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -2064,7 +2064,7 @@ pub const InstGraph = struct {
     /// instantiation node. Literal lowering calls this only when runtime demand
     /// reaches an unpinned literal leaf; custom specializations have already
     /// related the node to their concrete target before that point.
-    pub fn materializeLiteralDefault(self: *InstGraph, raw_node: NodeId) Allocator.Error!void {
+    pub fn materializeLiteralDefault(self: *InstGraph, raw_node: NodeId) void {
         self.requireRelationProduction();
         const node = self.find(raw_node);
         const node_content = self.nodes.items[@intFromEnum(node)];
@@ -6246,8 +6246,9 @@ test "issue 10941: row extension class unions remain linear" {
 
     // Repro for https://github.com/roc-lang/roc/issues/10941: re-rooting one
     // row-extension class must do work linear in the graph nodes and unions.
+    const row_count = 128;
     var extension = try graph.newNode(.empty_record);
-    for (0..128) |_| {
+    for (0..row_count) |_| {
         _ = try graph.newNode(.{ .record = .{
             .fields = &.{},
             .ext = extension,
@@ -6257,6 +6258,8 @@ test "issue 10941: row extension class unions remain linear" {
         extension = replacement;
     }
 
+    try std.testing.expectEqual(@as(u64, row_count * 2 + 1), diagnostics.nodes_created);
+    try std.testing.expectEqual(@as(u64, row_count), diagnostics.class_unions);
     const linear_work_limit = (diagnostics.nodes_created + diagnostics.class_unions) * 16;
     if (diagnostics.union_find_resolutions > linear_work_limit) {
         std.debug.print(

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -528,12 +528,6 @@ pub const InstGraph = struct {
     /// imported request use the exact finished TypeId rather than reconstructing
     /// an equivalent public shape.
     imported_monos: collections.DenseMap(NodeId, Type.TypeId),
-    /// Current extension root for each row root. This is the authority for
-    /// maintaining `row_parents`; stale extension edges are removed when row
-    /// content changes.
-    row_exts: std.ArrayList(?NodeId),
-    /// Row nodes by the extension node they currently chain through.
-    row_parents: collections.DenseMap(NodeId, std.ArrayList(NodeId)),
     /// Exact declaration-plus-current-argument-roots index for instantiated
     /// nominal backings. Keys point into the stable argument storage owned by
     /// `nominal_backing_instances`.
@@ -574,11 +568,6 @@ pub const InstGraph = struct {
     containment_visit_epochs: std.ArrayList(u32),
     containment_visit_epoch: u32,
     containment_cache: collections.DenseMap(NodeId, ContainmentCacheEntry),
-    /// Scratch epoch marks for `compactRowParents`, indexed by node id. A
-    /// slot carrying the current epoch means its class root is already kept
-    /// in the list being compacted.
-    row_parent_seen_epochs: std.ArrayList(u64),
-    row_parent_seen_epoch: u64,
     /// Pools for the visited sets the graph's walks create per query. Fresh
     /// maps re-allocate and re-zero sparse chunks across the node/type ID
     /// domains on every walk; pooled maps keep their chunks.
@@ -610,8 +599,6 @@ pub const InstGraph = struct {
             .active_snapshot_nodes = collections.DenseMap(Type.TypeId, NodeId).init(allocator),
             .imported_type_nodes = collections.DenseMap(Type.TypeId, NodeId).init(allocator),
             .imported_monos = collections.DenseMap(NodeId, Type.TypeId).init(allocator),
-            .row_exts = .empty,
-            .row_parents = collections.DenseMap(NodeId, std.ArrayList(NodeId)).init(allocator),
             .nominal_backing_index = std.HashMap(NominalBackingKey, NominalBackingInstanceId, NominalBackingKeyContext, 80).init(allocator),
             .nominal_backing_instances = .empty,
             .nominal_backings_by_root = collections.DenseMap(NodeId, std.ArrayList(NominalBackingOccurrence)).init(allocator),
@@ -627,8 +614,6 @@ pub const InstGraph = struct {
             .containment_visit_epochs = .empty,
             .containment_visit_epoch = 0,
             .containment_cache = collections.DenseMap(NodeId, ContainmentCacheEntry).init(allocator),
-            .row_parent_seen_epochs = .empty,
-            .row_parent_seen_epoch = 0,
             .node_set_pool = collections.DenseMapPool(NodeId, void).init(allocator),
             .type_set_pool = collections.DenseMapPool(Type.TypeId, void).init(allocator),
         };
@@ -659,10 +644,6 @@ pub const InstGraph = struct {
         }
         self.node_snapshots.deinit();
         self.current_snapshots.deinit();
-        var parents = self.row_parents.valueIterator();
-        while (parents.next()) |list| {
-            list.deinit(allocator);
-        }
         var backing_occurrences = self.nominal_backings_by_root.valueIterator();
         while (backing_occurrences.next()) |occurrences| {
             occurrences.deinit(allocator);
@@ -678,7 +659,6 @@ pub const InstGraph = struct {
         self.recursive_argument_slots.deinit(allocator);
         self.containment_pending.deinit(allocator);
         self.containment_visit_epochs.deinit(allocator);
-        self.row_parent_seen_epochs.deinit(allocator);
         self.node_set_pool.deinit();
         self.type_set_pool.deinit();
         var containment_entries = self.containment_cache.valueIterator();
@@ -686,8 +666,6 @@ pub const InstGraph = struct {
             entry.deinit(allocator);
         }
         self.containment_cache.deinit();
-        self.row_parents.deinit();
-        self.row_exts.deinit(allocator);
         self.imported_monos.deinit();
         self.active_snapshot_nodes.deinit();
         self.imported_type_nodes.deinit();
@@ -1109,7 +1087,7 @@ pub const InstGraph = struct {
                 }
                 named.def.iterator_representation = .minted;
                 named.def.iterator_depth = item.depth;
-                try self.setContent(node, .{ .named = named });
+                self.setContent(node, .{ .named = named });
             }
         }
     }
@@ -1143,7 +1121,7 @@ pub const InstGraph = struct {
         def.iterator_kind = .forced_dynamic;
         def.iterator_depth = 0;
         def.iterator_topology = topology;
-        try self.setContent(node, .{ .named = .{
+        self.setContent(node, .{ .named = .{
             .named_type = provenance.public_source.named_type,
             .def = def,
             .kind = provenance.public_source.kind,
@@ -1509,7 +1487,7 @@ pub const InstGraph = struct {
                 .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => Common.invariant("generated iterator identity target stopped being named"),
             };
             named.def.generated = item.digest;
-            try self.setContent(item.node, .{ .named = named });
+            self.setContent(item.node, .{ .named = named });
         }
     }
 
@@ -1705,9 +1683,7 @@ pub const InstGraph = struct {
         try self.class_member_head.append(self.allocator, id);
         try self.class_member_tail.append(self.allocator, id);
         try self.containment_visit_epochs.append(self.allocator, 0);
-        try self.row_exts.append(self.allocator, null);
         try self.request_source_interfaces.append(self.allocator, null);
-        try self.registerRowParent(id, node_content);
         self.countDiagnostic("nodes_created");
         return id;
     }
@@ -1721,7 +1697,7 @@ pub const InstGraph = struct {
         comptime fill: fn (@TypeOf(context), NodeId) Allocator.Error!InstNode,
     ) Allocator.Error!NodeId {
         const reserved = try self.newNode(.{ .unresolved = InstVariable.placeholder() });
-        try self.setContent(reserved, try fill(context, reserved));
+        self.setContent(reserved, try fill(context, reserved));
         return reserved;
     }
 
@@ -1912,114 +1888,6 @@ pub const InstGraph = struct {
         }
     }
 
-    fn registerRowParent(self: *InstGraph, row: NodeId, node_content: InstNode) Allocator.Error!void {
-        const row_root = self.find(row);
-        const maybe_ext = if (node_content == .tag_union)
-            node_content.tag_union.ext
-        else if (node_content == .record)
-            node_content.record.ext
-        else
-            null;
-        const ext = if (maybe_ext) |raw_ext| self.find(raw_ext) else {
-            try self.unregisterRowParent(row_root);
-            return;
-        };
-
-        const row_ext = &self.row_exts.items[@intFromEnum(row_root)];
-        if (row_ext.*) |old_ext| {
-            if (old_ext == ext) {
-                try self.addRowParent(ext, row_root);
-                return;
-            }
-            self.removeRowParent(old_ext, row_root);
-        }
-        row_ext.* = ext;
-        try self.addRowParent(ext, row_root);
-    }
-
-    fn unregisterRowParent(self: *InstGraph, row: NodeId) Allocator.Error!void {
-        const row_root = self.find(row);
-        const row_ext = &self.row_exts.items[@intFromEnum(row_root)];
-        if (row_ext.*) |old| {
-            row_ext.* = null;
-            self.removeRowParent(old, row_root);
-        }
-    }
-
-    /// Short parent lists de-duplicate exactly on insert; above this length
-    /// the insert-time scan (with a `find` per element) would make merging
-    /// two classes quadratic in their parent counts, so longer lists append
-    /// unconditionally and compact when they would otherwise grow.
-    const row_parent_exact_scan_max = 16;
-
-    fn addRowParent(self: *InstGraph, ext: NodeId, row: NodeId) Allocator.Error!void {
-        const entry = try self.row_parents.getOrPut(self.find(ext));
-        if (!entry.found_existing) entry.value_ptr.* = .empty;
-        const list = entry.value_ptr;
-        const row_root = self.find(row);
-        if (list.items.len <= row_parent_exact_scan_max) {
-            for (list.items) |existing| {
-                if (self.find(existing) == row_root) return;
-            }
-        } else if (list.items.len == list.capacity) {
-            // Duplicate class entries are tolerated by every reader (each
-            // resolves entries through `find`), so de-duplication can wait
-            // until the list is about to grow. Capacity doubles between
-            // compactions, keeping the total compaction work linear in the
-            // number of inserts.
-            try self.compactRowParents(list);
-            // Guarantee at least as many appends as surviving entries before
-            // the next compaction, so compaction cost amortizes to O(1) per
-            // insert even when it reclaims almost nothing.
-            try list.ensureUnusedCapacity(self.allocator, @max(list.items.len, row_parent_exact_scan_max));
-            for (list.items) |existing| {
-                if (existing == row_root) return;
-            }
-        }
-        try list.append(self.allocator, row_root);
-    }
-
-    /// Rewrite every entry to its current class root and drop duplicate
-    /// classes, preserving order of first occurrence.
-    fn compactRowParents(self: *InstGraph, list: *std.ArrayList(NodeId)) Allocator.Error!void {
-        const epochs_len = self.nodes.items.len;
-        if (self.row_parent_seen_epochs.items.len < epochs_len) {
-            const old_len = self.row_parent_seen_epochs.items.len;
-            try self.row_parent_seen_epochs.resize(self.allocator, epochs_len);
-            @memset(self.row_parent_seen_epochs.items[old_len..], 0);
-        }
-        self.row_parent_seen_epoch += 1;
-        const epoch = self.row_parent_seen_epoch;
-        var write: usize = 0;
-        for (list.items) |existing| {
-            const existing_root = self.find(existing);
-            const slot = &self.row_parent_seen_epochs.items[@intFromEnum(existing_root)];
-            if (slot.* == epoch) continue;
-            slot.* = epoch;
-            list.items[write] = existing_root;
-            write += 1;
-        }
-        list.shrinkRetainingCapacity(write);
-    }
-
-    fn removeRowParent(self: *InstGraph, ext: NodeId, row: NodeId) void {
-        const ext_root = self.find(ext);
-        const parents = self.row_parents.getPtr(ext_root) orelse return;
-        const row_root = self.find(row);
-        var index: usize = 0;
-        while (index < parents.items.len) {
-            if (self.find(parents.items[index]) == row_root) {
-                _ = parents.swapRemove(index);
-                continue;
-            }
-            index += 1;
-        }
-        if (parents.items.len == 0) {
-            var removed = self.row_parents.fetchRemove(ext_root).?;
-            removed.value.deinit(self.allocator);
-        }
-    }
-
     fn find(self: *InstGraph, id: NodeId) NodeId {
         self.countDiagnostic("union_find_resolutions");
         var current = id;
@@ -2206,7 +2074,7 @@ pub const InstGraph = struct {
             Common.invariant("unresolved literal leaf had no checked default phase");
         const target = checked.literal_defaulting.defaultTargetForPhase(phase) orelse
             Common.invariant("checking-finalized literal variable reached Monotype unresolved");
-        try self.setContent(node, switch (target) {
+        self.setContent(node, switch (target) {
             .dec => .{ .primitive = .dec },
             .str => .{ .primitive = .str },
         });
@@ -3029,7 +2897,7 @@ pub const InstGraph = struct {
 
         const args = try self.arena().alloc(NodeId, 1);
         args[0] = try self.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
-        try self.setContent(public_node, .{ .named = .{
+        self.setContent(public_node, .{ .named = .{
             .named_type = public_source.named_type,
             .def = public_source.def,
             .kind = public_source.kind,
@@ -3060,7 +2928,7 @@ pub const InstGraph = struct {
         }
 
         const args = try self.arena().dupe(NodeId, private_named.args);
-        try self.setContent(public_node, .{ .named = .{
+        self.setContent(public_node, .{ .named = .{
             .named_type = private_named.named_type,
             .def = private_named.def,
             .kind = private_named.kind,
@@ -3100,12 +2968,12 @@ pub const InstGraph = struct {
         switch (private_content) {
             .list => |private_elem| {
                 const elem = try self.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
-                try self.setContent(public_node, .{ .list = elem });
+                self.setContent(public_node, .{ .list = elem });
                 try self.relateOpaqueChild(elem, private_elem, row_width, pending);
             },
             .box => |private_elem| {
                 const elem = try self.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
-                try self.setContent(public_node, .{ .box = elem });
+                self.setContent(public_node, .{ .box = elem });
                 try self.relateOpaqueChild(elem, private_elem, row_width, pending);
             },
             .tuple => |private_items| {
@@ -3113,7 +2981,7 @@ pub const InstGraph = struct {
                 for (items) |*item| {
                     item.* = try self.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
                 }
-                try self.setContent(public_node, .{ .tuple = items });
+                self.setContent(public_node, .{ .tuple = items });
                 for (items, private_items) |item, private_item| {
                     try self.relateOpaqueChild(item, private_item, row_width, pending);
                 }
@@ -3130,7 +2998,7 @@ pub const InstGraph = struct {
                     };
                 }
                 const ext = try self.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
-                try self.setContent(public_node, .{ .record = .{ .fields = fields, .ext = ext } });
+                self.setContent(public_node, .{ .record = .{ .fields = fields, .ext = ext } });
                 for (fields, private_row.fields) |field, private_field| {
                     try self.relateOpaqueChild(field.ty, private_field.ty, row_width, pending);
                 }
@@ -3150,7 +3018,7 @@ pub const InstGraph = struct {
                     };
                 }
                 const ext = try self.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
-                try self.setContent(public_node, .{ .tag_union = .{ .tags = tags, .ext = ext } });
+                self.setContent(public_node, .{ .tag_union = .{ .tags = tags, .ext = ext } });
                 for (tags, private_row.tags) |tag, private_tag| {
                     for (tag.payloads, private_tag.payloads) |payload, private_payload| {
                         try self.relateOpaqueChild(payload, private_payload, row_width, pending);
@@ -3654,33 +3522,22 @@ pub const InstGraph = struct {
         self.current_snapshots_dirty = false;
     }
 
-    /// Redirect `loser` into `winner`, moving row back references and
-    /// invalidating the current snapshot cache. Immutable snapshot provenance
-    /// remains attached to permanent node ids and resolves through `find`.
+    /// Redirect `loser` into `winner` and invalidate the current snapshot
+    /// cache. Immutable snapshot provenance remains attached to permanent node
+    /// ids and resolves through `find`.
     fn union_(self: *InstGraph, raw_winner: NodeId, raw_loser: NodeId) Allocator.Error!void {
         const winner = self.find(raw_winner);
         const loser = self.find(raw_loser);
         if (winner == loser) return;
-        // Rekey before changing row or union state. Its allocation preflight
-        // can still fail without staling a resident key or unregistering the
-        // loser's row-parent edge.
+        // Rekey before changing union state. Its allocation preflight can still
+        // fail without staling a resident key.
         try self.migrateNominalBackingRoot(loser, winner);
-        try self.unregisterRowParent(loser);
         const winner_tail = self.class_member_tail.items[@intFromEnum(winner)];
         const loser_head = self.class_member_head.items[@intFromEnum(loser)];
         self.class_member_next.items[@intFromEnum(winner_tail)] = loser_head;
         self.class_member_tail.items[@intFromEnum(winner)] = self.class_member_tail.items[@intFromEnum(loser)];
         self.nodes.items[@intFromEnum(loser)] = .{ .redirect = winner };
         self.versions.items[@intFromEnum(winner)] +%= 1;
-        if (self.row_parents.fetchRemove(loser)) |moved| {
-            var moved_list = moved.value;
-            for (moved_list.items) |parent| {
-                const parent_root = self.find(parent);
-                self.row_exts.items[@intFromEnum(parent_root)] = winner;
-                try self.addRowParent(winner, parent_root);
-            }
-            moved_list.deinit(self.allocator);
-        }
         self.countDiagnostic("class_unions");
         self.invalidateActiveSnapshots(winner);
         try self.drainNominalBackingCollisions();
@@ -3689,18 +3546,17 @@ pub const InstGraph = struct {
     /// Replace a root's content with an observationally equivalent compressed
     /// form without invalidating immutable Type-shaped snapshots. Returns
     /// whether the stored graph content changed.
-    fn replaceContentWithoutSnapshotInvalidation(self: *InstGraph, raw_root: NodeId, new_content: InstNode) Allocator.Error!bool {
+    fn replaceContentWithoutSnapshotInvalidation(self: *InstGraph, raw_root: NodeId, new_content: InstNode) bool {
         const root = self.find(raw_root);
         if (instNodeEql(self.nodes.items[@intFromEnum(root)], new_content)) return false;
         self.nodes.items[@intFromEnum(root)] = new_content;
         self.versions.items[@intFromEnum(root)] +%= 1;
-        try self.registerRowParent(root, new_content);
         return true;
     }
 
     /// Replace a root's type content and invalidate every cached snapshot.
-    fn setContent(self: *InstGraph, root: NodeId, new_content: InstNode) Allocator.Error!void {
-        if (!try self.replaceContentWithoutSnapshotInvalidation(root, new_content)) return;
+    fn setContent(self: *InstGraph, root: NodeId, new_content: InstNode) void {
+        if (!self.replaceContentWithoutSnapshotInvalidation(root, new_content)) return;
         self.invalidateActiveSnapshots(root);
     }
 
@@ -3873,7 +3729,7 @@ pub const InstGraph = struct {
         if (left_content == .redirect) unreachable;
         if (left_content == .unresolved) {
             if (right_content == .unresolved) {
-                try self.setContent(right, .{ .unresolved = mergeVariables(left_content.unresolved, right_content.unresolved) });
+                self.setContent(right, .{ .unresolved = mergeVariables(left_content.unresolved, right_content.unresolved) });
                 try self.union_(right, left);
             } else if (right_content == .named and right_content.named.kind == .alias) {
                 try self.unifyThroughBacking(right, right_content, left, row_width, pending);
@@ -4283,7 +4139,7 @@ pub const InstGraph = struct {
         if (declared_backing.node != backing_node) {
             var compressed = named;
             compressed.backing = .{ .node = backing_node, .use = declared_backing.use, .authority = declared_backing.authority };
-            try self.setContent(named_node, .{ .named = compressed });
+            self.setContent(named_node, .{ .named = compressed });
         }
         // The named node already owns this exact structural backing. This
         // relation arises when a checked function interface names the wrapper
@@ -4345,7 +4201,7 @@ pub const InstGraph = struct {
             if (backing.node != result) {
                 var compressed = named;
                 compressed.backing = .{ .node = result, .use = backing.use, .authority = backing.authority };
-                try self.setContent(current, .{ .named = compressed });
+                self.setContent(current, .{ .named = compressed });
             }
             current = next;
         }
@@ -4455,7 +4311,7 @@ pub const InstGraph = struct {
                 const flat = try self.flattenTagRow(row);
                 if (flat.tags.len != 0) Common.invariant("instantiation unified a non-empty tag union with an empty tag union");
                 try self.unify(flat.ext, empty);
-                try self.setContent(row, .empty_tag_union);
+                self.setContent(row, .empty_tag_union);
                 try self.union_(empty, row);
             },
             .record => {
@@ -4467,7 +4323,7 @@ pub const InstGraph = struct {
                 }
                 try self.unify(flat.ext, empty);
                 if (flat.fields.len == 0) {
-                    try self.setContent(row, .empty_record);
+                    self.setContent(row, .empty_record);
                     try self.union_(empty, row);
                 } else {
                     // The empty construction adopts the explicit optional or
@@ -4510,7 +4366,7 @@ pub const InstGraph = struct {
         if (ext_content == .unresolved or ext_content == .empty_tag_union) {
             if (row.ext != ext) {
                 const flattened: InstNode = .{ .tag_union = .{ .tags = row.tags, .ext = ext } };
-                _ = try self.replaceContentWithoutSnapshotInvalidation(root, flattened);
+                _ = self.replaceContentWithoutSnapshotInvalidation(root, flattened);
             }
             return .{ .tags = row.tags, .ext = ext };
         }
@@ -4547,7 +4403,7 @@ pub const InstGraph = struct {
 
         const flat_tags = try self.arena().dupe(InstTag, tags.items);
         const flattened: InstNode = .{ .tag_union = .{ .tags = flat_tags, .ext = ext } };
-        _ = try self.replaceContentWithoutSnapshotInvalidation(root, flattened);
+        _ = self.replaceContentWithoutSnapshotInvalidation(root, flattened);
         return .{ .tags = flat_tags, .ext = ext };
     }
 
@@ -4569,7 +4425,7 @@ pub const InstGraph = struct {
         if (ext_content == .unresolved or ext_content == .empty_record) {
             if (row.ext != ext) {
                 const flattened: InstNode = .{ .record = .{ .fields = row.fields, .ext = ext } };
-                _ = try self.replaceContentWithoutSnapshotInvalidation(root, flattened);
+                _ = self.replaceContentWithoutSnapshotInvalidation(root, flattened);
             }
             return .{ .fields = row.fields, .ext = ext };
         }
@@ -4617,7 +4473,7 @@ pub const InstGraph = struct {
 
         const flat_fields = try self.arena().dupe(InstField, fields.items);
         const flattened: InstNode = .{ .record = .{ .fields = flat_fields, .ext = ext } };
-        _ = try self.replaceContentWithoutSnapshotInvalidation(root, flattened);
+        _ = self.replaceContentWithoutSnapshotInvalidation(root, flattened);
         return .{ .fields = flat_fields, .ext = ext };
     }
 
@@ -4709,7 +4565,7 @@ pub const InstGraph = struct {
             merged_ext = new_ext;
         }
 
-        try self.setContent(left, .{ .tag_union = .{
+        self.setContent(left, .{ .tag_union = .{
             .tags = try self.arena().dupe(InstTag, merged.items),
             .ext = merged_ext,
         } });
@@ -4736,7 +4592,7 @@ pub const InstGraph = struct {
                     Common.invariant("instantiation tried to write a tag row into a record row variable");
                 }
             }
-            try self.setContent(ext_root, .{ .tag_union = .{
+            self.setContent(ext_root, .{ .tag_union = .{
                 .tags = try self.arena().dupe(InstTag, tags),
                 .ext = tail_ext,
             } });
@@ -4851,7 +4707,7 @@ pub const InstGraph = struct {
             merged_ext = new_ext;
         }
 
-        try self.setContent(left, .{ .record = .{
+        self.setContent(left, .{ .record = .{
             .fields = try self.arena().dupe(InstField, merged.items),
             .ext = merged_ext,
         } });
@@ -4878,7 +4734,7 @@ pub const InstGraph = struct {
                     Common.invariant("instantiation tried to write a record row into a tag row variable");
                 }
             }
-            try self.setContent(ext_root, .{ .record = .{
+            self.setContent(ext_root, .{ .record = .{
                 .fields = try self.arena().dupe(InstField, fields),
                 .ext = tail_ext,
             } });
@@ -5026,7 +4882,7 @@ pub const InstGraph = struct {
             .erased => |digest| .{ .erased = digest },
             .zst => .zst,
         };
-        _ = try self.replaceContentWithoutSnapshotInvalidation(node, imported);
+        _ = self.replaceContentWithoutSnapshotInvalidation(node, imported);
         return node;
     }
 
@@ -5144,7 +5000,7 @@ pub const InstGraph = struct {
             .erased => |digest| .{ .erased = digest },
             .zst => .zst,
         };
-        _ = try self.replaceContentWithoutSnapshotInvalidation(node, imported_node);
+        _ = self.replaceContentWithoutSnapshotInvalidation(node, imported_node);
         return node;
     }
 
@@ -6375,6 +6231,42 @@ test "graph diagnostics count authoritative operations" {
     try std.testing.expectEqual(@as(u64, 1), diagnostics.finished_mono_nodes_visited);
 }
 
+test "issue 10941: row extension class unions remain linear" {
+    const gpa = std.testing.allocator;
+
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+    var diagnostics: GraphDiagnostics = .{};
+    graph.setDiagnostics(&diagnostics);
+
+    // Repro for https://github.com/roc-lang/roc/issues/10941: re-rooting one
+    // row-extension class must do work linear in the graph nodes and unions.
+    var extension = try graph.newNode(.empty_record);
+    for (0..128) |_| {
+        _ = try graph.newNode(.{ .record = .{
+            .fields = &.{},
+            .ext = extension,
+        } });
+        const replacement = try graph.newNode(.empty_record);
+        try graph.union_(replacement, extension);
+        extension = replacement;
+    }
+
+    const linear_work_limit = (diagnostics.nodes_created + diagnostics.class_unions) * 16;
+    if (diagnostics.union_find_resolutions > linear_work_limit) {
+        std.debug.print(
+            "row extension unions performed {d} union-find resolutions; expected at most {d}\n",
+            .{ diagnostics.union_find_resolutions, linear_work_limit },
+        );
+    }
+    try std.testing.expect(diagnostics.union_find_resolutions <= linear_work_limit);
+}
+
 test "completed monotype program view does not expose instantiation graph nodes" {
     @setEvalBranchQuota(10_000);
     comptime assertNoNodeId(Ast.ProgramView, "Ast.ProgramView");
@@ -6521,13 +6413,13 @@ test "open function interface shape preserves defaults and recursive structure" 
     try std.testing.expect(!std.mem.eql(u8, record_shape.bytes, tag_shape.bytes));
 
     const left_cycle = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
-    try graph.setContent(left_cycle, .{ .tuple = try graph.arena().dupe(NodeId, &.{left_cycle}) });
+    graph.setContent(left_cycle, .{ .tuple = try graph.arena().dupe(NodeId, &.{left_cycle}) });
     const left_recursive = try graph.newNode(.{ .func = .{
         .args = try graph.arena().dupe(NodeId, &.{left_cycle}),
         .ret = ret,
     } });
     const right_cycle = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
-    try graph.setContent(right_cycle, .{ .tuple = try graph.arena().dupe(NodeId, &.{right_cycle}) });
+    graph.setContent(right_cycle, .{ .tuple = try graph.arena().dupe(NodeId, &.{right_cycle}) });
     const right_recursive = try graph.newNode(.{ .func = .{
         .args = try graph.arena().dupe(NodeId, &.{right_cycle}),
         .ret = ret,
@@ -6631,7 +6523,7 @@ test "cyclic row extension is not a resolved graph type" {
     defer graph.destroy();
 
     const row = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
-    try graph.setContent(row, .{ .tag_union = .{ .tags = &.{}, .ext = row } });
+    graph.setContent(row, .{ .tag_union = .{ .tags = &.{}, .ext = row } });
     try std.testing.expect(!try graph.typeIsResolved(row));
 }
 
@@ -6675,7 +6567,7 @@ test "active Monotype snapshots are immutable across graph mutations" {
     const first = try graph.activeTypeViewForNode(node);
     try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, type_store.get(first));
 
-    try graph.setContent(node, .{ .primitive = .str });
+    graph.setContent(node, .{ .primitive = .str });
     const second = try graph.activeTypeViewForNode(node);
 
     try std.testing.expect(first != second);
@@ -7005,7 +6897,7 @@ test "final sealing does not mutate an earlier active snapshot" {
     const snapshot_field = GuardedList.at(type_store.fieldSpan(type_store.get(snapshot).record), 0);
     try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, type_store.get(snapshot_field.ty));
 
-    try graph.setContent(a_ty, .{ .primitive = .str });
+    graph.setContent(a_ty, .{ .primitive = .str });
 
     try graph.freezeRelations();
     var finals = GraphTypeFinals.init(graph);
@@ -7046,7 +6938,7 @@ test "final sealing follows active snapshots stored only in field value types" {
     }) });
 
     try std.testing.expect(try graph.typeHasActiveSnapshots(wrapper));
-    try graph.setContent(value_node, .{ .primitive = .str });
+    graph.setContent(value_node, .{ .primitive = .str });
 
     try graph.freezeRelations();
     var finals = GraphTypeFinals.init(graph);
@@ -7117,7 +7009,7 @@ test "final graph function recursively replaces active snapshots" {
         .ret = row,
     } });
     const draft_fn = try graph.activeTypeViewForNode(fn_node);
-    try graph.setContent(a_ty, .{ .primitive = .str });
+    graph.setContent(a_ty, .{ .primitive = .str });
 
     try graph.freezeRelations();
     var finals = GraphTypeFinals.init(graph);
@@ -7282,12 +7174,12 @@ test "generated-private traversal scratch handles cycles and epoch rollover" {
     try std.testing.expectEqual(@as(u64, 1), diagnostics.generated_private_nodes_visited);
 
     const unrelated = try graph.newNode(.{ .primitive = .u64 });
-    try graph.setContent(unrelated, .{ .primitive = .str });
+    graph.setContent(unrelated, .{ .primitive = .str });
     try std.testing.expect(!try graph.containsGeneratedPrivate(recursive));
     try std.testing.expectEqual(@as(u64, 2), diagnostics.generated_private_cache_hits);
     try std.testing.expectEqual(@as(u64, 1), diagnostics.generated_private_nodes_visited);
 
-    try graph.setContent(recursive, .zst);
+    graph.setContent(recursive, .zst);
     try std.testing.expect(!try graph.containsGeneratedPrivate(recursive));
     try std.testing.expectEqual(@as(u64, 2), diagnostics.generated_private_cache_hits);
     try std.testing.expectEqual(@as(u64, 2), diagnostics.generated_private_nodes_visited);
@@ -7361,14 +7253,14 @@ test "iterator-interface containment caches exact graph dependencies" {
     try std.testing.expectEqual(@as(u64, 1), diagnostics.iterator_interface_cache_hits);
 
     const unrelated = try graph.newNode(.{ .primitive = .u64 });
-    try graph.setContent(unrelated, .{ .primitive = .str });
+    graph.setContent(unrelated, .{ .primitive = .str });
     try std.testing.expect(!try graph.containsIteratorInterface(root));
     try std.testing.expectEqual(@as(u64, 2), diagnostics.iterator_interface_cache_hits);
     try std.testing.expectEqual(@as(u64, 2), diagnostics.iterator_interface_nodes_visited);
 
     const module_identity = try name_store.internModuleIdentity(&([_]u8{0x42} ** 32));
     const type_name = try name_store.internTypeName("Iter");
-    try graph.setContent(child, .{ .named = .{
+    graph.setContent(child, .{ .named = .{
         .named_type = .{ .module = .{}, .ty = testCheckedTypeId(14) },
         .def = .{ .module = module_identity, .type_name = type_name },
         .kind = .@"opaque",
@@ -8798,7 +8690,7 @@ test "issue 9647: recursive nominal backing cycle is not chased as structural ba
     const def: Type.TypeDef = .{ .module = module_identity, .type_name = type_name };
 
     const nominal = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
-    try graph.setContent(nominal, .{ .named = .{
+    graph.setContent(nominal, .{ .named = .{
         .named_type = named_type,
         .def = def,
         .kind = .nominal,
@@ -8840,7 +8732,7 @@ test "recursive nominal backing can meet an alias to that nominal" {
     const alias_def: Type.TypeDef = .{ .module = module_identity, .type_name = alias_name };
 
     const nominal = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
-    try graph.setContent(nominal, .{ .named = .{
+    graph.setContent(nominal, .{ .named = .{
         .named_type = nominal_type,
         .def = nominal_def,
         .kind = .nominal,


### PR DESCRIPTION
Monotype still maintained a reverse row-extension index after immutable active snapshots switched relation mutations to exact global cache invalidation. This removes that unconsumed bookkeeping and its allocation error propagation, and adds a deterministic regression test that keeps repeated row-extension class unions linear. Closes #10941.