### PR TITLE
Strip dyld export trie and weak binds from the macOS roc binary

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3475,10 +3475,35 @@ pub fn build(b: *std.Build) void {
     llvm_codegen_module.addImport("roc_target", roc_modules.roc_target);
     llvm_codegen_module.addImport("vendor_llvm_ir", roc_modules.vendor_llvm_ir);
 
+    // On macOS the linked roc executable exports every global symbol of its
+    // statically linked LLVM, LLD, Binaryen, zlib and zstd, and dyld walks
+    // all of that on every launch—~540M instructions before main() runs
+    // (#10992). Every install of the roc CLI for a macOS target goes through
+    // this tool, which removes the export trie and weak-bind info and
+    // rewrites the ad-hoc code signature.
+    const dyld_export_strip_module = b.createModule(.{
+        .root_source_file = b.path("src/cli/macho/DyldExportStrip.zig"),
+        .imports = &.{
+            .{ .name = "vendor_macho", .module = roc_modules.vendor_macho },
+        },
+    });
+    const strip_macho_exports_tool = b.addExecutable(.{
+        .name = "strip_macho_exports",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/build/strip_macho_exports.zig"),
+            .target = b.graph.host,
+            .optimize = .ReleaseSafe,
+            .imports = &.{
+                .{ .name = "dyld_export_strip", .module = dyld_export_strip_module },
+                .{ .name = "build_options", .module = roc_modules.build_options },
+            },
+        }),
+    });
+
     const main_exe_result = addMainExe(b, roc_modules, target, optimize, strip, omit_frame_pointer, use_system_llvm, user_llvm_path, flag_enable_tracy, zstd, compiled_builtins_module, write_compiled_builtins, llvm_codegen_module, flag_enable_tracy, test_filters, true, valgrind_support) orelse return;
     const roc_exe = main_exe_result.exe;
     roc_modules.addAll(roc_exe);
-    _ = install_and_run(b, no_bin, roc_exe, build_roc_step, run_roc_step, run_args);
+    const roc_install_step = install_and_run(b, no_bin, roc_exe, strip_macho_exports_tool, build_roc_step, run_roc_step, run_args);
 
     // Clear the Roc cache when building the compiler to ensure stale cached artifacts aren't used
     const clear_cache_step = createClearCacheStep(b);
@@ -3663,8 +3688,7 @@ pub fn build(b: *std.Build) void {
             exe.root_module.addImport("compiled_builtins", compiled_builtins_module);
             exe.step.dependOn(&write_compiled_builtins.step);
             release_exe_for_llvm_embedded = exe;
-            const install = b.addInstallArtifact(exe, .{});
-            build_release_step.dependOn(&install.step);
+            build_release_step.dependOn(addInstallMaybeStrippedExe(b, exe, strip_macho_exports_tool));
         }
     }
 
