### PR TITLE
Strip a source line once per line in the post-check architecture check

### DIFF
--- a/ci/check_postcheck_architecture.pl
+++ b/ci/check_postcheck_architecture.pl
@@ -139,11 +139,23 @@ for my $rel (iter_zig_files()) {
         ++$line_no;
         chomp $line;
 
+        # `zig_code_line` walks the line one character at a time, so asking for
+        # it inside the rule loop repeats that walk for every rule the line is
+        # checked against. One line's stripped form is the same for all of
+        # them, so compute it at most once and hand the same string to each.
+        my $code_subject;
+
         for my $rule (@RULES) {
             next if $rule->{allowed}{$rel};
             # Architecture rules constrain Zig tokens, not prose or fixture
             # strings. A rule must opt in explicitly if raw source text matters.
-            my $subject = $rule->{raw_text} ? $line : zig_code_line($line);
+            my $subject;
+            if ($rule->{raw_text}) {
+                $subject = $line;
+            } else {
+                $code_subject = zig_code_line($line) unless defined $code_subject;
+                $subject = $code_subject;
+            }
             if ($subject =~ $rule->{regex}) {
                 push @violations, "$rel:$line_no: $rule->{category}: $line";
             }


### PR DESCRIPTION
`run-check-postcheck-architecture` took 500 seconds in CI and has now started crossing the ten-minute cap, which fails the ubuntu, macOS and Windows minici shards on any branch that reaches it.

The check reads every Zig file line by line and tests each line against eighty rules. A rule that constrains Zig tokens rather than prose asks `zig_code_line` for the line with comments and string contents removed, and that call sat inside the rule loop, so a line was walked character by character once per rule it was checked against. The stripped form does not depend on the rule, so it is now computed at most once per line and shared.

That takes the check from 500s to 29s. Violations are still reported identically: an introduced `cloneTypeGraph` call is still caught with its file, line and category.
