### PR TITLE
Resolve names bound by a top-level destructure to their def in the dependency graph

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -4754,6 +4754,12 @@ fn poisonRecursiveNonFunctionDefs(
         region: Region,
     };
 
+    const DependencyGraph = @import("DependencyGraph.zig");
+    var binders: std.ArrayList(CIR.Pattern.Idx) = .empty;
+    defer binders.deinit(self.env.gpa);
+    var binder_scratch: std.ArrayList(CIR.Pattern.Idx) = .empty;
+    defer binder_scratch.deinit(self.env.gpa);
+
     for (eval_order.sccs) |scc| {
         if (!scc.is_recursive) continue;
 
@@ -4764,12 +4770,18 @@ fn poisonRecursiveNonFunctionDefs(
             const def = self.env.store.getDef(def_idx);
             if (isRecursiveFunctionDefExpr(self.env.store.getExpr(def.expr))) continue;
 
-            const ident = defPatternIdent(&self.env.store, def.pattern) orelse continue;
-            try defs_to_poison.append(self.env.gpa, .{
-                .def_idx = def_idx,
-                .ident = ident,
-                .region = self.env.store.getPatternRegion(def.pattern),
-            });
+            // Every name the def binds is computed from the one cyclic
+            // value, so each is circular: the single name of a plain def,
+            // or each name a destructure binds.
+            binders.clearRetainingCapacity();
+            try DependencyGraph.appendPatternBinders(self.env, def.pattern, &binders, &binder_scratch, self.env.gpa);
+            for (binders.items) |binder| {
+                try defs_to_poison.append(self.env.gpa, .{
+                    .def_idx = def_idx,
+                    .ident = defPatternIdent(&self.env.store, binder).?,
+                    .region = self.env.store.getPatternRegion(binder),
+                });
+            }
         }
 
         std.mem.sort(RecursiveNonFunctionDef, defs_to_poison.items, {}, struct {
@@ -4784,13 +4796,23 @@ fn poisonRecursiveNonFunctionDefs(
             }
         }.lessThan);
 
+        var poisoned_defs: std.AutoHashMapUnmanaged(CIR.Def.Idx, void) = .{};
+        defer poisoned_defs.deinit(self.env.gpa);
         for (defs_to_poison.items) |def_to_poison| {
-            const malformed_idx = try self.env.pushMalformed(CIR.Expr.Idx, Diagnostic{
+            const diagnostic = Diagnostic{
                 .circular_value_definition = .{
                     .ident = def_to_poison.ident,
                     .region = def_to_poison.region,
                 },
-            });
+            };
+            // A destructuring def reports once per bound name; its one
+            // right-hand side is replaced once.
+            const poisoned = try poisoned_defs.getOrPut(self.env.gpa, def_to_poison.def_idx);
+            if (poisoned.found_existing) {
+                try self.env.pushDiagnostic(diagnostic);
+                continue;
+            }
+            const malformed_idx = try self.env.pushMalformed(CIR.Expr.Idx, diagnostic);
             self.env.store.setDefExpr(def_to_poison.def_idx, malformed_idx);
         }
     }

--- a/src/canonicalize/DependencyGraph.zig
+++ b/src/canonicalize/DependencyGraph.zig
@@ -297,9 +297,12 @@ const DemandAnalyzer = struct {
             try analyzer.graph_def_set.put(allocator, def_idx, {});
         }
 
