### PR TITLE
Keep ReleaseSafe stack probes inside the run shim

### DIFF
--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -193,6 +193,10 @@ jobs:
           command: zig build ${{ matrix.build_jobs_flag }} build-ci
           retry_count: 3
 
+      - name: Check ReleaseSafe machine-code shim support ownership
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        run: zig build ${{ matrix.build_jobs_flag }} run-check-machine-code-shim-archive -Doptimize=ReleaseSafe
+
       - name: Pack MiniCI build artifact
         shell: bash
         run: |

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -78,6 +78,9 @@ jobs:
       - name: check formatting
         run: zig build run-check-zig-format
 
+      - name: Check ReleaseSafe machine-code shim support ownership
+        run: zig build run-check-machine-code-shim-archive -Doptimize=ReleaseSafe
+
       - name: Check Builtin.roc formatting
         run: zig build run-check-builtin-format
 

--- a/build.zig
+++ b/build.zig
@@ -2942,6 +2942,7 @@ pub fn build(b: *std.Build) void {
     const run_test_wasm_static_lib_step = b.step("run-test-wasm-static-lib", "Run WASM static library test runner");
     const run_test_dylib_step = b.step("run-test-dylib", "Build a Roc shared library and run it through the loader test");
     const run_test_archive_step = b.step("run-test-archive", "Build a Roc static archive, link a consumer against it, and run it");
+    const run_check_machine_code_shim_archive_step = b.step("run-check-machine-code-shim-archive", "Check that the machine-code shim keeps compiler-private support local");
     const build_coverage_tools_step = b.step("build-coverage-tools", "Build parser coverage tools");
     const run_coverage_parser_step = b.step("run-coverage-parser", "Run parser tests with kcov code coverage");
     const run_minici_step = b.step("minici", "Run a subset of CI build and test steps");
@@ -5452,6 +5453,10 @@ pub fn build(b: *std.Build) void {
         });
     }
 
