### PR TITLE
Keep interpreter callables alive after provided roots return

### DIFF
--- a/design.md
+++ b/design.md
@@ -11799,6 +11799,17 @@ columns until `deinit`. The mapped bytes and the scratch allocator must both
 outlive the view. Format version 15 introduced the portable columns; version 16
 added `LirProcSpec.ret_desc`.
 
+An interpreter-mode host entry pins each root's `LirInterpreter` on the heap.
+Every interpreter-created erased-callable allocation owns one reference to that
+interpreter, independent of the callable allocation's own Roc reference count,
+and its final-drop callback releases that reference after following the exact
+LIR capture-drop plan. Calls through a retained interpreter are reentrant on
+their current thread and serialized across threads. Runtime-created descriptor
+identities use lifetime-long storage, while operation-local interpreter scratch
+is recycled between independent host entries. The shim keeps the mapped
+`ProgramView` process-stable so every retained interpreter's store and layout
+pointers remain valid.
+
 Hosted proc entries keep their exact checked hosted ABI in both strategies. A
 boxy caller adapts arguments before the hosted call and adapts the result after
 the hosted call. It must not change the hosted dispatch index, hosted symbol

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -431,6 +431,30 @@ test "fx platform provided root preserves boxed callable identity (speed backend
     try expectProvidedBoxedCallableIdentity("--opt=speed", "fx_provided_boxed_callable_identity_speed");
 }
 