+        var binders: std.ArrayList(CIR.Pattern.Idx) = .empty;
+        defer binders.deinit(allocator);
+        var binder_scratch: std.ArrayList(CIR.Pattern.Idx) = .empty;
+        defer binder_scratch.deinit(allocator);
         for (summary_defs) |def_idx| {
-            const def = cir.store.getDef(def_idx);
-            try analyzer.pattern_to_def.put(allocator, def.pattern, def_idx);
+            try mapDefBinderPatterns(cir, &analyzer.pattern_to_def, def_idx, &binders, &binder_scratch, allocator);
         }
 
         for (resolved_literal_targets) |target| {
@@ -1050,61 +1053,136 @@ const DemandAnalyzer = struct {
         pending.append(stack_allocator, root) catch return false;
         while (pending.pop()) |current| {
             if (current == needle) return true;
-            switch (self.cir.store.getPattern(current)) {
-                .as => |as_pattern| pending.append(stack_allocator, as_pattern.pattern) catch return false,
-                .applied_tag => |tag| {
-                    for (self.cir.store.slicePatterns(tag.args)) |arg| {
-                        pending.append(stack_allocator, arg) catch return false;
-                    }
-                },
-                .nominal => |nominal| pending.append(stack_allocator, nominal.backing_pattern) catch return false,
-                .nominal_external => |nominal| pending.append(stack_allocator, nominal.backing_pattern) catch return false,
-                .record_destructure => |record| {
-                    for (self.cir.store.sliceRecordDestructs(record.destructs)) |destruct_idx| {
-                        const destruct = self.cir.store.getRecordDestruct(destruct_idx);
-                        pending.append(stack_allocator, destruct.kind.toPatternIdx()) catch return false;
-                    }
-                },
-                .list => |list| {
-                    for (self.cir.store.slicePatterns(list.patterns)) |item| {
-                        pending.append(stack_allocator, item) catch return false;
-                    }
-                    if (list.rest_info) |rest| {
-                        if (rest.pattern) |rest_pattern| {
-                            pending.append(stack_allocator, rest_pattern) catch return false;
-                        }
-                    }
-                },
-                .tuple => |tuple| {
-                    for (self.cir.store.slicePatterns(tuple.patterns)) |item| {
-                        pending.append(stack_allocator, item) catch return false;
-                    }
-                },
-                .str_interpolation => |str| {
-                    for (0..str.steps.span.len) |offset| {
-                        const step = self.cir.store.getStrPatternStep(str.steps, @intCast(offset));
-                        if (step.capture) |capture| {
-                            pending.append(stack_allocator, capture) catch return false;
-                        }
-                    }
-                },
-                .assign,
-                .num_literal,
-                .num_from_numeral_literal,
-                .small_dec_literal,
-                .dec_literal,
-                .frac_f32_literal,
-                .frac_f64_literal,
-                .str_literal,
-                .underscore,
-                .runtime_error,
-                => {},
-            }
+            appendChildPatterns(self.cir, current, &pending, stack_allocator) catch return false;
         }
 
         return false;
     }
 };
