### PR TITLE
Fix bundle roots for nested entrypoints

### DIFF
--- a/src/bundle/bundle.zig
+++ b/src/bundle/bundle.zig
@@ -109,31 +109,42 @@ pub const ErrorContext = struct {
     reason: PathValidationReason,
 };
 
+/// A file to read from `base_dir` and the distinct portable path to store in
+/// the archive.
+pub const Entry = struct {
+    source_path: []const u8,
+    archive_path: []const u8,
+};
+
+/// The content-addressed archive filename and total size of its input files.
+pub const Result = struct {
+    filename: []u8,
+    uncompressed_size: u64,
+};
+
 /// Bundle files into a compressed tar archive.
 ///
-/// The file_path_iter must yield file paths that are valid for use with `Dir.openFile`.
-/// This means paths must be relative (not absolute), must not contain ".." components,
-/// and on Windows must use forward slashes. File paths are limited to 255 bytes for
-/// tar compatibility. Paths must be encoded as WTF-8 on Windows, UTF-8 elsewhere.
-///
-/// If path_prefix is provided, it will be stripped from the beginning of each file path
-/// before adding to the tar archive.
+/// The entry iterator supplies a source path for `Dir.openFile` and a separate
+/// archive path. Archive paths must be relative, must not contain `..`
+/// components, and are limited to 255 bytes for tar compatibility. On Windows,
+/// archive paths are converted to forward slashes. Paths must be encoded as
+/// WTF-8 on Windows and UTF-8 elsewhere.
 ///
 /// Compression level should be between 1 (fastest) and 22 (best compression).
 /// Level 3 is a good default for speed/size tradeoff.
 ///