+/// Repro for https://github.com/roc-lang/roc/issues/10775: a boxed callable the
+/// host owns stays callable after the provided root that produced it returned,
+/// so invoking it through the erased-callable ABI must return 42.
+fn expectProvidedBoxedCallablePostRootCall(opt_flag: []const u8, output_basename: []const u8) FxPlatformTestError!void {
+    try expectProvidedCallableHostSelfTest(
+        opt_flag,
+        output_basename,
+        "--run-provided-boxed-callable-post-root-call",
+        "provided boxed callable post-root call",
+    );
+}
+
+test "fx platform host calls boxed callable after provided root returns (interpreter)" {
+    try expectProvidedBoxedCallablePostRootCall("--opt=interpreter", "fx_provided_boxed_callable_post_root_call_interpreter");
+}
+
+test "fx platform host calls boxed callable after provided root returns (dev backend)" {
+    try expectProvidedBoxedCallablePostRootCall("--opt=dev", "fx_provided_boxed_callable_post_root_call_dev");
+}
+
+test "fx platform host calls boxed callable after provided root returns (speed backend)" {
+    try expectProvidedBoxedCallablePostRootCall("--opt=speed", "fx_provided_boxed_callable_post_root_call_speed");
+}
+
 test "fx platform direct run preserves RocOps after F32.abs before list allocation" {
     const allocator = testing.allocator;
 

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -684,6 +684,15 @@ pub const Interpreter = struct {
         }
 
         pub fn enter(self: *Retained) void {
+            // Freestanding targets have no OS threads, and std.Thread cannot
+            // produce an identity for them. Their only possible nesting is
+            // same-thread reentrancy, so depth alone is the execution gate.
+            if (comptime is_freestanding) {
+                if (self.execution_depth == 0) self.interpreter.resetRetainedExecution();
+                self.execution_depth += 1;
+                return;
+            }
+
             const thread_id = std.Thread.getCurrentId();
             if (self.execution_owner.load(.acquire) == thread_id) {
                 self.execution_depth += 1;
@@ -698,6 +707,12 @@ pub const Interpreter = struct {
         }
 
         pub fn leave(self: *Retained) void {
+            if (comptime is_freestanding) {
+                if (builtin.mode == .Debug) std.debug.assert(self.execution_depth > 0);
+                self.execution_depth -= 1;
+                return;
+            }
+
             const thread_id = std.Thread.getCurrentId();
             if (builtin.mode == .Debug) {
                 std.debug.assert(self.execution_owner.load(.acquire) == thread_id);

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -4399,6 +4399,18 @@ pub const Interpreter = struct {
     ) Error!void {
         self.bindCallerRocOps(ops);
         self.bindBoxyRuntime();
+        if (sljmp.supported) {
+            var call_jmp_buf: JmpBuf = undefined;
+            const prev_jmp_buf = self.roc_env.installJumpBuf(&call_jmp_buf);
+            defer self.roc_env.restoreJumpBuf(prev_jmp_buf);
+            const sj = setjmp(&call_jmp_buf);
+            if (sj != 0) {
+                self.recordActiveFailureLocIfUnset();
+                self.recordFailedCallStackIfUnset() catch {};
+                return error.Crash;
+            }
+        }
+
         const proc_id: LIR.LirProcSpecId = @enumFromInt(context.proc_id);
         const proc_spec = self.store.getProcSpec(proc_id);
         const proc_arg_locals = self.store.getLocalSpan(proc_spec.args);

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -102,10 +102,10 @@ pub const ExpectFailure = struct {
 
 /// Environment for interpreter-managed RocOps forwarding.
 ///
-/// The interpreter always evaluates with the RocOps it was initialized with.
-/// These callbacks forward the caller's alloc/dealloc/realloc/dbg/expect/crash
-/// hooks while retaining local bookkeeping for crash and expect messages so
-/// hosts that care can inspect the last message after evaluation.
+/// These callbacks forward through the RocOps for the current host entry while
+/// retaining local bookkeeping for crash and expect messages so hosts that care
+/// can inspect the last message after evaluation. A retained interpreter
+/// rebinds this pointer when the host invokes one of its callables later.
 const InterpreterRocEnv = struct {
     allocator: Allocator,
     crashed: bool = false,
@@ -309,14 +309,22 @@ pub const Interpreter = struct {
     const max_debug_value_visits: usize = 16;
     pub const erased_callable_context_alignment: usize = builtins.erased_callable.capture_alignment;
 
+    const ErasedCallableCaptureDrop = enum(u8) {
+        none,
+        rc_helper,
+        boxy_capture,
+    };
+
     pub const ErasedCallableInterpreterContext = extern struct {
+        owner: ?*Retained,
         interpreter: *LirInterpreter,
-        capture_desc: ?*const LirProgram.BoxyTypeDesc,
         result_desc: ?*const LirProgram.BoxyTypeDesc,
         proc_id: u32,
-        capture_layout_plus_one: u32,
+        drop_layout_plus_one: u32,
         capture_value_offset: u32,
-        padding: u32,
+        drop_desc_field_offset: u32,
+        drop_kind: u8,
+        padding: [3]u8,
     };
 
     pub const erased_callable_context_capture_offset: usize =
@@ -327,6 +335,9 @@ pub const Interpreter = struct {
     layout_store: *const layout_mod.Store,
     helper: LayoutHelper,
     float_nan_mode: builtins.float_bits.NanMode,
+    /// Arena for runtime-created descriptors whose identities can escape in a
+    /// retained callable or host result and must survive later evaluations.
+    descriptor_arena: base.SingleThreadArena,
     /// Arena for interpreter-allocated memory (temporaries, copies).
     arena: base.SingleThreadArena,
     /// RocOps environment for builtin dispatch.
@@ -382,6 +393,9 @@ pub const Interpreter = struct {
     failed_stmt_inline_scope: InlineScopeId = InlineScopeId.none,
     comptime_branch_hits: std.ArrayList(ComptimeBranchHit),
     comptime_failed_site: ?LIR.ComptimeSiteId = null,
+    /// Heap-pinned owner used by host-facing integrations whose erased
+    /// callables can outlive the evaluation that created them.
+    retained_owner: ?*Retained = null,
 
     const RcPresence = enum(u2) {
         unknown,
@@ -606,6 +620,97 @@ pub const Interpreter = struct {
 
     pub const BoxyTables = boxy_runtime.BoxyTables;
 
+    /// Heap-pinned interpreter lifetime for host-facing execution. The root
+    /// call owns the initial reference and every interpreter-created erased
+    /// callable owns another. The recursive execution lock keeps reentrant
+    /// host callbacks working while serializing calls from other threads into
+    /// the same single-threaded interpreter state.
+    pub const Retained = struct {
+        allocator: Allocator,
+        references: std.atomic.Value(usize),
+        synchronization_io: std.Io,
+        execution_mutex: std.Io.Mutex = .init,
+        execution_owner: std.atomic.Value(std.Thread.Id) = .init(0),
+        execution_depth: usize = 0,
+        interpreter: LirInterpreter,
+
+        pub fn createWithBoxyTables(
+            allocator: Allocator,
+            store: *const LirStore,
+            layout_store: *const layout_mod.Store,
+            boxy_tables: BoxyTables,
+            caller_roc_ops: *RocOps,
+            float_nan_mode: builtins.float_bits.NanMode,
+            synchronization_io: std.Io,
+        ) Allocator.Error!*Retained {
+            const self = try allocator.create(Retained);
+            errdefer allocator.destroy(self);
+
+            self.* = .{
+                .allocator = allocator,
+                .references = .init(1),
+                .synchronization_io = synchronization_io,
+                .interpreter = try LirInterpreter.initWithBoxyTables(
+                    allocator,
+                    store,
+                    layout_store,
+                    boxy_tables,
+                    caller_roc_ops,
+                    float_nan_mode,
+                ),
+            };
+            self.interpreter.retained_owner = self;
+            return self;
+        }
+
+        pub fn retain(self: *Retained) void {
+            const previous = self.references.fetchAdd(1, .monotonic);
+            if (builtin.mode == .Debug) std.debug.assert(previous > 0);
+        }
+
+        pub fn release(self: *Retained) void {
+            const previous = self.references.fetchSub(1, .release);
+            if (builtin.mode == .Debug) std.debug.assert(previous > 0);
+            if (previous != 1) return;
+            _ = self.references.load(.acquire);
+            if (builtin.mode == .Debug) {
+                std.debug.assert(self.execution_owner.load(.acquire) == 0);
+                std.debug.assert(self.execution_depth == 0);
+            }
+
+            const allocator = self.allocator;
+            self.interpreter.deinit();
+            allocator.destroy(self);
+        }
+
+        pub fn enter(self: *Retained) void {
+            const thread_id = std.Thread.getCurrentId();
+            if (self.execution_owner.load(.acquire) == thread_id) {
+                self.execution_depth += 1;
+                return;
+            }
+
+            self.execution_mutex.lockUncancelable(self.synchronization_io);
+            if (builtin.mode == .Debug) std.debug.assert(self.execution_owner.load(.monotonic) == 0);
+            self.interpreter.resetRetainedExecution();
+            self.execution_depth = 1;
+            self.execution_owner.store(thread_id, .release);
+        }
+
+        pub fn leave(self: *Retained) void {
+            const thread_id = std.Thread.getCurrentId();
+            if (builtin.mode == .Debug) {
+                std.debug.assert(self.execution_owner.load(.acquire) == thread_id);
+                std.debug.assert(self.execution_depth > 0);
+            }
+            self.execution_depth -= 1;
+            if (self.execution_depth != 0) return;
+
+            self.execution_owner.store(0, .release);
+            self.execution_mutex.unlock(self.synchronization_io);
+        }
+    };
+
     pub fn init(
         allocator: Allocator,
         store: *const LirStore,
@@ -707,6 +812,7 @@ pub const Interpreter = struct {
             .layout_store = layout_store,
             .helper = LayoutHelper.init(layout_store),
             .float_nan_mode = float_nan_mode,
+            .descriptor_arena = base.SingleThreadArena.init(allocator),
             .arena = base.SingleThreadArena.init(allocator),
             .roc_env = roc_env,
             .roc_ops = RocOps{
@@ -773,6 +879,7 @@ pub const Interpreter = struct {
         self.roc_env.deinit();
         self.allocator.destroy(self.roc_env);
         self.static_strings.deinit();
+        self.descriptor_arena.deinit();
         self.arena.deinit();
         self.tag_variant_plans.deinit(self.allocator);
         self.struct_field_plans.deinit(self.allocator);
@@ -1064,8 +1171,36 @@ pub const Interpreter = struct {
         self.boxy_runtime.runtime_boxy_tag_payload_descs = &self.runtime_boxy_tag_payload_descs;
         self.boxy_runtime.runtime_boxy_payload_steps = &self.runtime_boxy_payload_steps;
         self.boxy_runtime.roc_ops = &self.roc_ops;
-        self.boxy_runtime.descriptor_arena = self.evalAllocator();
+        self.boxy_runtime.descriptor_arena = self.descriptor_arena.allocator();
         self.boxy_runtime.eval_arena = self.evalAllocator();
+    }
+
+    /// Discard operation-local allocations between independent host entries.
+    /// Descriptor identities live in `descriptor_arena` and remain stable for
+    /// every callable retained from this interpreter.
+    fn resetRetainedExecution(self: *LirInterpreter) void {
+        self.call_stack = .empty;
+        self.failed_call_stack = .empty;
+        self.comptime_branch_hits = .empty;
+        _ = self.arena.reset(.retain_capacity);
+
+        self.roc_env.resetForEval();
+        self.active_stmt_loc = base.SourceLoc.none;
+        self.active_stmt_region = base.Region.zero();
+        self.active_stmt_inline_scope = InlineScopeId.none;
+        self.failed_stmt_loc = base.SourceLoc.none;
+        self.failed_stmt_region = base.Region.zero();
+        self.failed_stmt_inline_scope = InlineScopeId.none;
+        self.comptime_failed_site = null;
+        if (builtin.mode == .Debug) self.inflight_zeroed_box_payloads.clearRetainingCapacity();
+    }
+
+    fn bindCallerRocOps(self: *LirInterpreter, caller_roc_ops: *RocOps) void {
+        // A host-created callable can synchronously invoke this interpreter's
+        // callable again with the interpreter's forwarding RocOps. Preserve
+        // the ultimate host in that case instead of forwarding back to self.
+        if (caller_roc_ops == &self.roc_ops) return;
+        self.roc_env.caller_roc_ops = caller_roc_ops;
     }
 
     /// Frame-aware services the boxy runtime calls back into: descriptor and
@@ -4144,7 +4279,21 @@ pub const Interpreter = struct {
         out_desc: *?*const anyopaque,
     ) callconv(.c) void {
         const context = erasedCallableInterpreterContextFromCapture(capture);
-        context.interpreter.callInterpreterErasedCallable(context, ops, ret, args, reuse, out_desc) catch |err| switch (err) {
+        const owner = context.owner;
+        if (owner) |retained| {
+            retained.retain();
+            retained.enter();
+        }
+        context.interpreter.callInterpreterErasedCallable(context, ops, ret, args, reuse, out_desc) catch |err| {
+            leaveAndReleaseErasedCallableOwner(owner);
+            reportInterpreterErasedCallableError(ops, err);
+            return;
+        };
+        leaveAndReleaseErasedCallableOwner(owner);
+    }
+
+    fn reportInterpreterErasedCallableError(ops: *RocOps, err: Error) void {
+        switch (err) {
             error.OutOfMemory => ops.crash("LIR/interpreter erased callable trampoline ran out of memory"),
             error.RuntimeError => ops.crash("LIR/interpreter erased callable trampoline hit runtime error"),
             error.ComptimeExhaustiveness => ops.crash("LIR/interpreter erased callable trampoline hit compile-time exhaustiveness marker"),
@@ -4155,50 +4304,101 @@ pub const Interpreter = struct {
             // expect_err statements only occur in top-level expect test
             // roots, never in callable bodies.
             error.ExpectErr => unreachable,
-        };
+        }
+    }
+
+    fn leaveAndReleaseErasedCallableOwner(owner: ?*Retained) void {
+        if (owner) |retained| {
+            retained.leave();
+            retained.release();
+        }
     }
 
     fn interpreterErasedCallableOnDrop(capture: ?[*]u8, roc_ops: *RocOps) callconv(.c) void {
         const context = erasedCallableInterpreterContextFromCapture(capture);
-        const capture_layout: layout_mod.Idx = if (context.capture_layout_plus_one == 0)
-            return
+        const owner = context.owner;
+        if (owner) |retained| retained.enter();
+        context.interpreter.bindCallerRocOps(roc_ops);
+
+        context.interpreter.dropInterpreterErasedCallableCapture(context, capture) catch |err| {
+            leaveAndReleaseErasedCallableOwner(owner);
+            reportInterpreterErasedCallableDropError(roc_ops, err);
+            return;
+        };
+        leaveAndReleaseErasedCallableOwner(owner);
+    }
+
+    fn dropInterpreterErasedCallableCapture(
+        self: *LirInterpreter,
+        context: *ErasedCallableInterpreterContext,
+        capture: ?[*]u8,
+    ) Error!void {
+        const drop_kind: ErasedCallableCaptureDrop = @enumFromInt(context.drop_kind);
+        if (drop_kind == .none) return;
+        const capture_layout: layout_mod.Idx = if (context.drop_layout_plus_one == 0)
+            self.invariantFailed(
+                "LIR/interpreter invariant violated: erased callable capture drop lacked a layout",
+                .{},
+            )
         else
-            @enumFromInt(context.capture_layout_plus_one - 1);
-        if (capture_layout == .zst) return;
+            @enumFromInt(context.drop_layout_plus_one - 1);
         const capture_value_ptr = (capture orelse unreachable) + context.capture_value_offset;
-        if (context.capture_desc) |capture_desc| {
-            context.interpreter.boxy_runtime.performBoxyLayoutDrop(
-                context.interpreter.boxyFrameHooks(null),
+        switch (drop_kind) {
+            .none => unreachable,
+            .rc_helper => self.performRcHelperRequired(
+                .{ .op = .decref, .layout_idx = capture_layout },
                 .{ .ptr = capture_value_ptr },
-                capture_layout,
-                capture_desc,
-                .decref,
                 1,
                 .atomic,
-            ) catch |err| switch (err) {
-                error.OutOfMemory => roc_ops.crash("LIR/interpreter erased callable capture drop ran out of memory"),
-                error.RuntimeError => roc_ops.crash("LIR/interpreter erased callable capture drop hit runtime error"),
-                error.ComptimeExhaustiveness => roc_ops.crash("LIR/interpreter erased callable capture drop hit compile-time exhaustiveness marker"),
-                error.DivisionByZero => roc_ops.crash("LIR/interpreter erased callable capture drop hit division by zero"),
-                error.Crash => roc_ops.crash("LIR/interpreter erased callable capture drop hit Roc crash"),
-                error.UnsupportedHostedFunction => roc_ops.crash("LIR/interpreter erased callable capture drop reached an unsupported hosted function"),
-                error.InvalidHostedFunctionSignature => roc_ops.crash("LIR/interpreter erased callable capture drop reached an invalid hosted function signature"),
-                error.ExpectErr => unreachable,
-            };
-            return;
+            ),
+            .boxy_capture => {
+                const desc_address = self.readPointerInt(.{
+                    .ptr = capture_value_ptr + context.drop_desc_field_offset,
+                });
+                const desc: *const LirProgram.BoxyTypeDesc = if (desc_address == 0)
+                    self.invariantFailed(
+                        "LIR/interpreter invariant violated: Boxy erased callable capture drop descriptor was null",
+                        .{},
+                    )
+                else
+                    @ptrFromInt(desc_address);
+                try self.boxy_runtime.performBoxyLayoutDrop(
+                    self.boxyFrameHooks(null),
+                    .{ .ptr = capture_value_ptr },
+                    capture_layout,
+                    desc,
+                    .decref,
+                    1,
+                    .atomic,
+                );
+            },
         }
-        context.interpreter.performRawRc(.decref, .{ .ptr = capture_value_ptr }, capture_layout, 1);
+    }
+
+    fn reportInterpreterErasedCallableDropError(roc_ops: *RocOps, err: Error) void {
+        switch (err) {
+            error.OutOfMemory => roc_ops.crash("LIR/interpreter erased callable capture drop ran out of memory"),
+            error.RuntimeError => roc_ops.crash("LIR/interpreter erased callable capture drop hit runtime error"),
+            error.ComptimeExhaustiveness => roc_ops.crash("LIR/interpreter erased callable capture drop hit compile-time exhaustiveness marker"),
+            error.DivisionByZero => roc_ops.crash("LIR/interpreter erased callable capture drop hit division by zero"),
+            error.Crash => roc_ops.crash("LIR/interpreter erased callable capture drop hit Roc crash"),
+            error.UnsupportedHostedFunction => roc_ops.crash("LIR/interpreter erased callable capture drop reached an unsupported hosted function"),
+            error.InvalidHostedFunctionSignature => roc_ops.crash("LIR/interpreter erased callable capture drop reached an invalid hosted function signature"),
+            error.ExpectErr => unreachable,
+        }
     }
 
     fn callInterpreterErasedCallable(
         self: *LirInterpreter,
         context: *ErasedCallableInterpreterContext,
-        _: *RocOps,
+        ops: *RocOps,
         ret: ?[*]u8,
         args: ?[*]const u8,
         reuse_ptr: ?[*]u8,
         out_desc: *?*const anyopaque,
     ) Error!void {
+        self.bindCallerRocOps(ops);
+        self.bindBoxyRuntime();
         const proc_id: LIR.LirProcSpecId = @enumFromInt(context.proc_id);
         const proc_spec = self.store.getProcSpec(proc_id);
         const proc_arg_locals = self.store.getLocalSpan(proc_spec.args);
@@ -4597,6 +4797,7 @@ pub const Interpreter = struct {
                 );
             }
         }
+        const result = try self.alloc(target_layout);
         const capture_size = erased_callable_context_capture_offset + capture_value_size;
         const data_ptr = if (assign.reuse) |reuse_local| blk: {
             const reuse_value = try self.getLocalChecked(frame, reuse_local);
@@ -4626,12 +4827,24 @@ pub const Interpreter = struct {
             builtins.erased_callable.allocation_has_refcounted_children,
         );
 
-        const on_drop: ?builtins.erased_callable.OnDropFn = switch (assign.on_drop) {
-            .none => null,
-            .rc_helper => &interpreterErasedCallableOnDrop,
-            .boxy_capture => &interpreterErasedCallableOnDrop,
-            .interpreter_context_drop => &interpreterErasedCallableOnDrop,
+        const capture_drop_kind: ErasedCallableCaptureDrop = switch (assign.on_drop) {
+            .none, .interpreter_context_drop => .none,
+            .rc_helper => .rc_helper,
+            .boxy_capture => .boxy_capture,
         };
+        const drop_layout: ?layout_mod.Idx = switch (assign.on_drop) {
+            .none, .interpreter_context_drop => null,
+            .rc_helper => |helper| helper.layout_idx,
+            .boxy_capture => |plan| plan.capture_layout,
+        };
+        const drop_desc_field_offset: u32 = switch (assign.on_drop) {
+            .boxy_capture => |plan| plan.desc_field_offset,
+            .none, .rc_helper, .interpreter_context_drop => 0,
+        };
+        const on_drop: ?builtins.erased_callable.OnDropFn = if (self.retained_owner != null or capture_drop_kind != .none)
+            &interpreterErasedCallableOnDrop
+        else
+            null;
         const payload = builtins.erased_callable.payloadPtr(data_ptr);
         payload.* = .{
             .callable_fn_ptr = &interpreterErasedCallableTrampoline,
@@ -4639,32 +4852,33 @@ pub const Interpreter = struct {
         };
 
         const context = erasedCallableInterpreterContextFromPayload(data_ptr);
-        const capture_desc = if (assign.capture) |capture_local|
-            frame.localDesc(capture_local) orelse try self.resolveOptionalBoxyDescRef(frame, self.store.getLocal(capture_local).boxy_desc)
+        const capture_value = if (assign.capture) |capture_local|
+            try self.getLocalChecked(frame, capture_local)
         else
             null;
         const result_desc = try self.resolveOptionalBoxyDescRef(frame, assign.result_desc);
+        if (self.retained_owner) |owner| owner.retain();
         context.* = .{
+            .owner = self.retained_owner,
             .interpreter = self,
-            .capture_desc = capture_desc,
             .result_desc = result_desc,
             .proc_id = @intFromEnum(assign.proc),
-            .capture_layout_plus_one = if (assign.capture_layout) |layout_idx| @intFromEnum(layout_idx) + 1 else 0,
+            .drop_layout_plus_one = if (drop_layout) |layout_idx| @intFromEnum(layout_idx) + 1 else 0,
             .capture_value_offset = @intCast(erased_callable_context_capture_offset),
-            .padding = 0,
+            .drop_desc_field_offset = drop_desc_field_offset,
+            .drop_kind = @intFromEnum(capture_drop_kind),
+            .padding = .{ 0, 0, 0 },
         };
 
-        if (assign.capture) |capture_local| {
+        if (capture_value) |value| {
             const capture_layout = assign.capture_layout orelse unreachable;
-            const capture_value = try self.getLocalChecked(frame, capture_local);
             const capture_ptr = erasedCallableInterpreterCaptureValuePtr(data_ptr);
             const size = self.helper.sizeOf(capture_layout);
             if (size > 0) {
-                @memcpy(capture_ptr[0..size], capture_value.ptr[0..size]);
+                @memcpy(capture_ptr[0..size], value.ptr[0..size]);
             }
         }
 
-        const result = try self.alloc(target_layout);
         self.writeBoxedDataPointer(result, data_ptr);
         return result;
     }

--- a/src/interpreter_shim/main.zig
+++ b/src/interpreter_shim/main.zig
@@ -35,7 +35,14 @@ const shim_symbols = builtins.shim_symbols;
 const SharedMemoryAllocator = ipc.SharedMemoryAllocator;
 
 const RuntimeState = struct {
-    shm: SharedMemoryAllocator,
+    source: union(enum) {
+        coordination,
+        embedded: struct {
+            base: usize,
+            len: usize,
+        },
+    },
+    shm: ?SharedMemoryAllocator,
     view: lir.LirImage.ProgramView,
 };
 
@@ -47,7 +54,7 @@ const ShimError = error{
 
 const RuntimeStateError = ipc.CoordinationError || ipc.platform.SharedMemoryError || lir.LirImage.ImageError;
 
-var runtime_state_initialized: bool = false;
+var runtime_state_initialized: std.atomic.Value(bool) = .init(false);
 var runtime_state: RuntimeState = undefined;
 var runtime_state_mutex: std.Io.Mutex = .init;
 
@@ -75,24 +82,35 @@ fn openRuntimeState(gpa: Allocator) RuntimeStateError!RuntimeState {
     const view = try lir.LirImage.viewMappedImageWithAllocator(header, shm.base_ptr, shm.total_size, TargetUsize.native, gpa);
 
     return .{
+        .source = .coordination,
         .shm = shm,
         .view = view,
     };
 }
 
+fn requireCoordinationRuntimeState(ops: *RocOps) ShimError!*RuntimeState {
+    return switch (runtime_state.source) {
+        .coordination => &runtime_state,
+        .embedded => {
+            ops.crash("LIR shim cannot use coordination after installing an embedded image");
+            return error.ImageUnavailable;
+        },
+    };
+}
+
 fn ensureRuntimeState(ops: *RocOps) ShimError!*RuntimeState {
-    if (runtime_state_initialized) return &runtime_state;
+    if (runtime_state_initialized.load(.acquire)) return requireCoordinationRuntimeState(ops);
 
     runtime_state_mutex.lockUncancelable(shimIo());
     defer runtime_state_mutex.unlock(shimIo());
 
-    if (runtime_state_initialized) return &runtime_state;
+    if (runtime_state_initialized.load(.monotonic)) return requireCoordinationRuntimeState(ops);
 
     runtime_state = openRuntimeState(allocator()) catch {
         ops.crash("LIR shim could not map the compiled Roc image");
         return error.ImageUnavailable;
     };
-    runtime_state_initialized = true;
+    runtime_state_initialized.store(true, .release);
     return &runtime_state;
 }
 
@@ -167,18 +185,22 @@ fn evaluateEntrypointInView(
     };
     defer gpa.free(arg_layouts);
 
-    var interpreter = eval.LirInterpreter.initWithBoxyTables(
+    const retained = eval.LirInterpreter.Retained.createWithBoxyTables(
         gpa,
         &view.store,
         &view.layouts,
         eval.LirInterpreter.BoxyTables.fromImageView(view),
         ops,
         .preserve,
+        shimIo(),
     ) catch {
         ops.crash("LIR shim could not initialize the LIR interpreter");
         return error.OutOfMemory;
     };
-    defer interpreter.deinit();
+    defer retained.release();
+    retained.enter();
+    defer retained.leave();
+    const interpreter = &retained.interpreter;
 
     const proc = view.store.getProcSpec(entrypoint.root_proc);
     _ = interpreter.eval(.{
@@ -188,7 +210,7 @@ fn evaluateEntrypointInView(
         .arg_ptr = arg_ptr,
         .ret_ptr = ret_ptr,
     }) catch |err| {
-        reportEvalError(ops, &interpreter, err);
+        reportEvalError(ops, interpreter, err);
         return;
     };
 }
@@ -209,6 +231,39 @@ fn viewEmbeddedLirImage(image_base: *anyopaque, image_len: usize, ops: *RocOps) 
         ops.crash("LIR shim could not view the embedded LIR image");
         return error.ImageUnavailable;
     };
+}
+
+fn requireEmbeddedRuntimeState(base: usize, image_len: usize, ops: *RocOps) ShimError!*RuntimeState {
+    return switch (runtime_state.source) {
+        .embedded => |embedded| if (embedded.base == base and embedded.len == image_len)
+            &runtime_state
+        else mismatch: {
+            ops.crash("LIR shim received a different embedded image after initialization");
+            break :mismatch error.ImageUnavailable;
+        },
+        .coordination => {
+            ops.crash("LIR shim cannot install an embedded image after coordination");
+            return error.ImageUnavailable;
+        },
+    };
+}
+
+fn ensureEmbeddedRuntimeState(image_base: *anyopaque, image_len: usize, ops: *RocOps) ShimError!*RuntimeState {
+    const base = @intFromPtr(image_base);
+    if (runtime_state_initialized.load(.acquire)) return requireEmbeddedRuntimeState(base, image_len, ops);
+
+    runtime_state_mutex.lockUncancelable(shimIo());
+    defer runtime_state_mutex.unlock(shimIo());
+
+    if (runtime_state_initialized.load(.monotonic)) return requireEmbeddedRuntimeState(base, image_len, ops);
+
+    runtime_state = .{
+        .source = .{ .embedded = .{ .base = base, .len = image_len } },
+        .shm = null,
+        .view = viewEmbeddedLirImage(image_base, image_len, ops) catch return error.ImageUnavailable,
+    };
+    runtime_state_initialized.store(true, .release);
+    return &runtime_state;
 }
 
 comptime {
@@ -248,15 +303,14 @@ fn shimEntrypointFromImage(
         return;
     };
 
-    var view = viewEmbeddedLirImage(base, image_len, ops) catch |err| switch (err) {
+    const state = ensureEmbeddedRuntimeState(base, image_len, ops) catch |err| switch (err) {
         error.ImageUnavailable,
         error.InvalidEntrypoint,
         error.OutOfMemory,
         => return,
     };
-    defer view.deinit();
 
-    evaluateEntrypointInView(&view, entry_idx, ops, ret_ptr, arg_ptr) catch |err| switch (err) {
+    evaluateEntrypointInView(&state.view, entry_idx, ops, ret_ptr, arg_ptr) catch |err| switch (err) {
         error.ImageUnavailable,
         error.InvalidEntrypoint,
         error.OutOfMemory,

--- a/test/provided-callable-host/app.roc
+++ b/test/provided-callable-host/app.roc
@@ -1,5 +1,6 @@
 app [
     make_boxed_callable,
+    make_boxed_str_callable,
     drop_boxed_callable,
     make_aliased_boxed_callables,
     make_shared_boxed_callables,
@@ -10,6 +11,9 @@ AliasedCallables : { first : Box(U64 -> U64), second : Box(U64 -> U64) }
 
 make_boxed_callable : U64 -> Box(U64 -> U64)
 make_boxed_callable = |offset| Box.box(|value| value + offset)
+
+make_boxed_str_callable : Str -> Box(U64 -> U64)
+make_boxed_str_callable = |captured| Box.box(|value| value + Str.count_utf8_bytes(captured))
 
 drop_boxed_callable : Box(U64 -> U64) -> {}
 drop_boxed_callable = |_callable| {}

--- a/test/provided-callable-host/platform/host.zig
+++ b/test/provided-callable-host/platform/host.zig
@@ -3,6 +3,9 @@
 //! The host obtains a capturing callable from one provided root and passes
 //! ownership to another provided root which ignores it. The callee must emit
 //! the erased-callable release helper, including its closure-environment drop.
+//! The host also invokes a callable it owns after the provided root that
+//! produced it has returned, which is how a platform resumes a Roc callable it
+//! retained across provided calls.
 
 const std = @import("std");
 const build_options = @import("build_options");
@@ -22,6 +25,7 @@ pub const std_options: std.Options = .{
 };
 
 const RocOps = builtins.host_abi.RocOps;
+const RocStr = builtins.str.RocStr;
 
 const HostEnv = struct {
     gpa: std.heap.DebugAllocator(.{
@@ -37,6 +41,7 @@ const HostEnv = struct {
 };
 
 extern fn roc_make_boxed_callable(offset: u64) callconv(.c) ?[*]u8;
+extern fn roc_make_boxed_str_callable(captured: RocStr) callconv(.c) ?[*]u8;
 extern fn roc_drop_boxed_callable(callable: ?[*]u8) callconv(.c) void;
 extern fn roc_make_aliased_boxed_callables() callconv(.c) ?[*]u8;
 extern fn roc_make_shared_boxed_callables() callconv(.c) ?[*]u8;
@@ -47,6 +52,30 @@ const AliasedCallables = extern struct {
     first: ?[*]u8,
     second: ?[*]u8,
 };
+
+/// Generated fixed-arity argument struct for the app's `U64 -> U64` callables.
+const U64ToU64Args = extern struct {
+    arg0: u64,
+};
+
+/// Invoke a boxed callable the host owns through the erased-callable ABI.
+/// Null reuse borrows the host's reference, so the host still owns the
+/// callable after the call and releases it separately.
+fn callBoxedU64ToU64(ops: *RocOps, callable: [*]u8, arg0: u64) u64 {
+    const payload = builtins.erased_callable.payloadPtr(callable);
+    var call_args = U64ToU64Args{ .arg0 = arg0 };
+    var result: u64 = undefined;
+    var result_desc: ?*const anyopaque = null;
+    payload.callable_fn_ptr(
+        ops,
+        @ptrCast(&result),
+        @ptrCast(&call_args),
+        builtins.erased_callable.capturePtr(callable),
+        null,
+        &result_desc,
+    );
+    return result;
+}
 
 var g_roc_ops: ?*RocOps = null;
 
@@ -68,11 +97,13 @@ fn __main() callconv(.c) void {}
 fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
     const drop_mode = "--run-provided-boxed-callable-drop";
     const identity_mode = "--run-provided-boxed-callable-identity";
+    const post_root_call_mode = "--run-provided-boxed-callable-post-root-call";
     const mode = if (argc == 2) std.mem.span(argv[1]) else "";
     const run_drop = std.mem.eql(u8, mode, drop_mode);
     const run_identity = std.mem.eql(u8, mode, identity_mode);
-    if (!run_drop and !run_identity) {
-        std.debug.print("usage: <app> {s}|{s}\n", .{ drop_mode, identity_mode });
+    const run_post_root_call = std.mem.eql(u8, mode, post_root_call_mode);
+    if (!run_drop and !run_identity and !run_post_root_call) {
+        std.debug.print("usage: <app> {s}|{s}|{s}\n", .{ drop_mode, identity_mode, post_root_call_mode });
         return 1;
     }
 
@@ -115,6 +146,40 @@ fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
         }
 
         std.debug.print("provided boxed callable drop ok\n", .{});
+        return 0;
+    }
+
+    // Repro for https://github.com/roc-lang/roc/issues/10775
+    //
+    // A callable the host owns outlives the provided root that produced it, so
+    // the host can invoke it once that root has returned. A heap string capture
+    // also makes the later callable drop exercise capture teardown through the
+    // retained interpreter.
+    if (run_post_root_call) {
+        const captured_text = "12345678901234567890123456789012345678901";
+        const captured = RocStr.fromSlice(captured_text, &roc_ops);
+        const callable = roc_make_boxed_str_callable(captured) orelse {
+            std.debug.print("provided callable maker returned null\n", .{});
+            return 1;
+        };
+
+        const first_result = callBoxedU64ToU64(&roc_ops, callable, 1);
+        const second_result = callBoxedU64ToU64(&roc_ops, callable, 2);
+        roc_drop_boxed_callable(callable);
+
+        if (first_result != 42 or second_result != 43) {
+            std.debug.print("provided callable calls after its root returned {d}, {d}\n", .{ first_result, second_result });
+            return 1;
+        }
+        if (host_env.dealloc_count != host_env.alloc_count) {
+            std.debug.print("provided callable post-root drop released {d} of {d} allocations\n", .{
+                host_env.dealloc_count,
+                host_env.alloc_count,
+            });
+            return 1;
+        }
+
+        std.debug.print("provided boxed callable post-root call ok\n", .{});
         return 0;
     }
 

--- a/test/provided-callable-host/platform/main.roc
+++ b/test/provided-callable-host/platform/main.roc
@@ -1,6 +1,7 @@
 platform ""
 	requires {
 		make_boxed_callable : U64 -> Box(U64 -> U64),
+		make_boxed_str_callable : Str -> Box(U64 -> U64),
 		drop_boxed_callable : Box(U64 -> U64) -> {},
 		make_aliased_boxed_callables : () -> Box({ first : Box(U64 -> U64), second : Box(U64 -> U64) }),
 		make_shared_boxed_callables : () -> Box({ first : Box(U64 -> U64), second : Box(U64 -> U64) }),
@@ -10,6 +11,7 @@ platform ""
 	packages {}
 	provides {
 		"roc_make_boxed_callable": make_boxed_callable_for_host,
+		"roc_make_boxed_str_callable": make_boxed_str_callable_for_host,
 		"roc_drop_boxed_callable": drop_boxed_callable_for_host,
 		"roc_make_aliased_boxed_callables": make_aliased_boxed_callables_for_host,
 		"roc_make_shared_boxed_callables": make_shared_boxed_callables_for_host,
@@ -35,6 +37,9 @@ platform ""
 
 make_boxed_callable_for_host : U64 -> Box(U64 -> U64)
 make_boxed_callable_for_host = make_boxed_callable
+
+make_boxed_str_callable_for_host : Str -> Box(U64 -> U64)
+make_boxed_str_callable_for_host = make_boxed_str_callable
 
 drop_boxed_callable_for_host : Box(U64 -> U64) -> {}
 drop_boxed_callable_for_host = drop_boxed_callable


### PR DESCRIPTION
Interpreter-created erased callables stored a pointer to a stack-local interpreter that was destroyed when its provided root returned. This pins each interpreter behind a callable-retained lifetime owner, keeps its LIR view and descriptors valid, recycles transient scratch between calls, and preserves correct reentrant and concurrent host invocation.

Fixes #10775.