+    if (main_exe_result.machine_code_shim_archive_check) |machine_code_shim_archive_check| {
+        run_check_machine_code_shim_archive_step.dependOn(machine_code_shim_archive_check);
+    }
+
     const guarded_list_violation_exe = b.addExecutable(.{
         .name = "guarded_list_violation_test",
         .root_module = b.createModule(.{
@@ -7150,6 +7155,7 @@ fn wasmObjectArtifact(b: *std.Build, obj: *Step.Compile) std.Build.LazyPath {
 const MainExeResult = struct {
     exe: *Step.Compile,
     machine_code_shim_test: ?*Step.Compile,
+    machine_code_shim_archive_check: ?*Step,
 };
 fn addMainExe(
     b: *std.Build,
@@ -7382,13 +7388,10 @@ fn addMainExe(
     machine_code_shim_lib.root_module.addImport("compiled_builtins", compiled_builtins_module);
     machine_code_shim_lib.step.dependOn(&write_compiled_builtins.step);
     machine_code_shim_lib.root_module.addObjectFile(builtins_obj.getEmittedBin());
-    // The shim is linked alongside a platform host that is its own compiler-rt
-    // carrier, and COFF rejects the resulting duplicate definitions of `memcpy`
-    // and the integer/float libcalls outright (the same hazard noted on the
-    // boxy object above). The shim does not need a copy of its own: its objects
-    // reference only memcpy, memmove and memset, which the rest of the link
-    // already provides -- both for a platform host and for the freestanding
-    // default platform.
+    // The shim defines its compiler-private stack probe internally. Do not
+    // bundle the complete compiler-rt object: its broad set of weak definitions
+    // can participate in platform symbol resolution, and COFF rejects duplicate
+    // definitions of memcpy and the integer/float libcalls outright.
     machine_code_shim_lib.bundle_compiler_rt = false;
     // On Linux the shim reaches the kernel directly, so the executables it is
     // linked into need no libc. Declaring that here makes the Zig compiler
@@ -7397,6 +7400,7 @@ fn addMainExe(
     if (target.result.os.tag == .linux) machine_code_shim_lib.root_module.link_libc = false;
 
     var machine_code_shim_test_for_registry: ?*Step.Compile = null;
+    var machine_code_shim_archive_check_for_registry: ?*Step = null;
     if (add_machine_code_shim_test) {
         const machine_code_shim_test = b.addTest(.{
             .name = "machine_code_shim",
@@ -7433,6 +7437,25 @@ fn addMainExe(
         machine_code_shim_test.bundle_compiler_rt = true;
         add_tracy(b, roc_modules.build_options, machine_code_shim_test, b.graph.host, false, flag_enable_tracy);
         machine_code_shim_test_for_registry = machine_code_shim_test;
+
+        // Run mode hands the linker the platform's own inputs plus this shim
+        // and nothing else. Check that compiler-private support does not escape
+        // the shim object as an undefined or global symbol. The checker reads
+        // ELF archive members directly.
+        if (target.result.ofmt == .elf) {
+            const machine_code_shim_archive_check = b.addExecutable(.{
+                .name = "machine_code_shim_archive_check",
+                .root_module = b.createModule(.{
+                    .root_source_file = b.path("src/machine_code_shim/archive_check.zig"),
+                    .target = b.graph.host,
+                    .optimize = .Debug,
+                }),
+            });
+            configureBackend(machine_code_shim_archive_check, b.graph.host);
+            const run_machine_code_shim_archive_check = b.addRunArtifact(machine_code_shim_archive_check);
+            run_machine_code_shim_archive_check.addFileArg(machine_code_shim_lib.getEmittedBin());
+            machine_code_shim_archive_check_for_registry = &run_machine_code_shim_archive_check.step;
+        }
     }
 
     const install_machine_code_shim = b.addInstallArtifact(machine_code_shim_lib, .{});
@@ -7757,6 +7780,7 @@ fn addMainExe(
     return .{
         .exe = exe,
         .machine_code_shim_test = machine_code_shim_test_for_registry,
+        .machine_code_shim_archive_check = machine_code_shim_archive_check_for_registry,
     };
 }
 

--- a/src/machine_code_shim/archive_check.zig
+++ b/src/machine_code_shim/archive_check.zig
@@ -18,6 +18,15 @@ const elf = std.elf;
 
 const ar_magic = "!<arch>\n";
 
+const ArchiveCheckError = std.process.Args.ToSliceError ||
+    std.Io.Dir.ReadFileAllocError ||
+    error{
+        MissingPath,
+        NotAnArchive,
+        NoObjectMembers,
+        CompilerPrivateSymbolEscaped,
+    };
+
 /// Compiler-private symbols the shim archive may neither leave unresolved nor
 /// expose to the surrounding platform link.
 const compiler_private = [_]struct { name: []const u8, why: []const u8 }{
@@ -36,16 +45,13 @@ const Use = struct {
 
 /// Fails when the archive named by the first argument lets a compiler-private
 /// symbol escape as undefined or globally visible.
-pub fn main(init: std.process.Init) anyerror!void {
+pub fn main(init: std.process.Init) ArchiveCheckError!void {
     var arena_impl = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var arg_iter = try std.process.Args.Iterator.initAllocator(init.minimal.args, arena);
-    defer arg_iter.deinit();
-    _ = arg_iter.skip();
-
-    const path = arg_iter.next() orelse {
+    const args = try init.minimal.args.toSlice(arena);
+    const path = if (args.len >= 2) args[1] else {
         std.debug.print("Usage: machine_code_shim_archive_check <archive path>\n", .{});
         return error.MissingPath;
     };

--- a/src/machine_code_shim/archive_check.zig
+++ b/src/machine_code_shim/archive_check.zig
@@ -1,0 +1,206 @@
+//! Checks that the machine-code shim keeps compiler-private support local.
+//!
+//! `roc <app>.roc` links this archive with the platform's own inputs and
+//! nothing else -- no compiler-rt object of the compiler's own. In particular,
+//! `__zig_probe_stack` belongs to Zig's compiler-rt, and a platform host need
+//! not be a Zig host. The shim therefore has to resolve that support locally:
+//! leaving it undefined reproduces https://github.com/roc-lang/roc/issues/11059,
+//! while exposing it globally lets a compiler-owned symbol participate in the
+//! platform link.
+//!
+//! Usage: machine_code_shim_archive_check <archive path>
+//!
+//! Reads ELF members, which is the format on the target this is wired up for.
+
+const std = @import("std");
+
+const elf = std.elf;
+
+const ar_magic = "!<arch>\n";
+
+/// Compiler-private symbols the shim archive may neither leave unresolved nor
+/// expose to the surrounding platform link.
+const compiler_private = [_]struct { name: []const u8, why: []const u8 }{
+    .{
+        .name = "__zig_probe_stack",
+        .why = "only Zig's compiler-rt defines it, and run mode links no compiler-rt beside the shim",
+    },
+};
+
+const Use = struct {
+    /// Archive member that references the symbol without defining it.
+    referenced_by: ?[]const u8 = null,
+    /// Archive member that exposes the compiler-owned definition globally.
+    globally_defined_by: ?[]const u8 = null,
+};
+
+/// Fails when the archive named by the first argument lets a compiler-private
+/// symbol escape as undefined or globally visible.
+pub fn main(init: std.process.Init) anyerror!void {
+    var arena_impl = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var arg_iter = try std.process.Args.Iterator.initAllocator(init.minimal.args, arena);
+    defer arg_iter.deinit();
+    _ = arg_iter.skip();
+
+    const path = arg_iter.next() orelse {
+        std.debug.print("Usage: machine_code_shim_archive_check <archive path>\n", .{});
+        return error.MissingPath;
+    };
+
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(init.io, path, arena, .unlimited);
+    if (bytes.len < ar_magic.len or !std.mem.eql(u8, bytes[0..ar_magic.len], ar_magic)) {
+        std.debug.print("FAILED: {s} does not start with the ar archive magic\n", .{path});
+        return error.NotAnArchive;
+    }
+
+    var uses = [_]Use{.{}} ** compiler_private.len;
+    const members_scanned = scanArchive(bytes, &uses);
+    if (members_scanned == 0) {
+        std.debug.print("FAILED: {s} holds no ELF object members\n", .{path});
+        return error.NoObjectMembers;
+    }
+
+    var found_escape = false;
+    for (compiler_private, uses) |symbol, use| {
+        if (use.referenced_by) |member| {
+            found_escape = true;
+            std.debug.print(
+                "FAILED: {s} references {s} without a local definition ({s}), from member {s}\n",
+                .{ path, symbol.name, symbol.why, member },
+            );
+        }
+        if (use.globally_defined_by) |member| {
+            found_escape = true;
+            std.debug.print(
+                "FAILED: {s} exposes compiler-owned symbol {s} from member {s}; it must be local to the referencing object\n",
+                .{ path, symbol.name, member },
+            );
+        }
+    }
+    if (found_escape) return error.CompilerPrivateSymbolEscaped;
+
+    std.debug.print("SUCCESS: {s} keeps checked compiler-private support local\n", .{path});
+}
+
+/// Walk the archive's members, recording where each checked symbol is
+/// undefined or globally defined. Returns the number of ELF object members
+/// read.
+fn scanArchive(bytes: []const u8, uses: *[compiler_private.len]Use) usize {
+    var members_scanned: usize = 0;
+    var long_names: []const u8 = &.{};
+    var offset: usize = ar_magic.len;
+
+    while (offset + 60 <= bytes.len) {
+        const header = bytes[offset .. offset + 60];
+        const name_field = std.mem.trimEnd(u8, header[0..16], " ");
+        const size_field = std.mem.trimEnd(u8, header[48..58], " ");
+        const member_size = std.fmt.parseInt(usize, size_field, 10) catch return members_scanned;
+        offset += 60;
+        if (offset + member_size > bytes.len) return members_scanned;
+
+        var member = bytes[offset .. offset + member_size];
+        var member_name = name_field;
+
+        // BSD-style long member names are stored in the member's first bytes.
+        if (std.mem.startsWith(u8, name_field, "#1/")) {
+            const name_len = std.fmt.parseInt(usize, name_field[3..], 10) catch return members_scanned;
+            if (name_len > member.len) return members_scanned;
+            member_name = std.mem.trimEnd(u8, member[0..name_len], "\x00");
+            member = member[name_len..];
+        }
+
+        // GNU-style long member names live in the "//" member, referenced as
+        // "/<offset into that member>".
+        if (std.mem.eql(u8, member_name, "//")) {
+            long_names = member;
+        } else if (member_name.len > 1 and member_name[0] == '/' and std.ascii.isDigit(member_name[1])) {
+            if (std.fmt.parseInt(usize, member_name[1..], 10) catch null) |name_off| {
+                if (name_off < long_names.len) {
+                    member_name = std.mem.trimEnd(u8, std.mem.sliceTo(long_names[name_off..], '\n'), "/");
+                }
+            }
+        }
+
+        const is_index = std.mem.eql(u8, member_name, "/") or
+            std.mem.eql(u8, member_name, "//") or
+            std.mem.eql(u8, member_name, "/SYM64/") or
+            std.mem.startsWith(u8, member_name, "__.SYMDEF");
+
+        if (!is_index and member.len >= 4 and std.mem.eql(u8, member[0..4], "\x7fELF")) {
+            scanElfMember(member, member_name, uses);
+            members_scanned += 1;
+        }
+
+        offset += member_size;
+        if (offset % 2 == 1) offset += 1; // members are 2-byte aligned
+    }
+
+    return members_scanned;
+}
+
+fn scanElfMember(bytes: []const u8, member_name: []const u8, uses: *[compiler_private.len]Use) void {
+    if (bytes.len <= elf.EI_CLASS) return;
+    const class = bytes[elf.EI_CLASS];
+    if (class == elf.ELFCLASS32) {
+        scanElfClass(elf.Elf32_Ehdr, elf.Elf32_Shdr, elf.Elf32_Sym, bytes, member_name, uses);
+    } else if (class == elf.ELFCLASS64) {
+        scanElfClass(elf.Elf64_Ehdr, elf.Elf64_Shdr, elf.Elf64_Sym, bytes, member_name, uses);
+    }
+}
+
+fn scanElfClass(
+    comptime Ehdr: type,
+    comptime Shdr: type,
+    comptime Sym: type,
+    bytes: []const u8,
+    member_name: []const u8,
+    uses: *[compiler_private.len]Use,
+) void {
+    if (bytes.len < @sizeOf(Ehdr)) return;
+    const ehdr = std.mem.bytesAsValue(Ehdr, bytes[0..@sizeOf(Ehdr)]);
+
+    const shoff: usize = @intCast(ehdr.e_shoff);
+    const shnum: usize = ehdr.e_shnum;
+    const shentsize: usize = ehdr.e_shentsize;
+    if (shentsize < @sizeOf(Shdr)) return;
+    if (shoff + shnum * shentsize > bytes.len) return;
+
+    var i: usize = 0;
+    while (i < shnum) : (i += 1) {
+        const shdr = std.mem.bytesAsValue(Shdr, bytes[shoff + i * shentsize ..][0..@sizeOf(Shdr)]);
+        if (shdr.sh_type != elf.SHT_SYMTAB) continue;
+
+        const strtab_index: usize = shdr.sh_link;
+        if (strtab_index >= shnum) return;
+        const strtab_hdr = std.mem.bytesAsValue(Shdr, bytes[shoff + strtab_index * shentsize ..][0..@sizeOf(Shdr)]);
+        const strtab_off: usize = @intCast(strtab_hdr.sh_offset);
+        const strtab_size: usize = @intCast(strtab_hdr.sh_size);
+        if (strtab_off + strtab_size > bytes.len) return;
+        const strtab = bytes[strtab_off .. strtab_off + strtab_size];
+
+        const sym_off: usize = @intCast(shdr.sh_offset);
+        const sym_size: usize = @intCast(shdr.sh_size);
+        if (sym_off + sym_size > bytes.len) return;
+        const sym_count = sym_size / @sizeOf(Sym);
+
+        var s: usize = 0;
+        while (s < sym_count) : (s += 1) {
+            const sym = std.mem.bytesAsValue(Sym, bytes[sym_off + s * @sizeOf(Sym) ..][0..@sizeOf(Sym)]);
+            const name_off: usize = sym.st_name;
+            if (name_off >= strtab.len) continue;
+            const name = std.mem.sliceTo(strtab[name_off..], 0);
+
+            for (compiler_private, uses) |symbol, *use| {
+                if (!std.mem.eql(u8, name, symbol.name)) continue;
+                if (sym.st_shndx == elf.SHN_UNDEF) {
+                    if (use.referenced_by == null) use.referenced_by = member_name;
+                } else if (sym.st_bind() != elf.STB_LOCAL) {
+                    if (use.globally_defined_by == null) use.globally_defined_by = member_name;
+                }
+            }
+        }
+    }
+}

--- a/src/machine_code_shim/main.zig
+++ b/src/machine_code_shim/main.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const stack_probe = @import("stack_probe.zig");
 const base_mod = @import("base");
 const backend = @import("backend");
 const builtins = @import("builtins");
@@ -957,6 +958,7 @@ fn shimEntrypoint(
 }
 
 fn shimDefaultMain(argc: usize, argv: [*][*:0]const u8) callconv(.c) usize {
+    stack_probe.retain();
     const ops = shim_host_abi.getOps();
     const app_args = if (argc > 1) argv[1..argc] else argv[0..0];
     var cli_args_list = shim_host_abi.buildDefaultRunCliArgs(app_args, allocator()) catch {

--- a/src/machine_code_shim/stack_probe.zig
+++ b/src/machine_code_shim/stack_probe.zig
@@ -1,0 +1,80 @@
+//! Compiler-owned stack probing for the machine-code shim.
+//!
+//! Safe Zig builds emit calls to `__zig_probe_stack` for large x86 and x86_64
+//! ELF and Mach-O stack frames. The shim is linked into programs whose platform
+//! host need not carry Zig's compiler-rt, so the shim must define that helper
+//! itself. Local binding resolves the generated calls without exposing a
+//! compiler-private symbol to the platform link.
+
+const builtin = @import("builtin");
+
+const needs_zig_probe = builtin.mode == .ReleaseSafe and
+    (builtin.object_format == .elf or builtin.object_format == .macho) and
+    (builtin.cpu.arch == .x86 or builtin.cpu.arch == .x86_64);
+
+/// Keep the local helper in the shim object. Zig's compiler-generated call is
+/// added after source reachability, so it cannot root the helper itself.
+pub inline fn retain() void {
+    if (!needs_zig_probe) return;
+
+    asm volatile (
+        \\        # %[probe:P]
+        :
+        : [probe] "X" (&zigProbeStack),
+    );
+}
+
+/// Touch every page in a large stack allocation before the caller moves its
+/// stack pointer across the complete frame. The calling convention matches the
+/// helper emitted by Zig: the requested byte count arrives in eax/rax.
+fn zigProbeStack() callconv(.naked) void {
+    @setRuntimeSafety(false);
+    if (!needs_zig_probe) unreachable;
+
+    const symbol = if (builtin.object_format == .macho)
+        "___zig_probe_stack:\n"
+    else
+        "__zig_probe_stack:\n";
+
+    if (builtin.cpu.arch == .x86_64) {
+        asm volatile (symbol ++
+                \\        push   %%rcx
+                \\        mov    %%rax, %%rcx
+                \\        cmp    $0x1000,%%rcx
+                \\        jb     2f
+                \\ 1:
+                \\        sub    $0x1000,%%rsp
+                \\        orl    $0,16(%%rsp)
+                \\        sub    $0x1000,%%rcx
+                \\        cmp    $0x1000,%%rcx
+                \\        ja     1b
+                \\ 2:
+                \\        sub    %%rcx, %%rsp
+                \\        orl    $0,16(%%rsp)
+                \\        add    %%rax,%%rsp
+                \\        pop    %%rcx
+                \\        ret
+        );
+    } else if (builtin.cpu.arch == .x86) {
+        asm volatile (symbol ++
+                \\        push   %%ecx
+                \\        mov    %%eax, %%ecx
+                \\        cmp    $0x1000,%%ecx
+                \\        jb     2f
+                \\ 1:
+                \\        sub    $0x1000,%%esp
+                \\        orl    $0,8(%%esp)
+                \\        sub    $0x1000,%%ecx
+                \\        cmp    $0x1000,%%ecx
+                \\        ja     1b
+                \\ 2:
+                \\        sub    %%ecx, %%esp
+                \\        orl    $0,8(%%esp)
+                \\        add    %%eax,%%esp
+                \\        pop    %%ecx
+                \\        ret
+        );
+    } else {
+        unreachable;
+    }
+}

--- a/src/machine_code_shim/stack_probe.zig
+++ b/src/machine_code_shim/stack_probe.zig
@@ -1,10 +1,10 @@
 //! Compiler-owned stack probing for the machine-code shim.
 //!
-//! Safe Zig builds emit calls to `__zig_probe_stack` for large x86 and x86_64
-//! ELF and Mach-O stack frames. The shim is linked into programs whose platform
-//! host need not carry Zig's compiler-rt, so the shim must define that helper
-//! itself. Local binding resolves the generated calls without exposing a
-//! compiler-private symbol to the platform link.
+//! ReleaseSafe Zig builds emit calls to `__zig_probe_stack` for large x86 and
+//! x86_64 ELF and Mach-O stack frames. The shim is linked into programs whose
+//! platform host need not carry Zig's compiler-rt, so the shim must define that
+//! helper itself. Local binding resolves the generated calls without exposing
+//! a compiler-private symbol to the platform link.
 
 const builtin = @import("builtin");
 
@@ -27,6 +27,7 @@ pub inline fn retain() void {
 /// Touch every page in a large stack allocation before the caller moves its
 /// stack pointer across the complete frame. The calling convention matches the
 /// helper emitted by Zig: the requested byte count arrives in eax/rax.
+/// The body mirrors Zig 0.16's `compiler_rt/stack_probe.zig` implementation.
 fn zigProbeStack() callconv(.naked) void {
     @setRuntimeSafety(false);
     if (!needs_zig_probe) unreachable;
@@ -74,7 +75,7 @@ fn zigProbeStack() callconv(.naked) void {
                 \\        pop    %%ecx
                 \\        ret
         );
-    } else {
-        unreachable;
     }
+
+    unreachable;
 }


### PR DESCRIPTION
ReleaseSafe Zig builds emit calls to `__zig_probe_stack` from the machine-code shim, but run-mode links cannot assume that a platform host carries Zig compiler-rt. This keeps the minimal x86/x86_64 probe implementation local to the shim object, preserving guard-page correctness without exposing the symbol or bundling compiler-rt's broad definition set. An archive contract check rejects either an unresolved or globally visible compiler-private probe.

Fixes #11059.