@@ -3675,7 +3699,9 @@ pub fn build(b: *std.Build) void {
     // subcommands, echo, and glue. Focus locally with:
     //   zig build run-test-cli -- --suite echo --filter "case name"
     if (!no_bin) {
-        const install = b.addInstallArtifact(roc_exe, .{});
+        // install_and_run only returns null under no_bin, which this branch
+        // excludes.
+        const install_step = roc_install_step.?;
 
         const parallel_cli_runner_exe = b.addExecutable(.{
             .name = "parallel_cli_runner",
@@ -3708,7 +3734,7 @@ pub fn build(b: *std.Build) void {
         if (run_args.len != 0) {
             run_cli.addArgs(run_args);
         }
-        run_cli.step.dependOn(&install.step);
+        run_cli.step.dependOn(install_step);
         run_cli.step.dependOn(build_test_hosts_step);
         run_cli_test_step = &run_cli.step;
         run_test_cli_step.dependOn(&run_cli.step);
@@ -4084,6 +4110,7 @@ pub fn build(b: *std.Build) void {
         b,
         no_bin,
         snapshot_exe,
+        null,
         build_snapshot_tool_step,
         run_snapshot_tool_step,
         run_args,
@@ -4154,6 +4181,7 @@ pub fn build(b: *std.Build) void {
         b,
         no_bin,
         eval_test_exe,
+        null,
         build_test_eval_runner_step,
         run_test_eval_step,
         eval_run_args,
@@ -4216,6 +4244,7 @@ pub fn build(b: *std.Build) void {
         b,
         no_bin,
         eval_host_effects_exe,
+        null,
         build_test_eval_host_effects_runner_step,
         run_test_eval_host_effects_step,
         eval_host_effects_run_args,
@@ -4281,6 +4310,7 @@ pub fn build(b: *std.Build) void {
         b,
         no_bin,
         lambda_mono_differential_exe,
+        null,
         build_test_lambda_mono_differential_step,
         run_test_lambda_mono_differential_step,
         lambda_mono_differential_run_args,
@@ -4318,7 +4348,7 @@ pub fn build(b: *std.Build) void {
             "corpus-only",
         });
         run_simd_lambda_mono.addArgs(run_args);
-        run_simd_lambda_mono.step.dependOn(&install.step);
+        run_simd_lambda_mono.step.dependOn(install);
         run_simd_lambda_mono.step.dependOn(&run_simd_eval.step);
         run_test_simd_differential_step.dependOn(&run_simd_lambda_mono.step);
     } else {
@@ -5785,7 +5815,7 @@ pub fn build(b: *std.Build) void {
         // an explicit type: peer-type resolution on an inline
         // `if (c) &.{x} else &.{}` inside a struct literal field is fragile.
         const snapshot_deps: []const *Step = if (snapshot_exe_install) |install|
-            &.{&install.step}
+            &.{install}
         else
             &.{};
 
@@ -6923,7 +6953,7 @@ fn add_fuzz_target(
     repro_exe.root_module.addImport("fuzz_test", fuzz_obj.root_module);
     repro_exe.root_module.addImport("build_options", roc_modules.build_options);
 
-    _ = install_and_run(b, no_bin, repro_exe, build_repro_step, run_repro_step, run_args);
+    _ = install_and_run(b, no_bin, repro_exe, null, build_repro_step, run_repro_step, run_args);
 
     if (fuzz and build_afl and !no_bin) {
         const fuzz_step = b.step(b.fmt("build-fuzz-{s}", .{name}), b.fmt("Build fuzz executable for {s}", .{name}));
@@ -7714,14 +7744,32 @@ fn addMainExe(
     };
 }
 
+/// Install `exe` into the bin directory. When `macho_strip_tool` is given and
+/// the target is macOS, the installed copy is produced by that tool (which
+/// removes the dyld export trie and weak-bind info; see
+/// src/cli/macho/DyldExportStrip.zig) instead of installing the linked
+/// artifact directly. Returns the step that puts the binary in place.
+fn addInstallMaybeStrippedExe(b: *std.Build, exe: *Step.Compile, macho_strip_tool: ?*Step.Compile) *Step {
+    if (macho_strip_tool) |tool| {
+        if (exe.root_module.resolved_target.?.result.os.tag == .macos) {
+            const strip_run = b.addRunArtifact(tool);
+            strip_run.addFileArg(exe.getEmittedBin());
+            const stripped = strip_run.addOutputFileArg(exe.out_filename);
+            return &b.addInstallBinFile(stripped, exe.out_filename).step;
+        }
+    }
+    return &b.addInstallArtifact(exe, .{}).step;
+}
+
 fn install_and_run(
     b: *std.Build,
     no_bin: bool,
     exe: *Step.Compile,
+    macho_strip_tool: ?*Step.Compile,
     build_step: *Step,
     run_step: *Step,
     run_args: []const []const u8,
-) ?*Step.InstallArtifact {
+) ?*Step {
     if (run_step != build_step) {
         run_step.dependOn(build_step);
     }
@@ -7731,22 +7779,22 @@ fn install_and_run(
         b.getInstallStep().dependOn(&exe.step);
         return null;
     } else {
-        const install = b.addInstallArtifact(exe, .{});
+        const install_step = addInstallMaybeStrippedExe(b, exe, macho_strip_tool);
 
         // Add a step to print success message after build completes
         const success_step = PrintBuildSuccessStep.create(b);
-        success_step.step.dependOn(&install.step);
+        success_step.step.dependOn(install_step);
         build_step.dependOn(&success_step.step);
 
-        b.getInstallStep().dependOn(&install.step);
+        b.getInstallStep().dependOn(install_step);
 
         const run = b.addRunArtifact(exe);
-        run.step.dependOn(&install.step);
+        run.step.dependOn(install_step);
         if (run_args.len != 0) {
             run.addArgs(run_args);
         }
         run_step.dependOn(&run.step);
-        return install;
+        return install_step;
     }
 }
 

--- a/src/build/strip_macho_exports.zig
+++ b/src/build/strip_macho_exports.zig
@@ -1,0 +1,45 @@
+//! Build helper: copy a freshly linked macOS roc executable and remove its
+//! dyld export trie and weak-binding info (see src/cli/macho/DyldExportStrip.zig
+//! for why), then rewrite the ad-hoc code signature the edit invalidated.
+//!
+//! Usage:
+//!   strip_macho_exports <input-binary> <output-binary>
+
+const std = @import("std");
+const build_options = @import("build_options");
+const DyldExportStrip = @import("dyld_export_strip");
+
+/// Largest binary this tool will process; the roc CLI is ~220 MB.
+const max_binary_bytes: usize = 4 * 1024 * 1024 * 1024;
+
+/// Copies the input executable to the output path, strips its dyld export
+/// and weak-bind info, and re-signs it.
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
+    const gpa = gpa_impl.allocator();
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const stderr_file: std.Io.File = .stderr();
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len != 3) {
+        stderr_file.writeStreamingAll(io, "Usage: strip_macho_exports <input-binary> <output-binary>\n") catch {};
+        std.process.exit(2);
+    }
+    const input_path = args[1];
+    const output_path = args[2];
+
+    const contents = try std.Io.Dir.cwd().readFileAlloc(io, input_path, arena, .limited(max_binary_bytes));
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = output_path,
+        .data = contents,
+        .flags = .{ .permissions = .executable_file },
+    });
+
+    _ = try DyldExportStrip.stripFile(io, gpa, arena, output_path);
+}

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -9,7 +9,7 @@ const collections = @import("collections");
 const build_options = @import("build_options");
 const embedded_lld = @import("embedded_lld");
 const stack_probe = embedded_lld.stack_probe;
-const CodeSignature = @import("vendor_macho").CodeSignature;
+const AdHocResign = @import("macho/AdHocResign.zig");
 const DwarfSplice = @import("macho/DwarfSplice.zig");
 const backend = @import("backend");
 const roc_target = @import("roc_target");
@@ -288,16 +288,6 @@ pub const LinkError = error{
 } || std.zig.system.DetectError;
 
 const PatchMachoStackSizeError = std.Io.File.OpenError || std.Io.File.ReadPositionalError || std.Io.File.WritePositionalError || error{
-    NotMacho64,
-    UnexpectedEof,
-};
-
-const ResignMachoError = Allocator.Error || CodeSignature.WriteError || std.Io.File.OpenError || std.Io.File.ReadPositionalError || std.Io.File.WritePositionalError || error{
-    CodeSignatureNotAtEnd,
-    InvalidCodeSignatureSize,
-    MissingLinkeditSegment,
-    MissingTextSegment,
-    NonResizable,
     NotMacho64,
     UnexpectedEof,
 };
@@ -950,7 +940,7 @@ pub fn link(ctx: *CliCtx, config: LinkConfig) LinkError!void {
         // Patching invalidated the ad-hoc code signature ld64.lld wrote; on
         // macOS 14+ the kernel SIGKILLs (137) binaries with bad signatures,
         // so rewrite the signature in place.
-        resignMachoAdHoc(ctx, config.output_path) catch |err| {
+        AdHocResign.resign(ctx.io.std_io, ctx.gpa, ctx.arena, config.output_path) catch |err| {
             std.log.warn("Failed to re-sign {s} after stacksize patch: {}", .{ config.output_path, err });
         };
     }
@@ -1086,8 +1076,6 @@ fn optimizeWasmOutput(ctx: *CliCtx, config: LinkConfig) LinkError!void {
 
 const macho = std.macho;
 
-const deterministic_macho_code_signature_identifier = "roc";
-
 /// Patch a freshly-linked macOS executable's LC_MAIN stacksize field. See the
 /// callsite in `link` for why this is needed.
 fn patchMachoStackSize(path: []const u8, stacksize: u64, io: std.Io) PatchMachoStackSizeError!void {
@@ -1114,106 +1102,6 @@ fn patchMachoStackSize(path: []const u8, stacksize: u64, io: std.Io) PatchMachoS
         offset += lc.cmdsize;
     }
     // No LC_MAIN—leave as-is (e.g. dylibs or unusual layouts).
-}
-
-/// Rewrite a Mach-O binary's ad-hoc code signature in place. The signature
-/// blob is the last content in the file, recorded by LC_CODE_SIGNATURE; we
-/// recompute the page hashes over everything before it and write a fresh
-/// linker-style ad-hoc signature into that extent.
-fn resignMachoAdHoc(ctx: *CliCtx, path: []const u8) ResignMachoError!void {
-    const io = ctx.io.std_io;
-    const gpa = ctx.gpa;
-
-    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_write });
-    defer file.close(io);
-
-    var header: macho.mach_header_64 = undefined;
-    const header_n = try file.readPositionalAll(io, std.mem.asBytes(&header), 0);
-    if (header_n != @sizeOf(macho.mach_header_64)) return error.UnexpectedEof;
-    if (header.magic != macho.MH_MAGIC_64) return error.NotMacho64;
-
-    const cmds_buf = try ctx.arena.alignedAlloc(u8, .of(macho.segment_command_64), header.sizeofcmds);
-    const cmds_n = try file.readPositionalAll(io, cmds_buf, @sizeOf(macho.mach_header_64));
-    if (cmds_n != header.sizeofcmds) return error.UnexpectedEof;
-
-    var cs_cmd: ?*align(8) macho.linkedit_data_command = null;
-    var text_seg: ?*align(8) macho.segment_command_64 = null;
-    var linkedit_seg: ?*align(8) macho.segment_command_64 = null;
-
-    var offset: usize = 0;
-    var i: u32 = 0;
-    while (i < header.ncmds) : (i += 1) {
-        if (offset + @sizeOf(macho.load_command) > cmds_buf.len) return error.UnexpectedEof;
-        const lc: *align(8) macho.load_command = @ptrCast(@alignCast(cmds_buf.ptr + offset));
-        if (lc.cmd == .CODE_SIGNATURE) {
-            cs_cmd = @ptrCast(lc);
-        } else if (lc.cmd == .SEGMENT_64) {
-            const seg: *align(8) macho.segment_command_64 = @ptrCast(lc);
-            if (std.mem.eql(u8, seg.segName(), "__TEXT")) {
-                text_seg = seg;
-            } else if (std.mem.eql(u8, seg.segName(), "__LINKEDIT")) {
-                linkedit_seg = seg;
-            }
-        }
-        offset += lc.cmdsize;
-    }
-
-    // No LC_CODE_SIGNATURE means the linker did not sign this binary (ld64.lld
-    // only ad-hoc signs arm64 by default), so patching invalidated nothing and
-    // the kernel does not require a signature.
-    const cs = cs_cmd orelse return;
-    const text = text_seg orelse return error.MissingTextSegment;
-    const linkedit = linkedit_seg orelse return error.MissingLinkeditSegment;
-
-    const page_size: u16 = if (header.cputype == macho.CPU_TYPE_ARM64) 0x4000 else 0x1000;
-    const ident = deterministic_macho_code_signature_identifier;
-
-    // The signature hashes every page before LC_CODE_SIGNATURE's dataoff,
-    // including page 0 with the load commands. Its exact size is known up
-    // front (one CodeDirectory blob, no special slots), so any load command
-    // size changes must be written back before hashing.
-    const hash_size = std.crypto.hash.sha2.Sha256.digest_length;
-    const total_pages = std.mem.alignForward(usize, cs.dataoff, page_size) / page_size;
-    const exact_size = @sizeOf(macho.SuperBlob) + @sizeOf(macho.BlobIndex) +
-        @sizeOf(macho.CodeDirectory) + ident.len + 1 + total_pages * hash_size;
-
-    const old_datasize = cs.datasize;
-    const old_sig_end: u64 = @as(u64, cs.dataoff) + @as(u64, old_datasize);
-    if (try file.length(io) != old_sig_end) return error.CodeSignatureNotAtEnd;
-
-    if (exact_size != old_datasize) {
-        cs.datasize = @intCast(exact_size);
-        if (exact_size > old_datasize) {
-            const grow: u64 = @intCast(exact_size - old_datasize);
-            linkedit.filesize += grow;
-        } else {
-            const shrink: u64 = @intCast(old_datasize - exact_size);
-            if (linkedit.filesize < shrink) return error.InvalidCodeSignatureSize;
-            linkedit.filesize -= shrink;
-        }
-        linkedit.vmsize = std.mem.alignForward(u64, linkedit.filesize, page_size);
-        try file.writePositionalAll(io, cmds_buf, @sizeOf(macho.mach_header_64));
-    }
-
-    var code_sig = CodeSignature.init(page_size);
-    defer code_sig.deinit(gpa);
-    code_sig.code_directory.ident = ident;
-
-    var sig_bytes: std.Io.Writer.Allocating = .init(gpa);
-    defer sig_bytes.deinit();
-    try code_sig.writeAdhocSignature(gpa, io, .{
-        .file = file,
-        .exec_seg_base = text.fileoff,
-        .exec_seg_limit = text.filesize,
-        .file_size = cs.dataoff,
-        .dylib = header.filetype == macho.MH_DYLIB,
-    }, &sig_bytes.writer);
-
-    const sig = sig_bytes.written();
-    std.debug.assert(sig.len == exact_size);
-    try file.writePositionalAll(io, sig, cs.dataoff);
-    const new_sig_end: u64 = @as(u64, cs.dataoff) + @as(u64, @intCast(sig.len));
-    try file.setLength(io, new_sig_end);
 }
 
 fn findArg(args: []const []const u8, needle: []const u8) ?usize {

--- a/src/cli/macho/AdHocResign.zig
+++ b/src/cli/macho/AdHocResign.zig
@@ -1,0 +1,121 @@
+//! Rewrites a Mach-O binary's ad-hoc code signature in place after other
+//! post-link edits have invalidated it. On macOS 14+ the kernel SIGKILLs
+//! (exit 137) binaries whose signature does not match their contents, so any
+//! step that patches a signed binary must finish by rewriting the signature.
+
+const std = @import("std");
+const macho = std.macho;
+const Allocator = std.mem.Allocator;
+const CodeSignature = @import("vendor_macho").CodeSignature;
+
+/// Identifier embedded in every signature this module writes. Constant so
+/// that identical binaries sign to identical bytes.
+pub const deterministic_identifier = "roc";
+
+/// Errors from `resign`.
+pub const Error = Allocator.Error || CodeSignature.WriteError || std.Io.File.OpenError || std.Io.File.ReadPositionalError || std.Io.File.WritePositionalError || error{
+    CodeSignatureNotAtEnd,
+    InvalidCodeSignatureSize,
+    MissingLinkeditSegment,
+    MissingTextSegment,
+    NonResizable,
+    NotMacho64,
+    UnexpectedEof,
+};
+
+/// Rewrite the ad-hoc code signature of the Mach-O binary at `path`. The
+/// signature blob is the last content in the file, recorded by
+/// LC_CODE_SIGNATURE; the page hashes are recomputed over everything before
+/// it and a fresh linker-style ad-hoc signature is written into that extent.
+/// A binary with no LC_CODE_SIGNATURE is left untouched: the linker did not
+/// sign it (ld64.lld only ad-hoc signs arm64 by default), so patching
+/// invalidated nothing and the kernel does not require a signature.
+pub fn resign(io: std.Io, gpa: Allocator, arena: Allocator, path: []const u8) Error!void {
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_write });
+    defer file.close(io);
+
+    var header: macho.mach_header_64 = undefined;
+    const header_n = try file.readPositionalAll(io, std.mem.asBytes(&header), 0);
+    if (header_n != @sizeOf(macho.mach_header_64)) return error.UnexpectedEof;
+    if (header.magic != macho.MH_MAGIC_64) return error.NotMacho64;
+
+    const cmds_buf = try arena.alignedAlloc(u8, .of(macho.segment_command_64), header.sizeofcmds);
+    const cmds_n = try file.readPositionalAll(io, cmds_buf, @sizeOf(macho.mach_header_64));
+    if (cmds_n != header.sizeofcmds) return error.UnexpectedEof;
+
+    var cs_cmd: ?*align(8) macho.linkedit_data_command = null;
+    var text_seg: ?*align(8) macho.segment_command_64 = null;
+    var linkedit_seg: ?*align(8) macho.segment_command_64 = null;
+
+    var offset: usize = 0;
+    var i: u32 = 0;
+    while (i < header.ncmds) : (i += 1) {
+        if (offset + @sizeOf(macho.load_command) > cmds_buf.len) return error.UnexpectedEof;
+        const lc: *align(8) macho.load_command = @ptrCast(@alignCast(cmds_buf.ptr + offset));
+        if (lc.cmd == .CODE_SIGNATURE) {
+            cs_cmd = @ptrCast(lc);
+        } else if (lc.cmd == .SEGMENT_64) {
+            const seg: *align(8) macho.segment_command_64 = @ptrCast(lc);
+            if (std.mem.eql(u8, seg.segName(), "__TEXT")) {
+                text_seg = seg;
+            } else if (std.mem.eql(u8, seg.segName(), "__LINKEDIT")) {
+                linkedit_seg = seg;
+            }
+        }
+        offset += lc.cmdsize;
+    }
+
+    const cs = cs_cmd orelse return;
+    const text = text_seg orelse return error.MissingTextSegment;
+    const linkedit = linkedit_seg orelse return error.MissingLinkeditSegment;
+
+    const page_size: u16 = if (header.cputype == macho.CPU_TYPE_ARM64) 0x4000 else 0x1000;
+    const ident = deterministic_identifier;
+
+    // The signature hashes every page before LC_CODE_SIGNATURE's dataoff,
+    // including page 0 with the load commands. Its exact size is known up
+    // front (one CodeDirectory blob, no special slots), so any load command
+    // size changes must be written back before hashing.
+    const hash_size = std.crypto.hash.sha2.Sha256.digest_length;
+    const total_pages = std.mem.alignForward(usize, cs.dataoff, page_size) / page_size;
+    const exact_size = @sizeOf(macho.SuperBlob) + @sizeOf(macho.BlobIndex) +
+        @sizeOf(macho.CodeDirectory) + ident.len + 1 + total_pages * hash_size;
+
+    const old_datasize = cs.datasize;
+    const old_sig_end: u64 = @as(u64, cs.dataoff) + @as(u64, old_datasize);
+    if (try file.length(io) != old_sig_end) return error.CodeSignatureNotAtEnd;
+
+    if (exact_size != old_datasize) {
+        cs.datasize = @intCast(exact_size);
+        if (exact_size > old_datasize) {
+            const grow: u64 = @intCast(exact_size - old_datasize);
+            linkedit.filesize += grow;
+        } else {
+            const shrink: u64 = @intCast(old_datasize - exact_size);
+            if (linkedit.filesize < shrink) return error.InvalidCodeSignatureSize;
+            linkedit.filesize -= shrink;
+        }
+        linkedit.vmsize = std.mem.alignForward(u64, linkedit.filesize, page_size);
+        try file.writePositionalAll(io, cmds_buf, @sizeOf(macho.mach_header_64));
+    }
+
+    var code_sig = CodeSignature.init(page_size);
+    defer code_sig.deinit(gpa);
+    code_sig.code_directory.ident = ident;
+
+    var sig_bytes: std.Io.Writer.Allocating = .init(gpa);
+    defer sig_bytes.deinit();
+    try code_sig.writeAdhocSignature(gpa, io, .{
+        .file = file,
+        .exec_seg_base = text.fileoff,
+        .exec_seg_limit = text.filesize,
+        .file_size = cs.dataoff,
+        .dylib = header.filetype == macho.MH_DYLIB,
+    }, &sig_bytes.writer);
+
+    const sig = sig_bytes.written();
+    std.debug.assert(sig.len == exact_size);
+    try file.writePositionalAll(io, sig, cs.dataoff);
+    const new_sig_end: u64 = @as(u64, cs.dataoff) + @as(u64, @intCast(sig.len));
+    try file.setLength(io, new_sig_end);
+}

--- a/src/cli/macho/DyldExportStrip.zig
+++ b/src/cli/macho/DyldExportStrip.zig
@@ -1,0 +1,307 @@
+//! Removes the dyld export trie and weak-binding info from a Mach-O
+//! executable, so that dyld stops walking them on every launch.
+//!
+//! A Mach-O executable statically linking LLVM, LLD, Binaryen, zlib and zstd
+//! carries tens of thousands of export-trie entries and thousands of weak
+//! external C++ symbols, and dyld processes all of them before main() runs
+//! (hundreds of millions of instructions per launch; roc-lang/roc#10992).
+//! None of it is consumed at runtime: the roc CLI loads only libSystem (which
+//! defines no C++ weak symbols to coalesce with), the temporary dylibs it
+//! dlopens bind only to libSystem under two-level namespace, and its
+//! dlsym(RTLD_DEFAULT) lookups resolve builtins through an in-process table.
+//!
+//! The rewrite zeroes the export and weak-bind ranges recorded in
+//! LC_DYLD_INFO/LC_DYLD_INFO_ONLY (and LC_DYLD_EXPORTS_TRIE if present) and
+//! clears the MH_WEAK_DEFINES and MH_BINDS_TO_WEAK header flags that gate
+//! dyld's weak-coalescing pass. This is the same end state Apple's linker
+//! produces for `-no_exported_symbols` plus hidden visibility. It applies
+//! only to executables; a dylib's exports are its interface and must stay.
+
+const std = @import("std");
+const macho = std.macho;
+const Allocator = std.mem.Allocator;
+const AdHocResign = @import("AdHocResign.zig");
+
+/// Errors from `stripHeader`.
+pub const StripError = error{
+    NotMacho64,
+    NotExecutable,
+    TruncatedLoadCommands,
+    UnsupportedDyldLayout,
+};
+
+/// A byte range of the stripped file whose contents are no longer referenced
+/// by any load command.
+pub const DeadRange = struct {
+    /// File offset of the start of the range.
+    off: u32,
+    /// Length of the range in bytes.
+    size: u32,
+};
+
+/// What `stripHeader` removed: the now-unreferenced byte ranges that held
+/// export info and the weak-bind opcodes. Any range may be empty when the
+/// corresponding info was already absent.
+pub const Summary = struct {
+    /// Range LC_DYLD_INFO(_ONLY) recorded for the export trie.
+    export_info: DeadRange,
+    /// Range LC_DYLD_EXPORTS_TRIE recorded for the export trie.
+    export_trie: DeadRange,
+    /// Range that held the weak-bind opcodes.
+    weak_bind_info: DeadRange,
+};
+
+/// Rewrite the Mach-O header and load commands at the start of `bytes`:
+/// zero the export and weak-bind ranges out of the dyld info load commands
+/// and clear MH_WEAK_DEFINES|MH_BINDS_TO_WEAK. `bytes` must hold at least
+/// the full header and load commands; the rest of the file is not needed.
+/// Idempotent: stripping an already-stripped image succeeds and reports
+/// empty ranges.
+pub fn stripHeader(bytes: []u8) StripError!Summary {
+    if (bytes.len < @sizeOf(macho.mach_header_64)) return error.NotMacho64;
+    const header: *align(1) macho.mach_header_64 = @ptrCast(bytes.ptr);
+    if (header.magic != macho.MH_MAGIC_64) return error.NotMacho64;
+    if (header.filetype != macho.MH_EXECUTE) return error.NotExecutable;
+
+    const cmds_end = @sizeOf(macho.mach_header_64) + @as(usize, header.sizeofcmds);
+    if (bytes.len < cmds_end) return error.TruncatedLoadCommands;
+
+    var summary: Summary = .{
+        .export_info = .{ .off = 0, .size = 0 },
+        .export_trie = .{ .off = 0, .size = 0 },
+        .weak_bind_info = .{ .off = 0, .size = 0 },
+    };
+
+    var offset: usize = @sizeOf(macho.mach_header_64);
+    var i: u32 = 0;
+    while (i < header.ncmds) : (i += 1) {
+        if (offset + @sizeOf(macho.load_command) > cmds_end) return error.TruncatedLoadCommands;
+        const lc: *align(1) macho.load_command = @ptrCast(bytes.ptr + offset);
+        if (lc.cmdsize < @sizeOf(macho.load_command) or offset + lc.cmdsize > cmds_end) {
+            return error.TruncatedLoadCommands;
+        }
+        switch (lc.cmd) {
+            .DYLD_INFO, .DYLD_INFO_ONLY => {
+                if (lc.cmdsize < @sizeOf(macho.dyld_info_command)) return error.TruncatedLoadCommands;
+                const info: *align(1) macho.dyld_info_command = @ptrCast(lc);
+                summary.export_info = .{ .off = info.export_off, .size = info.export_size };
+                summary.weak_bind_info = .{ .off = info.weak_bind_off, .size = info.weak_bind_size };
+                info.export_off = 0;
+                info.export_size = 0;
+                info.weak_bind_off = 0;
+                info.weak_bind_size = 0;
+            },
+            .DYLD_EXPORTS_TRIE => {
+                if (lc.cmdsize < @sizeOf(macho.linkedit_data_command)) return error.TruncatedLoadCommands;
+                const trie: *align(1) macho.linkedit_data_command = @ptrCast(lc);
+                summary.export_trie = .{ .off = trie.dataoff, .size = trie.datasize };
+                trie.dataoff = 0;
+                trie.datasize = 0;
+            },
+            // Chained fixups encode binds in a format this rewrite does not
+            // parse, so weak binds could survive it undetected. The linker
+            // producing the roc CLI emits classic LC_DYLD_INFO_ONLY; if that
+            // ever changes, fail the build loudly instead of shipping a
+            // binary that silently keeps its launch cost.
+            .DYLD_CHAINED_FIXUPS => return error.UnsupportedDyldLayout,
+            .NONE,
+            .SEGMENT,
+            .SYMTAB,
+            .SYMSEG,
+            .THREAD,
+            .UNIXTHREAD,
+            .LOADFVMLIB,
+            .IDFVMLIB,
+            .IDENT,
+            .FVMFILE,
+            .PREPAGE,
+            .DYSYMTAB,
+            .LOAD_DYLIB,
+            .ID_DYLIB,
+            .LOAD_DYLINKER,
+            .ID_DYLINKER,
+            .PREBOUND_DYLIB,
+            .ROUTINES,
+            .SUB_FRAMEWORK,
+            .SUB_UMBRELLA,
+            .SUB_CLIENT,
+            .SUB_LIBRARY,
+            .TWOLEVEL_HINTS,
+            .PREBIND_CKSUM,
+            .LOAD_WEAK_DYLIB,
+            .SEGMENT_64,
+            .ROUTINES_64,
+            .UUID,
+            .RPATH,
+            .CODE_SIGNATURE,
+            .SEGMENT_SPLIT_INFO,
+            .REEXPORT_DYLIB,
+            .LAZY_LOAD_DYLIB,
+            .ENCRYPTION_INFO,
+            .LOAD_UPWARD_DYLIB,
+            .VERSION_MIN_MACOSX,
+            .VERSION_MIN_IPHONEOS,
+            .FUNCTION_STARTS,
+            .DYLD_ENVIRONMENT,
+            .MAIN,
+            .DATA_IN_CODE,
+            .SOURCE_VERSION,
+            .DYLIB_CODE_SIGN_DRS,
+            .ENCRYPTION_INFO_64,
+            .LINKER_OPTION,
+            .LINKER_OPTIMIZATION_HINT,
+            .VERSION_MIN_TVOS,
+            .VERSION_MIN_WATCHOS,
+            .NOTE,
+            .BUILD_VERSION,
+            _,
+            => {},
+        }
+        offset += lc.cmdsize;
+    }
+
+    header.flags &= ~@as(u32, macho.MH_WEAK_DEFINES | macho.MH_BINDS_TO_WEAK);
+    return summary;
+}
+
+/// Errors from `stripFile`.
+pub const StripFileError = StripError || AdHocResign.Error || Allocator.Error || std.Io.File.OpenError || std.Io.File.ReadPositionalError || std.Io.File.WritePositionalError || error{DeadRangeOutOfBounds};
+
+/// Strip the executable at `path` in place: rewrite its header and load
+/// commands via `stripHeader`, zero the dead byte ranges the load commands
+/// no longer reference (zeroed pages cost nothing after compression, and
+/// leftover symbol names would be misleading to inspection tools), and
+/// rewrite the ad-hoc code signature the edits invalidated.
+pub fn stripFile(io: std.Io, gpa: Allocator, arena: Allocator, path: []const u8) StripFileError!Summary {
+    const summary = blk: {
+        var file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_write });
+        defer file.close(io);
+
+        const file_len = try file.length(io);
+
+        var header: macho.mach_header_64 = undefined;
+        const header_n = try file.readPositionalAll(io, std.mem.asBytes(&header), 0);
+        if (header_n != @sizeOf(macho.mach_header_64)) return error.NotMacho64;
+        if (header.magic != macho.MH_MAGIC_64) return error.NotMacho64;
+
+        const prefix_len = @sizeOf(macho.mach_header_64) + @as(usize, header.sizeofcmds);
+        const prefix = try arena.alloc(u8, prefix_len);
+        const prefix_n = try file.readPositionalAll(io, prefix, 0);
+        if (prefix_n != prefix_len) return error.TruncatedLoadCommands;
+
+        const summary = try stripHeader(prefix);
+        try file.writePositionalAll(io, prefix, 0);
+
+        for ([_]DeadRange{ summary.export_info, summary.export_trie, summary.weak_bind_info }) |range| {
+            if (range.size == 0) continue;
+            if (range.off < prefix_len) return error.DeadRangeOutOfBounds;
+            if (@as(u64, range.off) + @as(u64, range.size) > file_len) return error.DeadRangeOutOfBounds;
+            const zeros = try arena.alloc(u8, range.size);
+            @memset(zeros, 0);
+            try file.writePositionalAll(io, zeros, range.off);
+        }
+        break :blk summary;
+    };
+
+    try AdHocResign.resign(io, gpa, arena, path);
+    return summary;
+}
+
+const testing = std.testing;
+
+/// Byte layout used by the tests: header, one LC_DYLD_INFO_ONLY, one
+/// LC_DYLD_EXPORTS_TRIE.
+fn testImage(buf: []u8, filetype: u32, flags: u32) void {
+    @memset(buf, 0);
+    const header: *align(1) macho.mach_header_64 = @ptrCast(buf.ptr);
+    header.magic = macho.MH_MAGIC_64;
+    header.filetype = filetype;
+    header.flags = flags;
+    header.ncmds = 2;
+    header.sizeofcmds = @sizeOf(macho.dyld_info_command) + @sizeOf(macho.linkedit_data_command);
+
+    const info: *align(1) macho.dyld_info_command = @ptrCast(buf.ptr + @sizeOf(macho.mach_header_64));
+    info.cmd = .DYLD_INFO_ONLY;
+    info.cmdsize = @sizeOf(macho.dyld_info_command);
+    info.rebase_off = 100;
+    info.rebase_size = 10;
+    info.bind_off = 110;
+    info.bind_size = 20;
+    info.weak_bind_off = 130;
+    info.weak_bind_size = 40;
+    info.lazy_bind_off = 170;
+    info.lazy_bind_size = 5;
+    info.export_off = 175;
+    info.export_size = 80;
+
+    const trie: *align(1) macho.linkedit_data_command = @ptrCast(buf.ptr + @sizeOf(macho.mach_header_64) + @sizeOf(macho.dyld_info_command));
+    trie.cmd = .DYLD_EXPORTS_TRIE;
+    trie.cmdsize = @sizeOf(macho.linkedit_data_command);
+    trie.dataoff = 255;
+    trie.datasize = 33;
+}
+
+test "stripHeader zeroes export and weak-bind info and clears weak flags" {
+    var buf: [512]u8 = undefined;
+    testImage(&buf, macho.MH_EXECUTE, macho.MH_PIE | macho.MH_WEAK_DEFINES | macho.MH_BINDS_TO_WEAK);
+
+    const summary = try stripHeader(&buf);
+    try testing.expectEqual(@as(u32, 175), summary.export_info.off);
+    try testing.expectEqual(@as(u32, 80), summary.export_info.size);
+    try testing.expectEqual(@as(u32, 255), summary.export_trie.off);
+    try testing.expectEqual(@as(u32, 33), summary.export_trie.size);
+    try testing.expectEqual(@as(u32, 130), summary.weak_bind_info.off);
+    try testing.expectEqual(@as(u32, 40), summary.weak_bind_info.size);
+
+    const header: *align(1) macho.mach_header_64 = @ptrCast(&buf);
+    try testing.expectEqual(@as(u32, macho.MH_PIE), header.flags);
+
+    const info: *align(1) macho.dyld_info_command = @ptrCast(buf[@sizeOf(macho.mach_header_64)..].ptr);
+    try testing.expectEqual(@as(u32, 0), info.export_off);
+    try testing.expectEqual(@as(u32, 0), info.export_size);
+    try testing.expectEqual(@as(u32, 0), info.weak_bind_off);
+    try testing.expectEqual(@as(u32, 0), info.weak_bind_size);
+    // Rebase, bind and lazy-bind info stay untouched.
+    try testing.expectEqual(@as(u32, 100), info.rebase_off);
+    try testing.expectEqual(@as(u32, 20), info.bind_size);
+    try testing.expectEqual(@as(u32, 5), info.lazy_bind_size);
+}
+
+test "stripHeader is idempotent" {
+    var buf: [512]u8 = undefined;
+    testImage(&buf, macho.MH_EXECUTE, macho.MH_WEAK_DEFINES | macho.MH_BINDS_TO_WEAK);
+
+    _ = try stripHeader(&buf);
+    const second = try stripHeader(&buf);
+    try testing.expectEqual(@as(u32, 0), second.export_info.size);
+    try testing.expectEqual(@as(u32, 0), second.export_trie.size);
+    try testing.expectEqual(@as(u32, 0), second.weak_bind_info.size);
+}
+
+test "stripHeader rejects dylibs" {
+    var buf: [512]u8 = undefined;
+    testImage(&buf, macho.MH_DYLIB, 0);
+    try testing.expectError(error.NotExecutable, stripHeader(&buf));
+}
+
+test "stripHeader rejects chained fixups" {
+    var buf: [512]u8 = undefined;
+    testImage(&buf, macho.MH_EXECUTE, 0);
+    const info: *align(1) macho.load_command = @ptrCast(buf[@sizeOf(macho.mach_header_64)..].ptr);
+    info.cmd = .DYLD_CHAINED_FIXUPS;
+    try testing.expectError(error.UnsupportedDyldLayout, stripHeader(&buf));
+}
+
+test "stripHeader rejects non-Mach-O input" {
+    var buf: [512]u8 = @splat(0);
+    try testing.expectError(error.NotMacho64, stripHeader(&buf));
+    try testing.expectError(error.NotMacho64, stripHeader(buf[0..4]));
+}
+
+test "stripHeader rejects load commands past sizeofcmds" {
+    var buf: [512]u8 = undefined;
+    testImage(&buf, macho.MH_EXECUTE, 0);
+    const header: *align(1) macho.mach_header_64 = @ptrCast(&buf);
+    header.sizeofcmds = @sizeOf(macho.dyld_info_command); // second command now out of bounds
+    try testing.expectError(error.TruncatedLoadCommands, stripHeader(&buf));
+}

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -123,6 +123,7 @@ comptime {
         std.testing.refAllDecls(@import("test/platform_config.zig"));
         std.testing.refAllDecls(@import("ReplLine.zig"));
         std.testing.refAllDecls(@import("ReplSession.zig"));
+        std.testing.refAllDecls(@import("macho/DyldExportStrip.zig"));
     }
 }
 const linker = @import("linker.zig");


### PR DESCRIPTION
On macOS, every `roc` invocation spent ~540 million instructions inside dyld before `main()` ran (#10992). The linked executable exports all 41,805 global symbols of its statically linked LLVM, lld, Binaryen, zlib and zstd (a 2.4 MB export trie), and its 8,748 weak external C++ symbols produce 1 MB of weak-bind opcodes plus the MH_WEAK_DEFINES/MH_BINDS_TO_WEAK header flags that make dyld run weak coalescing across every loaded image on every launch. None of that is consumed at runtime: the binary loads only libSystem (which has no C++ weak symbols to coalesce with), the temporary dylibs it dlopens bind only to libSystem under two-level namespace, and dev-backend dlsym(RTLD_DEFAULT) lookups resolve builtins through an in-process table before ever reaching dyld — the trie contains no compiler-rt, libc, or roc host symbols at all. The Linux build of the same commit already exports nothing and starts in ~4 ms with the identical statically-linked LLVM inside.

This makes every install of the roc CLI for a macOS target go through a small build tool that zeroes the export-trie and weak-bind ranges out of LC_DYLD_INFO_ONLY, clears the two weak flags, zeroes the now-dead linkedit bytes, and rewrites the ad-hoc code signature the edits invalidated. The signer moves from cli/linker.zig into src/cli/macho/AdHocResign.zig so the tool and the linker share it. This is the same end state Apple's toolchain produces for -no_exported_symbols plus hidden visibility; Zig's build system exposes no way to request it at link time (current Zig master still exports every default-visibility global from Mach-O executables, and only its Wasm linker honors an exported-symbols list). What remains for dyld afterwards is 51 KB of rebase opcodes, 304 bytes of binds and 686 static initializers, which the Linux numbers bound at a few milliseconds.