-/// Returns the filename (base58-encoded blake3 hash + .tar.zst). Caller must free the returned string.
+/// Returns the filename (base58-encoded blake3 hash + .tar.zst) and the total
+/// input size. The caller must free `filename`.
 /// If an InvalidPath error is returned, error_context will contain details about the invalid path.
 pub fn bundle(
-    file_path_iter: anytype,
+    entry_iter: anytype,
     compression_level: c_int,
     allocator: *std.mem.Allocator,
     io: std.Io,
     output_writer: *std.Io.Writer,
     base_dir: std.Io.Dir,
-    path_prefix: ?[]const u8,
     error_context: ?*ErrorContext,
-) BundleError![]u8 {
+) BundleError!Result {
     // Create compressing hash writer that chains: tar → compress → hash → output
     var compress_writer = streaming_writer.CompressingHashWriter.init(
         allocator,
@@ -148,10 +159,41 @@ pub fn bundle(
 
     // Create tar writer that writes to the compressing writer
     var tar_writer = std.tar.Writer{ .underlying_writer = &compress_writer.interface };
+    var uncompressed_size: u64 = 0;
 
     // Process files one at a time
-    while (try file_path_iter.next()) |file_path| {
-        const file = base_dir.openFile(io, file_path, .{}) catch |err| switch (err) {
+    while (try entry_iter.next()) |entry| {
+        // Standardize archive names on forward slashes. Valid Unix source
+        // paths can contain backslashes, but archive names remain portable.
+        const tar_path = if (builtin.target.os.tag == .windows) blk: {
+            const path_buf = try allocator.alloc(u8, entry.archive_path.len);
+            @memcpy(path_buf, entry.archive_path);
+            std.mem.replaceScalar(u8, path_buf, '\\', '/');
+            break :blk path_buf;
+        } else if (std.mem.find(u8, entry.archive_path, "\\") == null) entry.archive_path else {
+            if (error_context) |ctx| {
+                ctx.path = entry.archive_path;
+                ctx.reason = .contained_backslash_on_unix;
+            }
+            return error.InvalidPath;
+        };
+        defer if (builtin.target.os.tag == .windows) allocator.free(tar_path);
+
+        if (pathHasBundleErr(tar_path)) |validation_error| {
+            if (error_context) |ctx| {
+                // Keep the caller-owned path rather than the temporary
+                // forward-slash copy used on Windows.
+                ctx.path = entry.archive_path;
+                ctx.reason = validation_error.reason;
+            }
+            return error.InvalidPath;
+        }
+
+        if (tar_path.len > TAR_PATH_MAX_LENGTH) {
+            return error.FilePathTooLong;
+        }
+
+        const file = base_dir.openFile(io, entry.source_path, .{}) catch |err| switch (err) {
             error.AntivirusInterference,
             error.BadPathName,
             error.Canceled,
@@ -192,46 +234,7 @@ pub fn bundle(
         };
 
         const file_size = std.math.cast(usize, stat.size) orelse return error.FileTooLarge;
-
-        // Strip path prefix if provided
-        const unescaped_path = if (path_prefix) |prefix| blk: {
-            if (std.mem.startsWith(u8, file_path, prefix)) {
-                break :blk file_path[prefix.len..];
-            } else {
-                break :blk file_path;
-            }
-        } else file_path;
-
-        // Standardize on forward slashes for directory separators.
-        //
-        // Valid UNIX paths can technically contain backslashes; if one does, give an error.
-        const tar_path = if (builtin.target.os.tag == .windows) blk: {
-            // On Windows, replace backslashes with forward slashes
-            const path_buf = try allocator.alloc(u8, unescaped_path.len);
-            @memcpy(path_buf, unescaped_path);
-            std.mem.replaceScalar(u8, path_buf, '\\', '/');
-            break :blk path_buf;
-        } else if (std.mem.find(u8, unescaped_path, "\\") == null) unescaped_path else {
-            if (error_context) |ctx| {
-                ctx.path = unescaped_path;
-                ctx.reason = .contained_backslash_on_unix;
-            }
-            return error.InvalidPath;
-        };
-        defer if (builtin.target.os.tag == .windows) allocator.free(tar_path);
-
-        // Validate the tar path after prefix stripping and forward-slash standardization.
-        if (pathHasBundleErr(tar_path)) |validation_error| {
-            if (error_context) |ctx| {
-                ctx.path = validation_error.path;
-                ctx.reason = validation_error.reason;
-            }
-            return error.InvalidPath;
-        }
-
-        if (tar_path.len > TAR_PATH_MAX_LENGTH) {
-            return error.FilePathTooLong;
-        }
+        uncompressed_size = std.math.add(u64, uncompressed_size, stat.size) catch return error.FileTooLarge;
 
         // Write tar header and stream file content
         const Options = @TypeOf(tar_writer).Options;
@@ -267,7 +270,7 @@ pub fn bundle(
 
     // Create filename with .tar.zst extension
     const filename = try std.fmt.allocPrint(allocator.*, "{s}{s}", .{ base58_hash, TAR_EXTENSION });
-    return filename;
+    return .{ .filename = filename, .uncompressed_size = uncompressed_size };
 }
 
 /// Validate a base58-encoded hash string and return the decoded hash.

--- a/src/bundle/bundle.zig
+++ b/src/bundle/bundle.zig
@@ -165,19 +165,21 @@ pub fn bundle(
     while (try entry_iter.next()) |entry| {
         // Standardize archive names on forward slashes. Valid Unix source
         // paths can contain backslashes, but archive names remain portable.
-        const tar_path = if (builtin.target.os.tag == .windows) blk: {
-            const path_buf = try allocator.alloc(u8, entry.archive_path.len);
-            @memcpy(path_buf, entry.archive_path);
-            std.mem.replaceScalar(u8, path_buf, '\\', '/');
-            break :blk path_buf;
-        } else if (std.mem.find(u8, entry.archive_path, "\\") == null) entry.archive_path else {
+        var normalized_tar_path: ?[]u8 = null;
+        defer if (normalized_tar_path) |path| allocator.free(path);
+        const has_backslash = std.mem.find(u8, entry.archive_path, "\\") != null;
+        const tar_path = if (builtin.target.os.tag == .windows and has_backslash) blk: {
+            const path = try allocator.dupe(u8, entry.archive_path);
+            std.mem.replaceScalar(u8, path, '\\', '/');
+            normalized_tar_path = path;
+            break :blk path;
+        } else if (!has_backslash) entry.archive_path else {
             if (error_context) |ctx| {
                 ctx.path = entry.archive_path;
                 ctx.reason = .contained_backslash_on_unix;
             }
             return error.InvalidPath;
         };
-        defer if (builtin.target.os.tag == .windows) allocator.free(tar_path);
 
         if (pathHasBundleErr(tar_path)) |validation_error| {
             if (error_context) |ctx| {

--- a/src/bundle/mod.zig
+++ b/src/bundle/mod.zig
@@ -24,6 +24,8 @@ pub const BundleError = bundle.BundleError;
 pub const PathValidationError = bundle.PathValidationError;
 pub const PathValidationReason = bundle.PathValidationReason;
 pub const ErrorContext = bundle.ErrorContext;
+pub const Entry = bundle.Entry;
+pub const Result = bundle.Result;
 
 // Re-export constants
 pub const STREAM_BUFFER_SIZE = bundle.STREAM_BUFFER_SIZE;

--- a/src/bundle/test_bundle.zig
+++ b/src/bundle/test_bundle.zig
@@ -18,6 +18,7 @@ const unbundle_mod = @import("unbundle");
 const DirExtractWriter = bundle.DirExtractWriter;
 const BufferExtractWriter = unbundle_mod.BufferExtractWriter;
 const FilePathIterator = test_util.FilePathIterator;
+const EntryIterator = test_util.EntryIterator;
 
 // Use fast compression for tests
 const TEST_COMPRESSION_LEVEL: c_int = 2;
@@ -220,7 +221,7 @@ test "bundle validates paths correctly" {
         var iter = FilePathIterator{ .paths = &paths };
 
         var error_ctx: bundle.ErrorContext = undefined;
-        const result = bundle.bundle(&iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, tmp.dir, null, &error_ctx);
+        const result = bundle.bundle(&iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, tmp.dir, &error_ctx);
 
         try testing.expectError(error.InvalidPath, result);
         try testing.expectEqual(bundle.PathValidationReason.windows_reserved_name, error_ctx.reason);
@@ -239,8 +240,9 @@ test "bundle validates paths correctly" {
         const paths = [_][]const u8{"normal.txt"};
         var iter = FilePathIterator{ .paths = &paths };
 
-        const filename = try bundle.bundle(&iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, tmp.dir, null, null);
-        defer allocator.free(filename);
+        const result = try bundle.bundle(&iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, tmp.dir, null);
+        defer allocator.free(result.filename);
+        try testing.expectEqual(@as(u64, "Normal content".len), result.uncompressed_size);
 
         // Should succeed
         var list = bundle_writer.toArrayList();
@@ -370,7 +372,7 @@ test "bundle and unbundle roundtrip" {
     var bundle_writer: std.Io.Writer.Allocating = .init(allocator);
     defer bundle_writer.deinit();
 
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null, null);
+    const filename = (try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null)).filename;
     defer allocator.free(filename);
 
     // Create destination temp directory
@@ -456,7 +458,7 @@ test "bundle and unbundle over socket stream" {
     var file_iter = FilePathIterator{ .paths = &file_paths };
     var bundle_writer_buffer: [4096]u8 = undefined;
     var bundle_writer = bundle_file.writer(io, &bundle_writer_buffer);
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.interface, src_dir, null, null);
+    const filename = (try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.interface, src_dir, null)).filename;
     try bundle_writer.interface.flush();
     defer allocator.free(filename);
 
@@ -601,7 +603,7 @@ test "minimal bundle unbundle" {
 
     const file_paths = [_][]const u8{"test.txt"};
     var file_iter = FilePathIterator{ .paths = &file_paths };
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null, null);
+    const filename = (try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null)).filename;
     defer allocator.free(filename);
 
     // Create destination temp directory
@@ -622,7 +624,7 @@ test "minimal bundle unbundle" {
     try testing.expectEqualStrings("Hello", content);
 }
 
-test "bundle with path prefix stripping" {
+test "bundle stores an archive path distinct from its source path" {
     const testing = std.testing;
     var allocator = testing.allocator;
     const io = std.testing.io;
@@ -636,7 +638,7 @@ test "bundle with path prefix stripping" {
     try src_dir.createDirPath(io, "foo/bar/src");
     try src_dir.createDirPath(io, "foo/bar/src/utils");
 
-    // Create test files with the prefix
+    // Create source files below a nested directory.
     {
         const file = try src_dir.createFile(io, "foo/bar/src/main.txt", .{});
         defer file.close(io);
@@ -648,20 +650,18 @@ test "bundle with path prefix stripping" {
         try file.writeStreamingAll(io, "Helper file content");
     }
 
-    // Bundle with path prefix
+    // Store each file relative to that directory in the archive.
     var bundle_writer: std.Io.Writer.Allocating = .init(allocator);
     defer bundle_writer.deinit();
 
-    // File paths include the full prefix
-    const file_paths = [_][]const u8{
-        "foo/bar/src/main.txt",
-        "foo/bar/src/utils/helper.txt",
+    const entries = [_]bundle.Entry{
+        .{ .source_path = "foo/bar/src/main.txt", .archive_path = "main.txt" },
+        .{ .source_path = "foo/bar/src/utils/helper.txt", .archive_path = "utils/helper.txt" },
     };
 
-    var file_iter = FilePathIterator{ .paths = &file_paths };
+    var entry_iter = EntryIterator{ .entries = &entries };
 
-    // Bundle with prefix "foo/bar/src/"
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, "foo/bar/src/", null);
+    const filename = (try bundle.bundle(&entry_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null)).filename;
     defer allocator.free(filename);
 
     // Create destination temp directory
@@ -708,7 +708,7 @@ test "blake3 hash verification failure" {
 
     const file_paths = [_][]const u8{"test.txt"};
     var file_iter = FilePathIterator{ .paths = &file_paths };
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null, null);
+    const filename = (try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null)).filename;
     defer allocator.free(filename);
 
     // Create destination directory
@@ -751,7 +751,7 @@ test "unbundle tolerates a pre-existing directory named after the archive" {
     const files = [_][]const u8{"test.txt"};
     var iter = FilePathIterator{ .paths = &files };
 
-    const filename = try bundle.bundle(&iter, TEST_COMPRESSION_LEVEL, &allocator, io, &output_writer.writer, src_dir, null, null);
+    const filename = (try bundle.bundle(&iter, TEST_COMPRESSION_LEVEL, &allocator, io, &output_writer.writer, src_dir, null)).filename;
     defer allocator.free(filename);
 
     // Create a destination directory that already contains a directory
@@ -798,7 +798,7 @@ test "blake3 hash detects corruption" {
 
     const file_paths = [_][]const u8{"test.txt"};
     var file_iter = FilePathIterator{ .paths = &file_paths };
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null, null);
+    const filename = (try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, src_dir, null)).filename;
     defer allocator.free(filename);
 
     // Corrupt the data by flipping a bit
@@ -885,7 +885,7 @@ test "double roundtrip bundle -> unbundle -> bundle -> unbundle" {
     }
     var iter1 = FilePathIterator{ .paths = paths1.items };
 
-    const filename1 = try bundle.bundle(&iter1, TEST_COMPRESSION_LEVEL, &allocator, io, &first_bundle_writer.writer, initial_dir, null, null);
+    const filename1 = (try bundle.bundle(&iter1, TEST_COMPRESSION_LEVEL, &allocator, io, &first_bundle_writer.writer, initial_dir, null)).filename;
     defer allocator.free(filename1);
 
     // Write first bundle to file
@@ -926,7 +926,7 @@ test "double roundtrip bundle -> unbundle -> bundle -> unbundle" {
     var iter2 = FilePathIterator{ .paths = paths2.items };
 
     const extracted1_dir = try unbundle1_dir.openDir(io, "extracted1", .{});
-    const filename2 = try bundle.bundle(&iter2, TEST_COMPRESSION_LEVEL, &allocator, io, &second_bundle_writer.writer, extracted1_dir, null, null);
+    const filename2 = (try bundle.bundle(&iter2, TEST_COMPRESSION_LEVEL, &allocator, io, &second_bundle_writer.writer, extracted1_dir, null)).filename;
     defer allocator.free(filename2);
 
     // Filenames should be identical (same content = same hash)
@@ -1116,7 +1116,7 @@ test "download from local server" {
     };
     var file_iter = FilePathIterator{ .paths = &file_paths };
 
-    const filename = try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, tmp.dir, null, null);
+    const filename = (try bundle.bundle(&file_iter, TEST_COMPRESSION_LEVEL, &allocator, io, &bundle_writer.writer, tmp.dir, null)).filename;
     defer allocator.free(filename);
 
     // Extract hash from filename
@@ -1286,7 +1286,7 @@ test "unbundleStream with BufferExtractWriter (WASM simulation)" {
     var bundle_writer: std.Io.Writer.Allocating = .init(allocator);
     defer bundle_writer.deinit();
 
-    const filename = try bundle.bundle(
+    const filename = (try bundle.bundle(
         &file_iter,
         TEST_COMPRESSION_LEVEL,
         &allocator,
@@ -1294,8 +1294,7 @@ test "unbundleStream with BufferExtractWriter (WASM simulation)" {
         &bundle_writer.writer,
         src_dir,
         null,
-        null,
-    );
+    )).filename;
     defer allocator.free(filename);
 
     // Parse hash from filename
@@ -1374,7 +1373,7 @@ test "unbundleStream with large file (multi-block zstd)" {
     var bundle_writer: std.Io.Writer.Allocating = .init(allocator);
     defer bundle_writer.deinit();
 
-    const filename = try bundle.bundle(
+    const filename = (try bundle.bundle(
         &file_iter,
         TEST_COMPRESSION_LEVEL,
         &allocator,
@@ -1382,8 +1381,7 @@ test "unbundleStream with large file (multi-block zstd)" {
         &bundle_writer.writer,
         src_dir,
         null,
-        null,
-    );
+    )).filename;
     defer allocator.free(filename);
 
     // Parse hash from filename
@@ -1458,7 +1456,7 @@ test "unbundleStream reports expanded size and enforces the limit" {
     var bundle_writer: std.Io.Writer.Allocating = .init(allocator);
     defer bundle_writer.deinit();
 
-    const filename = try bundle.bundle(
+    const filename = (try bundle.bundle(
         &file_iter,
         TEST_COMPRESSION_LEVEL,
         &allocator,
@@ -1466,8 +1464,7 @@ test "unbundleStream reports expanded size and enforces the limit" {
         &bundle_writer.writer,
         src_dir,
         null,
-        null,
-    );
+    )).filename;
     defer allocator.free(filename);
 
     const hash_str = filename[0 .. filename.len - ".tar.zst".len];

--- a/src/bundle/test_streaming.zig
+++ b/src/bundle/test_streaming.zig
@@ -309,7 +309,7 @@ test "large file streaming extraction" {
     var iter = test_util.FilePathIterator{ .paths = &paths };
 
     var allocator_copy = allocator;
-    const filename = try bundle.bundle(
+    const filename = (try bundle.bundle(
         &iter,
         3,
         &allocator_copy,
@@ -317,8 +317,7 @@ test "large file streaming extraction" {
         &bundle_writer.writer,
         tmp.dir,
         null,
-        null,
-    );
+    )).filename;
     defer allocator.free(filename);
 
     // Just verify we successfully bundled a large file

--- a/src/bundle/test_util.zig
+++ b/src/bundle/test_util.zig
@@ -2,16 +2,30 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const bundle = @import("bundle.zig");
 
 /// Iterator for file paths used in tests
 pub const FilePathIterator = struct {
     paths: []const []const u8,
     index: usize = 0,
 
-    pub fn next(self: *FilePathIterator) Allocator.Error!?[]const u8 {
+    pub fn next(self: *FilePathIterator) Allocator.Error!?bundle.Entry {
         if (self.index >= self.paths.len) return null;
         const path = self.paths[self.index];
         self.index += 1;
-        return path;
+        return .{ .source_path = path, .archive_path = path };
+    }
+};
+
+/// Iterator for explicit source and archive path pairs used in tests.
+pub const EntryIterator = struct {
+    entries: []const bundle.Entry,
+    index: usize = 0,
+
+    pub fn next(self: *EntryIterator) Allocator.Error!?bundle.Entry {
+        if (self.index >= self.entries.len) return null;
+        const entry = self.entries[self.index];
+        self.index += 1;
+        return entry;
     }
 };

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -7729,23 +7729,14 @@ fn formatUnbundlePathValidationReason(reason: unbundle.PathValidationReason) []c
 
 /// Use the Coordinator to discover every transitive module the entry point
 /// imports (directly, via re-exports, or via a `package [...]` header) and
-/// append any not already in `file_paths` so the bundle includes them
-/// automatically. `uncompressed_size` is updated to reflect the newly added
-/// files. Also validates platform target binaries if a platform is found.
+/// append the absolute path of any not already in `source_paths`. Also
+/// validates platform target binaries if a platform is found.
 fn discoverAndAddBundleModules(
     ctx: *CliCtx,
-    first_roc_file: []const u8,
-    file_paths: *std.ArrayList([]const u8),
-    uncompressed_size: *u64,
+    abs_entry: []const u8,
+    source_paths: *std.ArrayList([]const u8),
     stderr: anytype,
 ) CliMainError!void {
-    // Resolve the entry point to an absolute path
-    const abs_entry = std.Io.Dir.cwd().realPathFileAlloc(ctx.io.std_io, first_roc_file, ctx.gpa) catch |err| {
-        try stderr.print("Error: Could not resolve path '{s}': {}\n", .{ first_roc_file, err });
-        return err;
-    };
-    defer ctx.gpa.free(abs_entry);
-
     // Create a BuildEnv to parse headers and discover modules via the
     // Coordinator. Bundling compiles the workspace to discover transitive
     // modules; it uses the checked-module cache like every other pipeline.
@@ -7753,9 +7744,9 @@ fn discoverAndAddBundleModules(
     defer build_env.deinit();
 
     // Run the build—the Coordinator discovers all transitive module dependencies
-    build_env.build(abs_entry) catch {
+    build_env.build(abs_entry) catch |build_err| {
         // Drain and display any errors from the build
-        const drained = build_env.drainReports() catch &[_]BuildEnv.DrainedModuleReports{};
+        const drained = try build_env.drainReports();
         defer build_env.freeDrainedReportsPathsOnly(drained);
 
         for (drained) |mod| {
@@ -7770,7 +7761,7 @@ fn discoverAndAddBundleModules(
                 }
             }
         }
-        // Build errors are not fatal for bundling—continue to check what we can
+        return build_err;
     };
 
     // Detect platform from BuildEnv packages using the accessor
@@ -7780,18 +7771,15 @@ fn discoverAndAddBundleModules(
     var bundled_set = std.StringHashMap(void).init(ctx.gpa);
     defer bundled_set.deinit();
 
-    for (file_paths.items) |rel_path| {
-        const abs_path = std.Io.Dir.cwd().realPathFileAlloc(ctx.io.std_io, rel_path, ctx.gpa) catch continue;
-        defer ctx.gpa.free(abs_path);
-        try bundled_set.put(try ctx.arena.dupe(u8, abs_path), {});
+    for (source_paths.items) |abs_path| {
+        try bundled_set.put(abs_path, {});
     }
 
     // Append any discovered module that is not already in the bundle list.
     // URL dependencies are skipped: their files live in the local package
     // cache, and consumers resolve them from the URLs in the header.
-    // The Coordinator yields absolute paths; convert each to a path relative
-    // to cwd so it round-trips through `cwd.openFile` and survives the
-    // bundle's path-validation step (which rejects absolute paths).
+    // The Coordinator yields absolute paths. Keep that explicit source
+    // identity here; rocBundle assigns the separate archive path later.
     if (build_env.coordinator) |coord| {
         var coord_pkg_it = coord.packages.iterator();
         while (coord_pkg_it.next()) |pkg_entry| {
@@ -7800,25 +7788,9 @@ fn discoverAndAddBundleModules(
                 if (!build_env.isBundleableModule(pkg_entry.key_ptr.*, abs_path)) continue;
                 if (bundled_set.contains(abs_path)) continue;
 
-                const rel_path = std.fs.path.relative(ctx.arena, build_env.cwd, null, build_env.cwd, abs_path) catch {
-                    try stderr.print("Error: Discovered module path is outside the current directory and cannot be bundled: {s}\n", .{abs_path});
-                    return error.MissingBundleFiles;
-                };
-
-                // Confirm the file is actually readable from cwd before adding it.
-                const file = std.Io.Dir.cwd().openFile(ctx.io.std_io, rel_path, .{}) catch |err| {
-                    try stderr.print("Error: Could not open discovered module '{s}': {}\n", .{ rel_path, err });
-                    return err;
-                };
-                const stat = file.stat(ctx.io.std_io) catch |err| {
-                    file.close(ctx.io.std_io);
-                    return err;
-                };
-                file.close(ctx.io.std_io);
-
-                try file_paths.append(ctx.arena, rel_path);
-                try bundled_set.put(try ctx.arena.dupe(u8, abs_path), {});
-                uncompressed_size.* += stat.size;
+                const owned_abs_path = try ctx.arena.dupe(u8, abs_path);
+                try source_paths.append(ctx.arena, owned_abs_path);
+                try bundled_set.put(owned_abs_path, {});
             }
         }
     }
@@ -7853,63 +7825,32 @@ fn discoverAndAddBundleModules(
     }
 }
 
-/// Find the longest directory path that is an ancestor of every input in `abs_paths`.
-/// All inputs must be absolute paths (they may be paths to files or directories).
-/// Returns the common parent directory with no trailing path separator (except for
-/// a filesystem root such as "/"). Returns an empty slice if the inputs share no
-/// directory ancestor (e.g. two Windows paths on different drives).
-fn longestCommonParentDir(allocator: std.mem.Allocator, abs_paths: []const []const u8) Allocator.Error![]u8 {
-    std.debug.assert(abs_paths.len > 0);
+/// Give a source file its portable name inside a bundle rooted at
+/// `bundle_root`. A source outside that root cannot be represented without
+/// either escaping the extraction directory or changing source-level package
+/// paths, so reject it explicitly.
+fn bundleArchivePath(
+    allocator: Allocator,
+    bundle_root: []const u8,
+    abs_source_path: []const u8,
+) (Allocator.Error || error{InvalidPath})![]u8 {
+    const relative_path = try std.fs.path.relative(allocator, bundle_root, null, bundle_root, abs_source_path);
+    errdefer allocator.free(relative_path);
 
-    const isSep = struct {
-        fn f(byte: u8) bool {
-            return byte == '/' or byte == '\\';
-        }
-    }.f;
-
-    // Start with the dirname of the first path.
-    var common = std.ArrayList(u8).empty;
-    errdefer common.deinit(allocator);
-    const first_dir = std.fs.path.dirname(abs_paths[0]) orelse abs_paths[0];
-    try common.appendSlice(allocator, first_dir);
-
-    for (abs_paths[1..]) |path| {
-        const dir = std.fs.path.dirname(path) orelse path;
-
-        // Find longest byte prefix shared between `common` and `dir`.
-        var i: usize = 0;
-        const max = @min(common.items.len, dir.len);
-        while (i < max and common.items[i] == dir[i]) : (i += 1) {}
-
-        // i is on a directory boundary if it is at the end of either path
-        // OR the next byte of either path is a separator.
-        const at_boundary = (i == common.items.len and (i == dir.len or isSep(dir[i]))) or
-            (i == dir.len and (i == common.items.len or isSep(common.items[i])));
-
-        if (!at_boundary) {
-            // Back up to the last separator within [0..i). Drop everything after it.
-            var j: usize = i;
-            while (j > 0) {
-                j -= 1;
-                if (isSep(common.items[j])) {
-                    // Keep the separator only when it's the root sep at index 0.
-                    i = if (j == 0) 1 else j;
-                    break;
-                }
-            } else {
-                i = 0;
-            }
-        }
-
-        common.items.len = @min(common.items.len, i);
+    if (relative_path.len == 0 or
+        std.fs.path.isAbsolute(relative_path) or
+        std.mem.eql(u8, relative_path, "..") or
+        std.mem.startsWith(u8, relative_path, "../") or
+        std.mem.startsWith(u8, relative_path, "..\\"))
+    {
+        return error.InvalidPath;
     }
 
-    // Strip trailing separators (preserve a single root separator).
-    while (common.items.len > 1 and isSep(common.items[common.items.len - 1])) {
-        common.items.len -= 1;
+    if (builtin.target.os.tag == .windows) {
+        std.mem.replaceScalar(u8, relative_path, '\\', '/');
     }
 
-    return common.toOwnedSlice(allocator);
+    return relative_path;
 }
 
 /// Bundles a roc package and its dependencies into a compressed tar archive
@@ -7937,144 +7878,108 @@ pub fn rocBundle(ctx: *CliCtx, args: cli_args.BundleArgs) CliMainError!void {
         std.Io.Dir.cwd().deleteTree(ctx.io.std_io, ".roc_bundle_tmp") catch {};
     }
 
-    // Collect all files to bundle
-    var file_paths = std.ArrayList([]const u8).empty;
-    defer file_paths.deinit(ctx.arena);
-
-    var uncompressed_size: u64 = 0;
+    // Collect canonical source paths separately from their eventual archive
+    // names. A command-line spelling is only a way to find a file; it must not
+    // accidentally decide where that file appears inside the bundle.
+    var source_paths = std.ArrayList([]const u8).empty;
+    defer source_paths.deinit(ctx.arena);
 
     // If no paths provided, default to "main.roc"
     const paths_to_use = if (args.paths.len == 0) &[_][]const u8{"main.roc"} else args.paths;
 
-    // Remember the first path from CLI args (before sorting)
-    const first_cli_path = paths_to_use[0];
+    // Find the first .roc file to use as entry point for module discovery
+    const first_roc_index: ?usize = for (paths_to_use, 0..) |path, index| {
+        if (std.mem.endsWith(u8, path, ".roc")) break index;
+    } else null;
 
-    // Detect whether any input path is absolute. Absolute paths are not allowed
-    // inside the archive (the unbundle side rejects them, and a relative path
-    // is what the user actually wants extracted). If any input is absolute we
-    // rebase all paths against their longest common parent directory and pass
-    // that directory to the bundle library—so the archive itself only ever
-    // contains relative paths.
-    var any_absolute = false;
+    // Resolve every explicitly requested file exactly once. Discovered module
+    // paths are already absolute, so all following work uses one path form.
     for (paths_to_use) |path| {
-        if (std.fs.path.isAbsolute(path)) {
-            any_absolute = true;
-            break;
-        }
-    }
-
-    // Check that all files exist and collect their sizes
-    for (paths_to_use) |path| {
-        const file = cwd.openFile(ctx.io.std_io, path, .{}) catch |err| {
-            try stderr.print("Error: Could not open file '{s}': {}\n", .{ path, err });
+        const abs_path = cwd.realPathFileAlloc(ctx.io.std_io, path, ctx.arena) catch |err| {
+            try stderr.print("Error: Could not resolve file '{s}': {}\n", .{ path, err });
             return err;
         };
-        defer file.close(ctx.io.std_io);
-
-        const stat = try file.stat(ctx.io.std_io);
-        uncompressed_size += stat.size;
-
-        try file_paths.append(ctx.arena, path);
+        try source_paths.append(ctx.arena, abs_path);
     }
 
-    // Find the first .roc file to use as entry point for module discovery
-    const first_roc_file: ?[]const u8 = for (paths_to_use) |path| {
-        if (std.mem.endsWith(u8, path, ".roc")) break path;
-    } else null;
+    const entry_source_path = source_paths.items[first_roc_index orelse 0];
+    const bundle_root_path = std.fs.path.dirname(entry_source_path) orelse {
+        try stderr.print("Error: Could not determine the directory containing entry point '{s}'.\n", .{entry_source_path});
+        return error.InvalidPath;
+    };
 
     // Use the Coordinator to discover all transitive module dependencies
     // (explicit imports plus modules exposed by a `package [...]` header)
     // and append any not already in the file list.
-    if (first_roc_file) |roc_file| {
-        try discoverAndAddBundleModules(ctx, roc_file, &file_paths, &uncompressed_size, stderr);
+    if (first_roc_index != null) {
+        try discoverAndAddBundleModules(ctx, entry_source_path, &source_paths, stderr);
     }
 
-    // Sort and deduplicate paths
-    std.mem.sort([]const u8, file_paths.items, {}, struct {
-        fn lessThan(_: void, a: []const u8, b: []const u8) bool {
-            return std.mem.order(u8, a, b) == .lt;
+    var entries = std.ArrayList(bundle.Entry).empty;
+    defer entries.deinit(ctx.arena);
+    var archive_sources = std.StringHashMap([]const u8).init(ctx.gpa);
+    defer archive_sources.deinit();
+    var entry_archive_path: ?[]const u8 = null;
+
+    for (source_paths.items) |abs_source_path| {
+        const archive_path = bundleArchivePath(ctx.arena, bundle_root_path, abs_source_path) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidPath => {
+                try stderr.print(
+                    "Error: Cannot bundle '{s}' because it is outside the entry point directory '{s}'.\n",
+                    .{ abs_source_path, bundle_root_path },
+                );
+                return error.InvalidPath;
+            },
+        };
+
+        const existing_source = try archive_sources.getOrPut(archive_path);
+        if (existing_source.found_existing) {
+            if (std.mem.eql(u8, existing_source.value_ptr.*, abs_source_path)) continue;
+            try stderr.print(
+                "Error: Both '{s}' and '{s}' would be stored as '{s}' in the bundle.\n",
+                .{ existing_source.value_ptr.*, abs_source_path, existing_source.key_ptr.* },
+            );
+            return error.InvalidPath;
+        }
+        existing_source.value_ptr.* = abs_source_path;
+
+        try entries.append(ctx.arena, .{
+            .source_path = archive_path,
+            .archive_path = archive_path,
+        });
+        if (std.mem.eql(u8, abs_source_path, entry_source_path)) {
+            entry_archive_path = archive_path;
+        }
+    }
+
+    std.mem.sort(bundle.Entry, entries.items, {}, struct {
+        fn lessThan(_: void, a: bundle.Entry, b: bundle.Entry) bool {
+            return std.mem.order(u8, a.archive_path, b.archive_path) == .lt;
         }
     }.lessThan);
 
-    // Remove duplicates by keeping only unique consecutive elements
-    var unique_count: usize = 0;
-    for (file_paths.items, 0..) |path, i| {
-        if (i == 0 or !std.mem.eql(u8, path, file_paths.items[i - 1])) {
-            file_paths.items[unique_count] = path;
-            unique_count += 1;
-        }
-    }
-    file_paths.items.len = unique_count;
-
-    // If we have more than one file, ensure the first CLI arg stays first
-    if (file_paths.items.len > 1) {
-        // Find the first CLI path in the sorted array
-        var found_index: ?usize = null;
-        for (file_paths.items, 0..) |path, i| {
-            if (std.mem.eql(u8, path, first_cli_path)) {
-                found_index = i;
+    // Keep the entry point first while sorting every other name. This makes
+    // bundle hashes deterministic without depending on coordinator map order.
+    if (entry_archive_path) |entry_path| {
+        for (entries.items, 0..) |entry, index| {
+            if (std.mem.eql(u8, entry.archive_path, entry_path)) {
+                const entry_point = entries.items[index];
+                var destination = index;
+                while (destination > 0) : (destination -= 1) {
+                    entries.items[destination] = entries.items[destination - 1];
+                }
+                entries.items[0] = entry_point;
                 break;
             }
         }
-
-        // Swap the found item with the first position if needed
-        if (found_index) |idx| {
-            if (idx != 0) {
-                const temp = file_paths.items[0];
-                file_paths.items[0] = file_paths.items[idx];
-                file_paths.items[idx] = temp;
-            }
-        }
     }
 
-    // If any input was absolute, rebase all paths against their longest common
-    // parent directory so the archive only contains relative paths. The opened
-    // directory becomes the base_dir passed to the bundle library.
-    //
-    // Discovery (above) added transitively imported modules as cwd-relative
-    // paths; `realpathAlloc` resolves both forms so they share the common
-    // parent uniformly here.
-    var rebased_base_dir: ?std.Io.Dir = null;
-    defer if (rebased_base_dir) |d| d.close(ctx.io.std_io);
-    var archive_paths: []const []const u8 = file_paths.items;
-    if (any_absolute) {
-        const resolved = try ctx.arena.alloc([]u8, file_paths.items.len);
-        for (file_paths.items, 0..) |p, i| {
-            resolved[i] = cwd.realPathFileAlloc(ctx.io.std_io, p, ctx.arena) catch |err| {
-                try stderr.print("Error: Could not resolve path '{s}': {}\n", .{ p, err });
-                return err;
-            };
-        }
-
-        const common = try longestCommonParentDir(ctx.arena, resolved);
-        if (common.len == 0) {
-            try stderr.print("Error: Input file paths have no common parent directory.\n", .{});
-            return error.InvalidPath;
-        }
-
-        const opened_dir = std.Io.Dir.openDirAbsolute(ctx.io.std_io, common, .{}) catch |err| {
-            try stderr.print("Error: Could not open common parent directory '{s}': {}\n", .{ common, err });
-            return err;
-        };
-        rebased_base_dir = opened_dir;
-
-        // Build relative-to-common paths for the archive.
-        const rel_paths = try ctx.arena.alloc([]const u8, resolved.len);
-        for (resolved, 0..) |abs, i| {
-            // abs must start with `common`; everything after is the relative path.
-            // common has no trailing separator, so skip the leading separator byte
-            // that follows it within abs.
-            if (abs.len <= common.len or
-                !std.mem.eql(u8, abs[0..common.len], common) or
-                !(abs[common.len] == '/' or abs[common.len] == '\\'))
-            {
-                try stderr.print("Error: Path '{s}' is not under the common parent '{s}'.\n", .{ abs, common });
-                return error.InvalidPath;
-            }
-            rel_paths[i] = abs[common.len + 1 ..];
-        }
-        archive_paths = rel_paths;
-    }
+    var bundle_root_dir = std.Io.Dir.openDirAbsolute(ctx.io.std_io, bundle_root_path, .{}) catch |err| {
+        try stderr.print("Error: Could not open entry point directory '{s}': {}\n", .{ bundle_root_path, err });
+        return err;
+    };
+    defer bundle_root_dir.close(ctx.io.std_io);
 
     // Create temporary output file
     const temp_filename = "temp_bundle.tar.zst";
@@ -8085,35 +7990,32 @@ pub fn rocBundle(ctx: *CliCtx, args: cli_args.BundleArgs) CliMainError!void {
     });
     defer temp_file.close(ctx.io.std_io);
 
-    // Create file path iterator
-    const FilePathIterator = struct {
-        paths: []const []const u8,
+    const EntryIterator = struct {
+        entries: []const bundle.Entry,
         index: usize = 0,
 
-        pub fn next(self: *@This()) Allocator.Error!?[]const u8 {
-            if (self.index >= self.paths.len) return null;
-            const path = self.paths[self.index];
+        pub fn next(self: *@This()) Allocator.Error!?bundle.Entry {
+            if (self.index >= self.entries.len) return null;
+            const entry = self.entries[self.index];
             self.index += 1;
-            return path;
+            return entry;
         }
     };
 
-    var iter = FilePathIterator{ .paths = archive_paths };
+    var iter = EntryIterator{ .entries = entries.items };
 
     // Bundle the files
     var allocator_copy = ctx.arena;
     var error_ctx: bundle.ErrorContext = undefined;
     var temp_writer_buffer: [4096]u8 = undefined;
     var temp_writer = temp_file.writerStreaming(ctx.io.std_io, &temp_writer_buffer);
-    const bundle_base_dir = rebased_base_dir orelse cwd;
-    const final_filename = bundle.bundleFiles(
+    const bundle_result = bundle.bundleFiles(
         &iter,
         @intCast(args.compression_level),
         &allocator_copy,
         ctx.io.std_io,
         &temp_writer.interface,
-        bundle_base_dir,
-        null, // path_prefix parameter - null means no stripping
+        bundle_root_dir,
         &error_ctx,
     ) catch |err| {
         switch (err) {
@@ -8140,6 +8042,8 @@ pub fn rocBundle(ctx: *CliCtx, args: cli_args.BundleArgs) CliMainError!void {
         return err;
     };
     // No need to free when using arena allocator
+    const final_filename = bundle_result.filename;
+    const uncompressed_size = bundle_result.uncompressed_size;
 
     try temp_writer.interface.flush();
 
@@ -18272,36 +18176,22 @@ test "check errors determine command failure after work completes" {
     try failOnCheckErrors(.{});
 }
 
-test "longestCommonParentDir" {
+test "bundle archive paths are relative to the entry point directory" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
-    const cases = [_]struct {
-        paths: []const []const u8,
-        expected: []const u8,
-    }{
-        // Single file: parent directory of that file.
-        .{ .paths = &.{"/tmp/pkg/main.roc"}, .expected = "/tmp/pkg" },
-        // Two files sharing a parent.
-        .{ .paths = &.{ "/tmp/pkg/main.roc", "/tmp/pkg/Mod.roc" }, .expected = "/tmp/pkg" },
-        // Files in sibling subdirectories: common parent.
-        .{ .paths = &.{ "/tmp/nested/a/main.roc", "/tmp/nested/b/Mod.roc" }, .expected = "/tmp/nested" },
-        // Names share a byte prefix but no directory boundary—must back up.
-        .{ .paths = &.{ "/tmp/abc/a.roc", "/tmp/abd/b.roc" }, .expected = "/tmp" },
-        // Only root in common.
-        .{ .paths = &.{ "/etc/foo.roc", "/var/bar.roc" }, .expected = "/" },
-        // Three files with same parent.
-        .{ .paths = &.{ "/a/b/c/x.roc", "/a/b/c/y.roc", "/a/b/c/z.roc" }, .expected = "/a/b/c" },
-        // Three files where the third narrows the common parent.
-        .{ .paths = &.{ "/a/b/c/x.roc", "/a/b/c/y.roc", "/a/b/d/z.roc" }, .expected = "/a/b" },
-    };
+    const root = if (builtin.target.os.tag == .windows) "C:\\pkg\\src" else "/pkg/src";
+    const main_path = if (builtin.target.os.tag == .windows) "C:\\pkg\\src\\main.roc" else "/pkg/src/main.roc";
+    const nested = if (builtin.target.os.tag == .windows) "C:\\pkg\\src\\internal\\Helper.roc" else "/pkg/src/internal/Helper.roc";
+    const outside = if (builtin.target.os.tag == .windows) "C:\\pkg\\src-other\\Secret.roc" else "/pkg/src-other/Secret.roc";
 
-    for (cases) |tc| {
-        const got = try longestCommonParentDir(allocator, tc.paths);
-        defer allocator.free(got);
-        testing.expectEqualStrings(tc.expected, got) catch |err| {
-            std.debug.print("Failed case: expected='{s}' got='{s}'\n", .{ tc.expected, got });
-            return err;
-        };
-    }
+    const main_archive_path = try bundleArchivePath(allocator, root, main_path);
+    defer allocator.free(main_archive_path);
+    try testing.expectEqualStrings("main.roc", main_archive_path);
+
+    const nested_archive_path = try bundleArchivePath(allocator, root, nested);
+    defer allocator.free(nested_archive_path);
+    try testing.expectEqualStrings("internal/Helper.roc", nested_archive_path);
+
+    try testing.expectError(error.InvalidPath, bundleArchivePath(allocator, root, outside));
 }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -434,6 +434,7 @@ const CustomCase = enum {
     docs_main_platform_url_package,
     build_issue_9435_hosted_nominal_return,
     bundle_complex_package,
+    bundle_entrypoint_subdirectory,
     install_run_roundtrip,
     install_hash_mismatch,
     install_glue_roundtrip,
@@ -1833,6 +1834,7 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc docs Builtin.roc succeeds", .body = .{ .command = .{ .args = &.{ "docs", "--no-cache" }, .roc_file = "src/build/roc/Builtin.roc", .contains = &.{.{ .stream = .stdout, .text = "Generated docs for" }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc test complex_package --verbose passes all tests", .body = .{ .command = .{ .args = &.{ "test", "--no-cache", "--verbose" }, .roc_file = "test/complex_package/main.roc", .contains = &.{ .{ .stream = .stdout, .text = "tests passed" }, .{ .stream = .stdout, .text = "PASS" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc bundle complex_package includes all transitively imported modules", .body = .{ .custom = .bundle_complex_package } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc bundle issue 10845 entry point in a subdirectory bundles relative to it", .body = .{ .custom = .bundle_entrypoint_subdirectory } },
     .{ .id = 0, .suite = .subcommands, .name = "failed inline expect exits with code 1 and continues program (dev)", .backend = .dev, .body = .{ .command = .{ .args = &.{}, .roc_file = "test/cli/failed_inline_expect.roc", .exit = .{ .code = 1 }, .contains = &.{ .{ .stream = .stdout, .text = "Hello, World!" }, .{ .stream = .stderr, .text = "expect failed" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "failed inline expect exits with code 1 and continues program (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/cli/failed_inline_expect.roc", .exit = .{ .code = 1 }, .contains = &.{ .{ .stream = .stdout, .text = "Hello, World!" }, .{ .stream = .stderr, .text = "Expect failed" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "failed inline expect is omitted from roc --opt=size", .body = .{ .command = .{ .args = &.{ "--opt=size", "--no-cache" }, .roc_file = "test/cli/failed_inline_expect.roc", .contains = &.{.{ .stream = .stdout, .text = "Hello, World!" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "expect failed" }, .{ .stream = .stderr, .text = "Expect failed" } } } } },
@@ -2862,6 +2864,7 @@ fn runCustomCase(
         .docs_main_platform_url_package => customDocsMainPlatformUrlPackage(io, allocator, &env, &timer, timeout_ms),
         .build_issue_9435_hosted_nominal_return => customBuildIssue9435(io, allocator, &env, &timer, timeout_ms),
         .bundle_complex_package => customBundleComplexPackage(io, allocator, &env, &timer, timeout_ms),
+        .bundle_entrypoint_subdirectory => customBundleEntrypointSubdirectory(io, allocator, &env, &timer, timeout_ms),
         .install_run_roundtrip => customInstallRunRoundtrip(io, allocator, &env, &timer, timeout_ms),
         .install_hash_mismatch => customInstallHashMismatch(io, allocator, &env, &timer, timeout_ms),
         .install_glue_roundtrip => customInstallGlueRoundtrip(io, allocator, &env, &timer, timeout_ms),
@@ -7453,6 +7456,98 @@ fn customBundleComplexPackage(io: std.Io, allocator: Allocator, env: *const Case
         .contains = &.{.{ .stream = .stdout, .text = "Created:" }},
         .not_contains = &.{.{ .stream = .stderr, .text = "missing from bundle" }},
     })) |failure| return failure;
+    return null;
+}
+
+/// Repro for https://github.com/roc-lang/roc/issues/10845
+fn customBundleEntrypointSubdirectory(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
+    const package_dir = createWorkSubdir(io, allocator, env, "bundle-subdir") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create package dir: {}", .{err});
+    const src_dir = std.fs.path.join(allocator, &.{ package_dir, "src" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate src dir: {}", .{err});
+    std.Io.Dir.cwd().createDirPath(io, src_dir) catch |err|
+        return customInfraFailure(allocator, timer, "failed to create src dir: {}", .{err});
+
+    const package_main = std.fs.path.join(allocator, &.{ src_dir, "main.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate main.roc path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = package_main, .data = "package [Helper] {}\n" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write main.roc: {}", .{err});
+    const package_helper = std.fs.path.join(allocator, &.{ src_dir, "Helper.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate Helper.roc path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = package_helper, .data = "module []\n\nhelper : U64\nhelper = 42\n" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write Helper.roc: {}", .{err});
+    const outside_module = std.fs.path.join(allocator, &.{ package_dir, "Outside.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate outside module path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = outside_module, .data = "module []\n" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write outside module: {}", .{err});
+
+    const out_dir = createWorkSubdir(io, allocator, env, "bundle-subdir-out") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create bundle output dir: {}", .{err});
+    const extract_dir = createWorkSubdir(io, allocator, env, "bundle-subdir-extract") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create extract dir: {}", .{err});
+
+    const roc_abs = if (std.fs.path.isAbsolute(roc_binary_path))
+        roc_binary_path
+    else
+        std.fs.path.join(allocator, &.{ project_root_path, roc_binary_path }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate roc path: {}", .{err});
+
+    const bundle_timeout = childCommandTimeoutMs(timer, timeout_ms) orelse
+        return timeoutFailure(allocator, timer, .run, "case timeout exhausted before bundling");
+    const bundle_result = runRawInEnv(io, allocator, env, &.{ roc_abs, "bundle", "--output-dir", out_dir, "src/main.roc" }, package_dir, null, bundle_timeout) catch |err|
+        return customInfraFailure(allocator, timer, "bundle spawn error: {}", .{err});
+    if (exitCode(bundle_result.term) != 0) {
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle failed");
+    }
+    const created_prefix = "Created: ";
+    const created_idx = std.mem.find(u8, bundle_result.stdout, created_prefix) orelse
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle did not report a created file");
+    const created_rest = bundle_result.stdout[created_idx + created_prefix.len ..];
+    const created_eol = std.mem.find(u8, created_rest, "\n") orelse created_rest.len;
+    const bundle_path = std.mem.trim(u8, created_rest[0..created_eol], " \r");
+    const bundle_filename = std.fs.path.basename(bundle_path);
+    if (!std.mem.endsWith(u8, bundle_filename, ".tar.zst")) {
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle did not create a .tar.zst archive");
+    }
+    const extracted_name = bundle_filename[0 .. bundle_filename.len - ".tar.zst".len];
+
+    const unbundle_timeout = childCommandTimeoutMs(timer, timeout_ms) orelse
+        return timeoutFailure(allocator, timer, .run, "case timeout exhausted before unbundling");
+    const unbundle_result = runRawInEnv(io, allocator, env, &.{ roc_abs, "unbundle", bundle_path }, extract_dir, null, unbundle_timeout) catch |err|
+        return customInfraFailure(allocator, timer, "unbundle spawn error: {}", .{err});
+    if (exitCode(unbundle_result.term) != 0) {
+        return failureFromRun(allocator, timer, unbundle_result, "roc unbundle failed");
+    }
+
+    const extracted_root = std.fs.path.join(allocator, &.{ extract_dir, extracted_name }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate extracted root path: {}", .{err});
+
+    for ([_][]const u8{ "main.roc", "Helper.roc" }) |entry| {
+        const entry_path = std.fs.path.join(allocator, &.{ extracted_root, entry }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate extracted entry path: {}", .{err});
+        std.Io.Dir.cwd().access(io, entry_path, .{}) catch |err|
+            return customFailure(allocator, timer, "bundle of src/main.roc is missing {s} at its root: {}", .{ entry, err });
+    }
+
+    const extracted_src = std.fs.path.join(allocator, &.{ extracted_root, "src" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate extracted src path: {}", .{err});
+    if (std.Io.Dir.cwd().access(io, extracted_src, .{})) |_| {
+        return customFailure(allocator, timer, "bundle of src/main.roc kept the src/ directory inside the archive", .{});
+    } else |_| {}
+
+    // Raising the archive root to include an outside file would put main.roc
+    // below src/ again. Refuse that unrepresentable layout explicitly.
+    const outside_timeout = childCommandTimeoutMs(timer, timeout_ms) orelse
+        return timeoutFailure(allocator, timer, .run, "case timeout exhausted before outside-root bundle check");
+    const outside_result = runRawInEnv(io, allocator, env, &.{ roc_abs, "bundle", "--output-dir", out_dir, "src/main.roc", "Outside.roc" }, package_dir, null, outside_timeout) catch |err|
+        return customInfraFailure(allocator, timer, "outside-root bundle spawn error: {}", .{err});
+    if (exitCode(outside_result.term) == 0) {
+        return failureFromRun(allocator, timer, outside_result, "roc bundle accepted a file outside the entry point directory");
+    }
+    if (std.mem.find(u8, outside_result.stderr, "outside the entry point directory") == null) {
+        return failureFromRun(allocator, timer, outside_result, "roc bundle did not explain the outside-root file error");
+    }
+
     return null;
 }
 

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -1452,6 +1452,7 @@ const State = struct {
         "local_dense",
         "pool",
         "result_discriminant",
+        "any_negative",
     };
 
     /// Fields a refill leaves as the recycled state already has them. Every


### PR DESCRIPTION
When an entry point was below the current directory, its command-line path accidentally became its name inside the archive, producing bundles whose main.roc was not at the root. This derives every archive name from its canonical source path relative to the entry point directory, rejects files outside that directory because they cannot be represented without changing package paths, and gives the low-level bundler explicit source and archive paths so it streams each file once while computing the reported size.

The branch also restores the baseline build by listing any_negative in the existing refillFrom field-accounting check, matching the field the method already copies.

Fixes #10845.