+
+/// Append the patterns nested directly inside `pattern_idx`.
+fn appendChildPatterns(
+    cir: *const ModuleEnv,
+    pattern_idx: CIR.Pattern.Idx,
+    out: *std.ArrayList(CIR.Pattern.Idx),
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!void {
+    switch (cir.store.getPattern(pattern_idx)) {
+        .as => |as_pattern| try out.append(allocator, as_pattern.pattern),
+        .applied_tag => |tag| {
+            for (cir.store.slicePatterns(tag.args)) |arg| {
+                try out.append(allocator, arg);
+            }
+        },
+        .nominal => |nominal| try out.append(allocator, nominal.backing_pattern),
+        .nominal_external => |nominal| try out.append(allocator, nominal.backing_pattern),
+        .record_destructure => |record| {
+            for (cir.store.sliceRecordDestructs(record.destructs)) |destruct_idx| {
+                const destruct = cir.store.getRecordDestruct(destruct_idx);
+                try out.append(allocator, destruct.kind.toPatternIdx());
+            }
+        },
+        .list => |list| {
+            for (cir.store.slicePatterns(list.patterns)) |item| {
+                try out.append(allocator, item);
+            }
+            if (list.rest_info) |rest| {
+                if (rest.pattern) |rest_pattern| {
+                    try out.append(allocator, rest_pattern);
+                }
+            }
+        },
+        .tuple => |tuple| {
+            for (cir.store.slicePatterns(tuple.patterns)) |item| {
+                try out.append(allocator, item);
+            }
+        },
+        .str_interpolation => |str| {
+            for (0..str.steps.span.len) |offset| {
+                const step = cir.store.getStrPatternStep(str.steps, @intCast(offset));
+                if (step.capture) |capture| {
+                    try out.append(allocator, capture);
+                }
+            }
+        },
+        .assign,
+        .num_literal,
+        .num_from_numeral_literal,
+        .small_dec_literal,
+        .dec_literal,
+        .frac_f32_literal,
+        .frac_f64_literal,
+        .str_literal,
+        .underscore,
+        .runtime_error,
+        => {},
+    }
+}
+
+/// Append every binder pattern (`assign` or `as`) inside `root`, `root`
+/// itself included, in a deterministic order.
+///
+/// The walk is an explicit worklist (zero-recursion policy).
+pub fn appendPatternBinders(
+    cir: *const ModuleEnv,
+    root: CIR.Pattern.Idx,
+    out: *std.ArrayList(CIR.Pattern.Idx),
+    scratch: *std.ArrayList(CIR.Pattern.Idx),
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!void {
+    scratch.clearRetainingCapacity();
+    try scratch.append(allocator, root);
+    while (scratch.pop()) |pattern_idx| {
+        if (patternBindsName(cir.store.getPattern(pattern_idx))) {
+            try out.append(allocator, pattern_idx);
+        }
+        try appendChildPatterns(cir, pattern_idx, scratch, allocator);
+    }
+}
+
+/// Whether a pattern node itself binds a name (nested binders aside).
+fn patternBindsName(pattern: CIR.Pattern) bool {
+    return switch (pattern) {
+        .assign, .as => true,
+        .applied_tag,
+        .nominal,
+        .nominal_external,
+        .record_destructure,
+        .list,
+        .tuple,
+        .str_interpolation,
+        .num_literal,
+        .num_from_numeral_literal,
+        .small_dec_literal,
+        .dec_literal,
+        .frac_f32_literal,
+        .frac_f64_literal,
+        .str_literal,
+        .underscore,
+        .runtime_error,
+        => false,
+    };
+}
+
+/// Map every name a def's pattern binds to that def. A def whose pattern
+/// destructures its right-hand side binds several names, and a reference to
+/// any of them is a reference to the def that computes the whole value, so
+/// each one must resolve to the def for the name-reference graph to see the
+/// dependency (and any cycle) it creates.
+fn mapDefBinderPatterns(
+    cir: *const ModuleEnv,
+    pattern_to_def: *std.AutoHashMapUnmanaged(CIR.Pattern.Idx, CIR.Def.Idx),
+    def_idx: CIR.Def.Idx,
+    binders: *std.ArrayList(CIR.Pattern.Idx),
+    scratch: *std.ArrayList(CIR.Pattern.Idx),
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!void {
+    binders.clearRetainingCapacity();
+    try appendPatternBinders(cir, cir.store.getDef(def_idx).pattern, binders, scratch, allocator);
+    for (binders.items) |binder| {
+        try pattern_to_def.put(allocator, binder, def_idx);
+    }
+}
 
 /// Build a dependency graph for all definitions
 pub fn buildDependencyGraph(
@@ -1516,9 +1594,12 @@ pub fn computeCheckOrder(
     // Source position of each def, for the deterministic tie-break.
     var def_position: std.AutoHashMapUnmanaged(CIR.Def.Idx, u32) = .{};
     defer def_position.deinit(allocator);
+    var binders: std.ArrayList(CIR.Pattern.Idx) = .empty;
+    defer binders.deinit(allocator);
+    var binder_scratch: std.ArrayList(CIR.Pattern.Idx) = .empty;
+    defer binder_scratch.deinit(allocator);
     for (defs_slice, 0..) |def_idx, position| {
-        const def = cir.store.getDef(def_idx);
-        try pattern_to_def.put(allocator, def.pattern, def_idx);
+        try mapDefBinderPatterns(cir, &pattern_to_def, def_idx, &binders, &binder_scratch, allocator);
         try def_position.put(allocator, def_idx, @intCast(position));
     }
 

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8094,6 +8094,9 @@ fn poisonCheckedStrictDemandCycles(
         region: Region,
     };
 
+    var bindings = std.ArrayList(PatternBinding).empty;
+    defer bindings.deinit(self.gpa);
+
     for (eval_order.sccs) |scc| {
         if (!scc.is_recursive) continue;
 
@@ -8103,12 +8106,18 @@ fn poisonCheckedStrictDemandCycles(
         for (scc.defs) |def_idx| {
             const def = self.cir.store.getDef(def_idx);
             if (isFunctionDef(&self.cir.store, self.cir.store.getExpr(def.expr))) continue;
-            const ident = self.getPatternIdent(def.pattern) orelse continue;
-            try defs_to_poison.append(self.gpa, .{
-                .def_idx = def_idx,
-                .ident = ident,
-                .region = self.cir.store.getPatternRegion(def.pattern),
-            });
+            // Every name the def binds is computed from the one cyclic
+            // value, so each is circular: the single name of a plain def,
+            // or each name a destructure binds.
+            bindings.clearRetainingCapacity();
+            try self.collectPatternBindings(def.pattern, &bindings);
+            for (bindings.items) |binding| {
+                try defs_to_poison.append(self.gpa, .{
+                    .def_idx = def_idx,
+                    .ident = binding.ident,
+                    .region = self.cir.store.getPatternRegion(binding.pattern_idx),
+                });
+            }
         }
 
         std.mem.sort(RecursiveNonFunctionDef, defs_to_poison.items, {}, struct {
@@ -8123,11 +8132,16 @@ fn poisonCheckedStrictDemandCycles(
             }
         }.lessThan);
 
+        var poisoned_defs: std.AutoHashMapUnmanaged(CIR.Def.Idx, void) = .{};
+        defer poisoned_defs.deinit(self.gpa);
         for (defs_to_poison.items) |def_to_poison| {
             _ = try self.problems.appendProblem(self.gpa, .{ .circular_value_definition = .{
                 .ident = def_to_poison.ident,
                 .region = def_to_poison.region,
             } });
+            // A destructuring def reports once per bound name but is poisoned once.
+            const poisoned = try poisoned_defs.getOrPut(self.gpa, def_to_poison.def_idx);
+            if (poisoned.found_existing) continue;
             try self.poisonRecursiveNonFunctionProcessingDef(.{
                 .def_idx = def_to_poison.def_idx,
                 .def_name = def_to_poison.ident,
@@ -23484,6 +23498,15 @@ fn poisonRecursiveNonFunctionProcessingDef(
     }
     try self.erroneous_value_exprs.put(self.gpa, def.expr, {});
     try self.erroneous_value_patterns.put(self.gpa, def.pattern, {});
+    // A use of a name reads the poisoned value through that name's own
+    // binder pattern, so every name the def binds is erroneous, not only
+    // the pattern as a whole.
+    var bindings = std.ArrayList(PatternBinding).empty;
+    defer bindings.deinit(self.gpa);
+    try self.collectPatternBindings(def.pattern, &bindings);
+    for (bindings.items) |binding| {
+        try self.erroneous_value_patterns.put(self.gpa, binding.pattern_idx, {});
+    }
 
     if (use_expr) |expr_idx| {
         if (self.cir.store.getExpr(expr_idx) != .e_runtime_error) {
@@ -24163,10 +24186,17 @@ fn checkDefaultRestrictions(self: *Self) std.mem.Allocator.Error!void {
     defer evidence.deinit(self.gpa);
 
     // Top-level binder pattern -> def body, for following reference edges
-    // through def bodies during the residue walk.
+    // through def bodies during the residue walk. A destructuring def
+    // binds several names, each of which reads the def body.
+    var def_bindings = std.ArrayList(PatternBinding).empty;
+    defer def_bindings.deinit(self.gpa);
     for (self.cir.store.sliceDefs(self.cir.all_defs)) |def_idx| {
         const def = self.cir.store.getDef(def_idx);
-        try evidence.pattern_to_def_expr.put(self.gpa, def.pattern, def.expr);
+        def_bindings.clearRetainingCapacity();
+        try self.collectPatternBindings(def.pattern, &def_bindings);
+        for (def_bindings.items) |binding| {
+            try evidence.pattern_to_def_expr.put(self.gpa, binding.pattern_idx, def.expr);
+        }
     }
 
     // Scheme-use evidence indexes for the dispatch joins. A dispatch fired
@@ -24941,7 +24971,14 @@ fn recordDefaultWalkStmtBindings(
     local_pattern_to_expr: *std.AutoHashMapUnmanaged(CIR.Pattern.Idx, CIR.Expr.Idx),
 ) std.mem.Allocator.Error!void {
     switch (self.cir.store.getStatement(stmt_idx)) {
-        .s_decl => |decl| try local_pattern_to_expr.put(self.gpa, decl.pattern, decl.expr),
+        .s_decl => |decl| {
+            var bindings = std.ArrayList(PatternBinding).empty;
+            defer bindings.deinit(self.gpa);
+            try self.collectPatternBindings(decl.pattern, &bindings);
+            for (bindings.items) |binding| {
+                try local_pattern_to_expr.put(self.gpa, binding.pattern_idx, decl.expr);
+            }
+        },
         .s_var => |var_stmt| try local_pattern_to_expr.put(self.gpa, var_stmt.pattern_idx, var_stmt.expr),
         // No other statement form binds a pattern to an expression the walk
         // can follow (a reassignment mutates an `s_var` binder already
@@ -31787,6 +31824,155 @@ test "literal dispatch finalization rejects a strict value cycle through from_nu
     try std.testing.expect(cycle_defs[0] != cycle_defs[1]);
     try std.testing.expect(test_env.module_env.hasTopLevelDemandDependency(cycle_defs[0], cycle_defs[1]));
     try std.testing.expect(test_env.module_env.hasTopLevelDemandDependency(cycle_defs[1], cycle_defs[0]));
+}
+
+test "top-level destructure bound through its own name is a circular value definition" {
+    const TestEnv = @import("test/TestEnv.zig");
+    // `{x}` on the right is a block returning `x`, so `x` is computed from
+    // itself through the destructure.
+    const source =
+        \\{x} = {x}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneCanError("Circular Value Definition");
+}
+
+/// Assert that canonicalization reported exactly one circular value
+/// definition for each expected name and nothing else, in any order.
+fn expectCircularValueDefinitions(test_env: anytype, expected_names: []const []const u8) error{ OutOfMemory, TestExpectedEqual, TestUnexpectedResult }!void {
+    const diagnostics = try test_env.module_env.getDiagnostics();
+    defer std.testing.allocator.free(diagnostics);
+    try std.testing.expectEqual(expected_names.len, diagnostics.len);
+    for (expected_names) |expected_name| {
+        const expected_ident = try test_env.module_env.common.idents.insert(std.testing.allocator, Ident.for_text(expected_name));
+        var reports: usize = 0;
+        for (diagnostics) |diagnostic| {
+            try std.testing.expect(diagnostic == .circular_value_definition);
+            if (diagnostic.circular_value_definition.ident.eql(expected_ident)) reports += 1;
+        }
+        try std.testing.expectEqual(@as(usize, 1), reports);
+    }
+}
+
+test "top-level destructure in a value cycle with a plain def reports every name it binds" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\{a, b} = { a: c, b: 1 }
+        \\c = a
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try expectCircularValueDefinitions(&test_env, &.{ "a", "b", "c" });
+}
+
+test "top-level tuple destructure in a value cycle reports every name it binds" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\(a, b) = (c, 1)
+        \\c = a
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try expectCircularValueDefinitions(&test_env, &.{ "a", "b", "c" });
+}
+
+test "name bound by a nested top-level destructure in a value cycle is a circular value definition" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\{ outer: { inner } } = { outer: { inner: c } }
+        \\c = inner
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try expectCircularValueDefinitions(&test_env, &.{ "inner", "c" });
+}
+
+test "two top-level destructures in one value cycle are each a circular value definition" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\{b} = { b: c }
+        \\{a} = { a: b }
+        \\c = a
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try expectCircularValueDefinitions(&test_env, &.{ "b", "a", "c" });
+}
+
+test "mutually recursive functions through a top-level destructure check as one group" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\{ f } = { f: |x| g(x) }
+        \\g = |x| f(x)
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
+test "literal dispatch finalization rejects a strict value cycle through a top-level destructure" {
+    const TestEnv = @import("test/TestEnv.zig");
+    // `1` resolves to `MyNum.from_numeral` through `typed`, and that method
+    // reads `bump`, which reads `number` back out of the destructure.
+    const source =
+        \\MyNum := { value : U64 }.{
+        \\    from_numeral : Numeral -> Try(MyNum, [InvalidNumeral(Str)])
+        \\    from_numeral = |_| Ok({ value: bump })
+        \\}
+        \\
+        \\{number} = { number: 1 }
+        \\
+        \\typed : MyNum
+        \\typed = number
+        \\
+        \\bump : U64
+        \\bump = number.value
+    ;
+    var test_env = try TestEnv.init("LiteralResolution", source);
+    defer test_env.deinit();
+
+    const problems = test_env.checker.problems.problems.items;
+    const expected_names = [_][]const u8{ "number", "bump" };
+    try std.testing.expectEqual(expected_names.len, problems.len);
+    for (expected_names) |expected_name| {
+        const expected_ident = try test_env.module_env.common.idents.insert(std.testing.allocator, Ident.for_text(expected_name));
+        var reports: usize = 0;
+        for (problems) |found_problem| {
+            try std.testing.expect(found_problem == .circular_value_definition);
+            if (found_problem.circular_value_definition.ident.eql(expected_ident)) reports += 1;
+        }
+        try std.testing.expectEqual(@as(usize, 1), reports);
+    }
+}
+
+test "names bound by a top-level destructure resolve to their def for other defs" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\{x} = { x: 1 }
+        \\later = x + 1
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("Dec");
+}
+
+test "a lambda referring to a name bound by the same top-level destructure is not a strict cycle" {
+    const TestEnv = @import("test/TestEnv.zig");
+    const source =
+        \\{f, n} = { f: |s| Str.concat(s, n), n: "s" }
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertCanErrors(&.{});
 }
 
 test "literal strict demands flow through polymorphic called function summaries" {

--- a/test/snapshots/top_level_destructure_names_resolve_to_def.md
+++ b/test/snapshots/top_level_destructure_names_resolve_to_def.md
@@ -1,0 +1,116 @@
+# META
+~~~ini
+description=Names bound by a top-level destructure depend on their def like plain names do, so later defs may use them
+type=file
+~~~
+# SOURCE
+~~~roc
+{x} = { x: 1 }
+later = x + 1
+{n} = { n: "s" }
+f = |_| n
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenCurly,LowerIdent,CloseCurly,OpAssign,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,
+LowerIdent,OpAssign,LowerIdent,OpPlus,Int,
+OpenCurly,LowerIdent,CloseCurly,OpAssign,OpenCurly,LowerIdent,OpColon,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,LowerIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-record
+				(field (name "x") (rest false)))
+			(e-record
+				(field (field "x")
+					(e-int (raw "1")))))
+		(s-decl
+			(p-ident (raw "later"))
+			(e-binop (op "+")
+				(e-ident (raw "x"))
+				(e-int (raw "1"))))
+		(s-decl
+			(p-record
+				(field (name "n") (rest false)))
+			(e-record
+				(field (field "n")
+					(e-string
+						(e-string-part (raw "s"))))))
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-ident (raw "n"))))))
+~~~
+# FORMATTED
+~~~roc
+{ x } = { x: 1 }
+
+later = x + 1
+
+{ n } = { n: "s" }
+
+f = |_| n
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-record-destructure
+			(destructs
+				(record-destruct (label "x") (ident "x")
+					(required
+						(p-assign (ident "x"))))))
+		(e-record
+			(fields
+				(field (name "x")
+					(e-num (value "1"))))))
+	(d-let
+		(p-assign (ident "later"))
+		(e-dispatch-call (method "plus") (constraint-fn-var 244)
+			(receiver
+				(e-lookup-local
+					(p-assign (ident "x"))))
+			(args
+				(e-num (value "1")))))
+	(d-let
+		(p-record-destructure
+			(destructs
+				(record-destruct (label "n") (ident "n")
+					(required
+						(p-assign (ident "n"))))))
+		(e-record
+			(fields
+				(field (name "n")
+					(e-string
+						(e-literal (string "s")))))))
+	(d-let
+		(p-assign (ident "f"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-lookup-local
+				(p-assign (ident "n"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Dec"))
+		(patt (type "_arg -> Str")))
+	(expressions
+		(expr (type "{ x: Dec }"))
+		(expr (type "Dec"))
+		(expr (type "{ n: Str }"))
+		(expr (type "_arg -> Str"))))
+~~~

--- a/test/snapshots/top_level_destructure_value_cycle.md
+++ b/test/snapshots/top_level_destructure_value_cycle.md
@@ -1,0 +1,63 @@
+# META
+~~~ini
+description=A top-level destructure whose right-hand side is a block returning one of its own bound names is a circular value definition, not a compiler stack overflow
+type=file
+~~~
+# SOURCE
+~~~roc
+{x}={x}
+~~~
+# EXPECTED
+CIRCULAR VALUE DEFINITION - top_level_destructure_value_cycle.md:1:2:1:3
+# PROBLEMS
+── ✗ circular value definition ──────── top_level_destructure_value_cycle.md:1:2
+
+The value x is part of a recursive non-function definition cycle.
+
+{x}={x}
+ ^
+
+Only functions can be recursive. Non-function top-level values must be fully
+computable without depending on themselves through other values.
+
+# TOKENS
+~~~zig
+OpenCurly,LowerIdent,CloseCurly,OpAssign,OpenCurly,LowerIdent,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-record
+				(field (name "x") (rest false)))
+			(e-block
+				(statements
+					(e-ident (raw "x")))))))
+~~~
+# FORMATTED
+~~~roc
+{ x } = {
+	x
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-record-destructure
+			(destructs
+				(record-destruct (label "x") (ident "x")
+					(required
+						(p-assign (ident "x"))))))
+		(e-runtime-error (tag "circular_value_definition"))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions
+		(expr (type "Error"))))
+~~~

--- a/test/snapshots/top_level_destructure_value_cycle_with_plain_def.md
+++ b/test/snapshots/top_level_destructure_value_cycle_with_plain_def.md
@@ -1,0 +1,101 @@
+# META
+~~~ini
+description=A value cycle that runs through a name bound by a top-level destructure is reported like any other circular value definition
+type=file
+~~~
+# SOURCE
+~~~roc
+{a, b} = { a: c, b: 1 }
+c = a
+~~~
+# EXPECTED
+CIRCULAR VALUE DEFINITION - top_level_destructure_value_cycle_with_plain_def.md:1:2:1:3
+CIRCULAR VALUE DEFINITION - top_level_destructure_value_cycle_with_plain_def.md:1:5:1:6
+CIRCULAR VALUE DEFINITION - top_level_destructure_value_cycle_with_plain_def.md:1:15:1:16
+# PROBLEMS
+── ✗ circular value definition ─ top_level_destructure_value_cycle_with_plain_def.md:1:2
+
+The value a is part of a recursive non-function definition cycle.
+
+{a, b} = { a: c, b: 1 }
+ ^
+
+Only functions can be recursive. Non-function top-level values must be fully
+computable without depending on themselves through other values.
+
+── ✗ circular value definition ─ top_level_destructure_value_cycle_with_plain_def.md:1:5
+
+The value b is part of a recursive non-function definition cycle.
+
+{a, b} = { a: c, b: 1 }
+    ^
+
+Only functions can be recursive. Non-function top-level values must be fully
+computable without depending on themselves through other values.
+
+── ✗ circular value definition ─ top_level_destructure_value_cycle_with_plain_def.md:1:15
+
+The value c is part of a recursive non-function definition cycle.
+
+{a, b} = { a: c, b: 1 }
+              ^
+
+Only functions can be recursive. Non-function top-level values must be fully
+computable without depending on themselves through other values.
+
+# TOKENS
+~~~zig
+OpenCurly,LowerIdent,Comma,LowerIdent,CloseCurly,OpAssign,OpenCurly,LowerIdent,OpColon,LowerIdent,Comma,LowerIdent,OpColon,Int,CloseCurly,
+LowerIdent,OpAssign,LowerIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-record
+				(field (name "a") (rest false))
+				(field (name "b") (rest false)))
+			(e-record
+				(field (field "a")
+					(e-ident (raw "c")))
+				(field (field "b")
+					(e-int (raw "1")))))
+		(s-decl
+			(p-ident (raw "c"))
+			(e-ident (raw "a")))))
+~~~
+# FORMATTED
+~~~roc
+{ a, b } = { a: c, b: 1 }
+
+c = a
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-record-destructure
+			(destructs
+				(record-destruct (label "a") (ident "a")
+					(required
+						(p-assign (ident "a"))))
+				(record-destruct (label "b") (ident "b")
+					(required
+						(p-assign (ident "b"))))))
+		(e-runtime-error (tag "circular_value_definition")))
+	(d-let
+		(p-assign (ident "c"))
+		(e-runtime-error (tag "circular_value_definition"))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error")))
+	(expressions
+		(expr (type "Error"))
+		(expr (type "Error"))))
+~~~


### PR DESCRIPTION
Fixes #10822. A top-level `{x}={x}` overflowed the compiler's stack. The right-hand `{x}` is a block returning `x`, so the def is a strict value cycle, but `DependencyGraph` only mapped each def's whole pattern to the def and never the names a destructure binds. The lookup of `x` therefore resolved to no def, no group was recursive, neither the canonicalizer's nor the checker's cycle poisoning ran (both also skipped defs without a single name), and the checker's hoist bookkeeping chased the extraction root's dependencies back into itself until the stack ran out.

Every `assign`/`as` binder inside a def's pattern now maps to that def in both places the graph is built, so references to destructured names create the same dependency edges plain names do. The canonicalizer's and checker's cycle poisoning report a circular value definition for each name a cyclic destructuring def binds while replacing its right-hand side once, and the program from the issue now reports `The value x is part of a recursive non-function definition cycle` at the `x` in `{x}`.

While probing adjacent cases I found two unrelated gaps that this PR does not touch: any function value bound through a top-level destructure (for example `{f} = { f: |_| 1 }` followed by `f({})`) panics in postcheck lowering with "local lookup referenced an unbound pattern binder", and a top-level destructured name cannot be referenced before its def is canonicalized. Both reproduce without this change.