### PR TITLE
Fix nominal record mismatch diagnostics

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -762,7 +762,7 @@ const CheckTypeCheckerPatternsStep = struct {
         // report.zig compares already-formatted diagnostic text only to avoid
         // printing two visually identical types. This is presentation logic,
         // not a type-checking or identifier comparison.
-        .{ .file = "report.zig", .start = 564, .end = 564 },
+        .{ .file = "report.zig", .start = 565, .end = 565 },
     };
 
     fn isInExcludedRange(file_path: []const u8, line_number: usize) bool {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4948,6 +4948,15 @@ fn unifyInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) 
     return self.runUnify(a, b, env, unifyOptionsForContext(ctx, .poison_to_err));
 }
 
+/// Unify the record relation that owns a record-aware diagnostic. If a
+/// nominal backing must be opened, retain that exact instantiated structure
+/// for the reporter without changing the user-facing root types.
+fn unifyRecordInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) std.mem.Allocator.Error!unifier.Result {
+    var opts = unifyOptionsForContext(ctx, .poison_to_err);
+    opts.retain_record_mismatch = true;
+    return self.runUnify(a, b, env, opts);
+}
+
 fn exprIsFreshRecordConstruction(self: *const Self, expr_idx: CIR.Expr.Idx) bool {
     const expr = self.cir.store.getExpr(expr_idx);
     return expr == .e_record or expr == .e_empty_record;
@@ -4965,7 +4974,18 @@ fn unifyOwnedRelation(
     ctx: problem.Context,
     row_width_relation: unifier.RowWidthRelation,
 ) std.mem.Allocator.Error!unifier.Result {
-    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary);
+    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary, false);
+}
+
+fn unifyOwnedRecordRelation(
+    self: *Self,
+    expected: Var,
+    actual: Var,
+    env: *Env,
+    ctx: problem.Context,
+    row_width_relation: unifier.RowWidthRelation,
+) std.mem.Allocator.Error!unifier.Result {
+    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary, true);
 }
 
 /// `unifyOwnedRelation` for a relation whose initial pair carries a root
@@ -4978,6 +4998,7 @@ fn unifyOwnedRootRelation(
     ctx: problem.Context,
     row_width_relation: unifier.RowWidthRelation,
     root_relation: unifier.RootRelation,
+    retain_record_mismatch: bool,
 ) std.mem.Allocator.Error!unifier.Result {
     const result = try self.runUnify(expected, actual, env, .{
         .context = ctx,
@@ -4986,6 +5007,7 @@ fn unifyOwnedRootRelation(
         .row_width_relation = row_width_relation,
         .field_presence_relation = fieldPresenceRelationForContext(ctx, row_width_relation),
         .record_construction_var = if (row_width_relation == .construction) actual else null,
+        .retain_record_mismatch = retain_record_mismatch,
     });
     if (result.isAccepted()) return result;
     return .{ .problem = try self.appendTypeMismatch(expected, actual, ctx) };
@@ -5002,6 +5024,8 @@ fn appendTypeMismatch(
 ) std.mem.Allocator.Error!problem.Problem.Idx {
     const expected_snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, expected);
     const actual_snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, actual);
+    const unify_env = self.unifyEnv();
+    const evidence = try unifier.snapshotMismatchEvidence(&unify_env);
     return self.problems.appendProblem(self.gpa, .{ .type_mismatch = .{
         .types = .{
             .expected_var = expected,
@@ -5010,6 +5034,7 @@ fn appendTypeMismatch(
             .actual_snapshot = actual_snapshot,
         },
         .context = ctx,
+        .evidence = evidence,
     } });
 }
 
@@ -5034,6 +5059,7 @@ fn unifyNominalConstructorBacking(
         .{ .nominal_constructor = ctx },
         row_width_relation,
         .nominal_constructor_backing,
+        false,
     );
 }
 
@@ -17745,7 +17771,7 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                             }}),
                         },
                     }, env, expr_region);
-                    _ = try self.unifyInContext(
+                    _ = try self.unifyRecordInContext(
                         record_being_updated_var,
                         actual_field_record,
                         env,
@@ -17785,7 +17811,7 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                     }, env, expr_region);
 
                     // Unify this record update with the record we're updating
-                    _ = try self.unifyInContext(record_being_updated_var, single_field_record, env, .{ .record_update = .{
+                    _ = try self.unifyRecordInContext(record_being_updated_var, single_field_record, env, .{ .record_update = .{
                         .field_name = field.name,
                         .field_region_idx = @enumFromInt(@intFromEnum(field_idx)),
                         .record_region_idx = @enumFromInt(@intFromEnum(record_being_updated_var)),
@@ -18997,7 +19023,7 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                 // A rejected access belongs to this expression. Preserve the
                 // independently-solved receiver graph and make only the access
                 // erroneous so post-check lowering emits its runtime crash.
-                const access_result = try self.unifyOwnedRelation(record_being_accessed, acc_receiver_var, env, .{ .record_access = .{
+                const access_result = try self.unifyOwnedRecordRelation(record_being_accessed, acc_receiver_var, env, .{ .record_access = .{
                     .field_name = access.name,
                     .field_region = access_region,
                     .mode = switch (access.mode) {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4953,7 +4953,7 @@ fn unifyInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) 
 /// for the reporter without changing the user-facing root types.
 fn unifyRecordInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) std.mem.Allocator.Error!unifier.Result {
     var opts = unifyOptionsForContext(ctx, .poison_to_err);
-    opts.retain_record_mismatch = true;
+    opts.nominal_record_mismatch_role = .expected;
     return self.runUnify(a, b, env, opts);
 }
 
@@ -4974,7 +4974,7 @@ fn unifyOwnedRelation(
     ctx: problem.Context,
     row_width_relation: unifier.RowWidthRelation,
 ) std.mem.Allocator.Error!unifier.Result {
-    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary, false);
+    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary, .none);
 }
 
 fn unifyOwnedRecordRelation(
@@ -4985,7 +4985,7 @@ fn unifyOwnedRecordRelation(
     ctx: problem.Context,
     row_width_relation: unifier.RowWidthRelation,
 ) std.mem.Allocator.Error!unifier.Result {
-    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary, true);
+    return self.unifyOwnedRootRelation(expected, actual, env, ctx, row_width_relation, .ordinary, .actual);
 }
 
 /// `unifyOwnedRelation` for a relation whose initial pair carries a root
@@ -4998,7 +4998,7 @@ fn unifyOwnedRootRelation(
     ctx: problem.Context,
     row_width_relation: unifier.RowWidthRelation,
     root_relation: unifier.RootRelation,
-    retain_record_mismatch: bool,
+    nominal_record_mismatch_role: unifier.NominalRecordMismatchRole,
 ) std.mem.Allocator.Error!unifier.Result {
     const result = try self.runUnify(expected, actual, env, .{
         .context = ctx,
@@ -5007,7 +5007,7 @@ fn unifyOwnedRootRelation(
         .row_width_relation = row_width_relation,
         .field_presence_relation = fieldPresenceRelationForContext(ctx, row_width_relation),
         .record_construction_var = if (row_width_relation == .construction) actual else null,
-        .retain_record_mismatch = retain_record_mismatch,
+        .nominal_record_mismatch_role = nominal_record_mismatch_role,
     });
     if (result.isAccepted()) return result;
     return .{ .problem = try self.appendTypeMismatch(expected, actual, ctx) };
@@ -5059,7 +5059,7 @@ fn unifyNominalConstructorBacking(
         .{ .nominal_constructor = ctx },
         row_width_relation,
         .nominal_constructor_backing,
-        false,
+        .none,
     );
 }
 

--- a/src/check/mod.zig
+++ b/src/check/mod.zig
@@ -97,6 +97,7 @@ test "check tests" {
     std.testing.refAllDecls(@import("test/issue_10759_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10804_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10824_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11057_test.zig"));
     std.testing.refAllDecls(@import("test/nominal_decl_growth_test.zig"));
 
     // Cross-module monomorphization tests

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -22,6 +22,7 @@ pub const MissingPatternsRange = types.MissingPatternsRange;
 
 // Type mismatch types
 pub const TypeMismatch = types.TypeMismatch;
+pub const TypeMismatchEvidence = types.TypeMismatchEvidence;
 pub const TypePair = types.TypePair;
 pub const IncompatiblePlatformRequirement = types.IncompatiblePlatformRequirement;
 pub const CrossModuleImport = types.CrossModuleImport;

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -439,6 +439,10 @@ pub const TypeMismatch = struct {
     types: TypePair,
     /// Where this type mismatch occurred (for contextual error messages)
     context: Context = .none,
+    /// Exact structural evidence retained by unification for reports that
+    /// would otherwise have to reconstruct a nested mismatch from the root
+    /// operands. This is populated only for contexts that consume it.
+    evidence: TypeMismatchEvidence = .none,
 };
 
 /// The expected and actual types in a type mismatch
@@ -450,6 +454,18 @@ pub const TypePair = struct {
     /// The specific region where this constraint originated from (e.g., dot access expression)
     /// If present, this region should be highlighted instead of the variable's region
     constraint_origin_var: ?Var = null,
+};
+
+/// Exact mismatch operands selected by unification after a record-backed
+/// nominal application has been opened and instantiated. Root `TypePair`
+/// snapshots preserve the user's named types; this evidence preserves the
+/// structural reason those types failed to relate.
+pub const TypeMismatchEvidence = union(enum) {
+    none,
+    record: struct {
+        expected_snapshot: SnapshotContentIdx,
+        actual_snapshot: SnapshotContentIdx,
+    },
 };
 
 /// Problem data for platform requirement type mismatches

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -439,9 +439,9 @@ pub const TypeMismatch = struct {
     types: TypePair,
     /// Where this type mismatch occurred (for contextual error messages)
     context: Context = .none,
-    /// Exact structural evidence retained by unification for reports that
-    /// would otherwise have to reconstruct a nested mismatch from the root
-    /// operands. This is populated only for contexts that consume it.
+    /// Exact structural evidence retained by unification so reports can show
+    /// a nested mismatch hidden behind the root operands. This is populated
+    /// only for contexts that consume it.
     evidence: TypeMismatchEvidence = .none,
 };
 

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -113,6 +113,7 @@ const VarWithSnapshot = problem_mod.VarWithSnapshot;
 
 // Context types for precise error reporting
 const Context = problem_mod.Context;
+const TypeMismatchEvidence = problem_mod.TypeMismatchEvidence;
 
 /// Returns singular form if count is 1, plural form otherwise.
 /// Usage: pluralize(count, "argument", "arguments")
@@ -928,8 +929,8 @@ pub const ReportBuilder = struct {
                     .fn_args_bound_var => |ctx| self.buildIncompatibleFnArgsBoundVar(mismatch.types, ctx),
                     .method_type => |ctx| self.buildIncompatibleMethodType(mismatch.types, ctx),
                     .expect => self.buildExpect(mismatch.types),
-                    .record_access => |ctx| self.buildRecordAccess(mismatch.types, ctx),
-                    .record_update => |ctx| self.buildRecordUpdate(mismatch.types, ctx),
+                    .record_access => |ctx| self.buildRecordAccess(mismatch.types, mismatch.evidence, ctx),
+                    .record_update => |ctx| self.buildRecordUpdate(mismatch.types, mismatch.evidence, ctx),
                     .recursive_def => |ctx| self.buildRecursiveDef(mismatch.types, ctx),
                     .platform_requirement => |ctx| {
                         var report = try self.makeMismatchReport(
@@ -3467,11 +3468,16 @@ pub const ReportBuilder = struct {
     fn buildRecordAccess(
         self: *Self,
         types: TypePair,
+        evidence: TypeMismatchEvidence,
         ctx: Context.RecordAccessContext,
     ) Allocator.Error!Report {
         self.diff_fields.items.clearRetainingCapacity();
 
-        const record = try self.snapshots.gatherRecordFields(types.actual_snapshot, self.gpa, &self.diff_fields);
+        const actual_snapshot = switch (evidence) {
+            .record => |record| record.actual_snapshot,
+            .none => types.actual_snapshot,
+        };
+        const record = try self.snapshots.gatherRecordFields(actual_snapshot, self.gpa, &self.diff_fields);
 
         const region = ProblemRegion{ .simple = regionIdxFrom(types.actual_var) };
         switch (record) {
@@ -3534,12 +3540,22 @@ pub const ReportBuilder = struct {
     fn buildRecordUpdate(
         self: *Self,
         types: TypePair,
+        evidence: TypeMismatchEvidence,
         ctx: Context.RecordUpdateContext,
     ) Allocator.Error!Report {
         self.diff_fields.items.clearRetainingCapacity();
 
+        const expected_snapshot = switch (evidence) {
+            .record => |record| record.expected_snapshot,
+            .none => types.expected_snapshot,
+        };
+        const actual_snapshot = switch (evidence) {
+            .record => |record| record.actual_snapshot,
+            .none => types.actual_snapshot,
+        };
+
         // Get the record data of the type we tried to  update
-        const expected_record = try self.snapshots.gatherRecordFields(types.expected_snapshot, self.gpa, &self.diff_fields);
+        const expected_record = try self.snapshots.gatherRecordFields(expected_snapshot, self.gpa, &self.diff_fields);
         switch (expected_record) {
             .not_a_record => {
                 return try self.makeBadTypeReport(
@@ -3578,7 +3594,7 @@ pub const ReportBuilder = struct {
                 // robust full record builder
 
                 // Get the record data of the type we tried to  update
-                const actual_record = try self.snapshots.gatherRecordFields(types.actual_snapshot, self.gpa, &self.diff_fields);
+                const actual_record = try self.snapshots.gatherRecordFields(actual_snapshot, self.gpa, &self.diff_fields);
                 const actual_field = switch (actual_record) {
                     .record => |fields| blk: {
                         const slice = self.diff_fields.sliceRange(fields);

--- a/src/check/test/issue_11057_test.zig
+++ b/src/check/test/issue_11057_test.zig
@@ -83,6 +83,27 @@ test "issue 11057: nominal update evidence uses the instantiated backing" {
     try test_env.assertOneTypeErrorMsg(field_mismatch);
 }
 
+test "issue 11057: nominal update evidence keeps roles through an alias" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\NamedConfig := { foo : U64, bar : U64 }
+        \\Config : NamedConfig
+        \\
+        \\config : Config
+        \\config = NamedConfig.{ foo: 1, bar: 2 }
+        \\
+        \\bar = True
+        \\
+        \\config2 = { ..config, bar }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(field_mismatch);
+}
+
 // spellchecker:off
 test "issue 11057: a missing nominal record field remains a field diagnostic" {
     const source =

--- a/src/check/test/issue_11057_test.zig
+++ b/src/check/test/issue_11057_test.zig
@@ -1,0 +1,183 @@
+//! Regression tests for issue 11057: https://github.com/roc-lang/roc/issues/11057
+
+const TestEnv = @import("./TestEnv.zig");
+
+const field_mismatch =
+    \\**Type Mismatch**
+    \\The type of the field `bar` is incompatible.
+    \\```roc
+    \\config2 = { ..config, bar }
+    \\```
+    \\                      ^^^
+    \\
+    \\You are trying to update the `bar` field to be the type:
+    \\
+    \\    [True, ..]
+    \\
+    \\But the `config` record needs it to be
+    \\
+    \\    U64
+    \\
+    \\__Note:__ You cannot change the type of a record field with the record update syntax. You can do that by create a new record, copying over the unchanged fields, then transforming `bar` to be the new type.
+    \\
+    \\
+;
+
+test "issue 11057: updating a nominal record with a wrong-typed field reports the field" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Config := { foo : U64, bar : U64 }
+        \\
+        \\config : Config
+        \\config = Config.{ foo: 1, bar: 2 }
+        \\
+        \\bar = True
+        \\
+        \\config2 = { ..config, bar }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(field_mismatch);
+}
+
+test "issue 11057: updating an aliased record with a wrong-typed field reports the field" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Config : { foo : U64, bar : U64 }
+        \\
+        \\config : Config
+        \\config = { foo: 1, bar: 2 }
+        \\
+        \\bar = True
+        \\
+        \\config2 = { ..config, bar }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(field_mismatch);
+}
+
+test "issue 11057: nominal update evidence uses the instantiated backing" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Config(a) := { foo : U64, bar : a }
+        \\
+        \\config : Config(U64)
+        \\config = Config.{ foo: 1, bar: 2 }
+        \\
+        \\bar = True
+        \\
+        \\config2 = { ..config, bar }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(field_mismatch);
+}
+
+// spellchecker:off
+test "issue 11057: a missing nominal record field remains a field diagnostic" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Config := { hello : Str }
+        \\
+        \\config : Config
+        \\config = Config.{ hello: "world" }
+        \\
+        \\config2 = { ..config, hllo: "goodbye" }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(
+        \\**Type Mismatch**
+        \\This record does not have a `hllo` field.
+        \\```roc
+        \\config2 = { ..config, hllo: "goodbye" }
+        \\```
+        \\              ^^^^^^
+        \\
+        \\This is often due to a typo. The most similar fields are:
+        \\
+        \\    - `hello`
+        \\
+        \\So maybe `hllo` should be `hello`?
+        \\
+        \\__Note:__ You cannot add new fields to a record with the record update syntax.
+        \\
+        \\
+    );
+}
+
+test "issue 11057: nominal record access uses structural evidence" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Config := { hello : Str }
+        \\
+        \\config : Config
+        \\config = Config.{ hello: "world" }
+        \\
+        \\value = config.hllo
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(
+        \\**Type Mismatch**
+        \\This record does not have a `hllo` field.
+        \\```roc
+        \\value = config.hllo
+        \\```
+        \\              ^^^^^
+        \\
+        \\This is often due to a typo. The most similar fields are:
+        \\
+        \\    - `hello`
+        \\
+        \\So maybe `hllo` should be `hello`?
+        \\
+        \\
+    );
+}
+
+test "issue 11057: an empty nominal backing remains an empty-record diagnostic" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Config := {}
+        \\
+        \\config : Config
+        \\config = Config.{}
+        \\
+        \\config2 = { ..config, hello: "world" }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeErrorMsg(
+        \\**Type Mismatch**
+        \\The `config` record does not have a `hello` field.
+        \\```roc
+        \\config2 = { ..config, hello: "world" }
+        \\```
+        \\              ^^^^^^
+        \\
+        \\It is actually a record with no fields.
+        \\
+        \\
+    );
+}
+// spellchecker:on

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -84,6 +84,16 @@ const TwoTagsSafeList = TwoTags.SafeList;
 
 const Problem = problem_mod.Problem;
 const Context = problem_mod.Context;
+const TypeMismatchEvidence = problem_mod.TypeMismatchEvidence;
+
+const RawTypePair = struct {
+    expected: Var,
+    actual: Var,
+};
+
+const RawMismatchEvidence = struct {
+    record: ?RawTypePair = null,
+};
 
 /// Exact checker evidence produced when a fresh record construction omits a
 /// defaulted field through width absorption. `record_var` is the original
@@ -268,6 +278,9 @@ pub const Options = struct {
     root_relation: RootRelation = .ordinary,
     row_width_relation: RowWidthRelation = .construction,
     field_presence_relation: FieldPresenceRelation = .ordinary,
+    /// Retain the outer nominal record opening if this relation rejects and
+    /// its reporter needs to inspect the instantiated backing.
+    retain_record_mismatch: bool = false,
     /// Source-backed record construction whose omission decisions this
     /// relation owns. The checker publishes successful default absorptions
     /// against this exact expression when the empty row operand is an
@@ -304,6 +317,7 @@ pub fn unify(env: *const Env, a: Var, b: Var, opts: Options) std.mem.Allocator.E
         env.occurs_scratch,
         opts.row_width_relation,
         opts.field_presence_relation,
+        opts.retain_record_mismatch,
         env.construction_probe,
         opts.record_construction_var,
     );
@@ -324,6 +338,7 @@ pub fn unify(env: *const Env, a: Var, b: Var, opts: Options) std.mem.Allocator.E
 
         const expected_snapshot = try env.snapshots.snapshotVarForError(env.types, env.type_writer, a);
         const actual_snapshot = try env.snapshots.snapshotVarForError(env.types, env.type_writer, b);
+        const evidence = try snapshotMismatchEvidence(env);
         const problem_idx = try env.problems.appendProblem(env.problems_gpa, .{ .type_mismatch = .{
             .types = .{
                 .expected_var = a,
@@ -332,12 +347,31 @@ pub fn unify(env: *const Env, a: Var, b: Var, opts: Options) std.mem.Allocator.E
                 .actual_snapshot = actual_snapshot,
             },
             .context = opts.context,
+            .evidence = evidence,
         } });
         try env.types.poisonOnMismatch(a, b);
         return Result{ .problem = problem_idx };
     };
 
     return .unified;
+}
+
+fn snapshotRawRecordEvidence(env: *const Env, raw: RawTypePair) std.mem.Allocator.Error!TypeMismatchEvidence {
+    return .{ .record = .{
+        .expected_snapshot = try env.snapshots.snapshotVarForError(env.types, env.type_writer, raw.expected),
+        .actual_snapshot = try env.snapshots.snapshotVarForError(env.types, env.type_writer, raw.actual),
+    } };
+}
+
+/// Snapshot exact mismatch operands retained by an owning relation. The raw
+/// vars point at the already-instantiated structures the unifier compared, so
+/// reporting never has to reopen a nominal declaration.
+pub fn snapshotMismatchEvidence(env: *const Env) std.mem.Allocator.Error!TypeMismatchEvidence {
+    const raw = env.unify_scratch.mismatch_evidence;
+    return if (raw.record) |record|
+        try snapshotRawRecordEvidence(env, record)
+    else
+        .none;
 }
 
 /// A temporary unification context used to unify two type variables within a `Store`.
@@ -368,6 +402,7 @@ const Unifier = struct {
     occurs_scratch: *occurs.Scratch,
     row_width_relation: RowWidthRelation,
     field_presence_relation: FieldPresenceRelation,
+    retain_record_mismatch: bool,
     /// The unresolved "actual" var before resolution, used for deferred constraint origin tracking.
     /// This allows error messages to point to the original expression rather than the resolved type.
     unresolved_a: ?Var,
@@ -394,6 +429,7 @@ const Unifier = struct {
         occurs_scratch: *occurs.Scratch,
         row_width_relation: RowWidthRelation,
         field_presence_relation: FieldPresenceRelation,
+        retain_record_mismatch: bool,
         construction_probe: ?ConstructionProbe,
         record_construction_var: ?Var,
     ) Unifier {
@@ -405,6 +441,7 @@ const Unifier = struct {
             .occurs_scratch = occurs_scratch,
             .row_width_relation = row_width_relation,
             .field_presence_relation = field_presence_relation,
+            .retain_record_mismatch = retain_record_mismatch,
             .unresolved_a = null,
             .unresolved_b = null,
             .enclosing_records = null,
@@ -700,6 +737,10 @@ const Unifier = struct {
             .ignore => return,
             .set_flag => |flag_idx| {
                 self.scratch.mismatch_flags.items.items[flag_idx] = true;
+            },
+            .record_then_propagate => |record| {
+                self.scratch.mismatch_evidence.record = record;
+                return error.TypeMismatch;
             },
         }
     }
@@ -2018,6 +2059,7 @@ const Unifier = struct {
                 return;
             } else {
                 // Anon has fields but nominal is empty
+                try self.retainOuterRecordMismatch(vars, opened_backing, direction);
                 return error.TypeMismatch;
             }
         }
@@ -2037,12 +2079,35 @@ const Unifier = struct {
         } });
 
         // Unify the record fields
+        try self.retainOuterRecordMismatch(vars, opened_backing, direction);
+
         try self.unifyTwoRecords(
             vars,
             anon_record_fields,
             anon_record_ext,
             nominal_backing_record.fields,
             .{ .ext = nominal_backing_record.ext },
+        );
+    }
+
+    /// Retain only the outer record relation owned by the active diagnostic.
+    /// Nested nominal payloads belong to fields inside that record and must
+    /// not replace its structural evidence.
+    fn retainOuterRecordMismatch(
+        self: *Self,
+        vars: *const ResolvedVarDescs,
+        opened_backing: Var,
+        direction: NominalDirection,
+    ) std.mem.Allocator.Error!void {
+        if (!self.retain_record_mismatch or self.enclosing_records != null) return;
+
+        const evidence: RawTypePair = switch (direction) {
+            .a_is_nominal => .{ .expected = opened_backing, .actual = vars.b.var_ },
+            .b_is_nominal => .{ .expected = vars.a.var_, .actual = opened_backing },
+        };
+        _ = try self.scratch.unify_work_stack.append(
+            self.scratch.gpa,
+            .{ .mismatch_handler = .{ .record_then_propagate = evidence } },
         );
     }
 
@@ -3747,6 +3812,7 @@ const MismatchHandling = union(enum) {
     propagate,
     ignore,
     set_flag: u32,
+    record_then_propagate: RawTypePair,
 };
 
 const SameAliasAfterArgs = struct {
@@ -3818,7 +3884,7 @@ pub fn partitionFields(
     a_fields_range: RecordFieldSafeList.Range,
     b_fields_range: RecordFieldSafeList.Range,
 ) std.mem.Allocator.Error!Unifier.PartitionedRecordFields {
-    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, null, null);
+    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, false, null, null);
     return try unifier.partitionFields(scratch, a_fields_range, b_fields_range);
 }
 
@@ -3832,7 +3898,7 @@ pub fn partitionTags(
     a_tags_range: TagSafeList.Range,
     b_tags_range: TagSafeList.Range,
 ) std.mem.Allocator.Error!Unifier.PartitionedTags {
-    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, null, null);
+    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, false, null, null);
     return try unifier.partitionTags(scratch, a_tags_range, b_tags_range);
 }
 
@@ -3890,6 +3956,7 @@ pub const Scratch = struct {
     // explicit unification work stack
     unify_work_stack: WorkFrame.SafeList,
     mismatch_flags: MkSafeList(bool),
+    mismatch_evidence: RawMismatchEvidence,
 
     // records - used internal by unification
     gathered_fields: RecordFieldSafeList,
@@ -3956,6 +4023,7 @@ pub const Scratch = struct {
             .fresh_vars = try VarSafeList.initCapacity(gpa, 8),
             .unify_work_stack = try WorkFrame.SafeList.initCapacity(gpa, 32),
             .mismatch_flags = try MkSafeList(bool).initCapacity(gpa, 8),
+            .mismatch_evidence = .{},
             .gathered_fields = try RecordFieldSafeList.initCapacity(gpa, 32),
             .only_in_a_fields = try RecordFieldSafeList.initCapacity(gpa, 32),
             .only_in_b_fields = try RecordFieldSafeList.initCapacity(gpa, 32),
@@ -4012,6 +4080,7 @@ pub const Scratch = struct {
     pub fn reset(self: *Scratch) void {
         self.unify_work_stack.items.clearRetainingCapacity();
         self.mismatch_flags.items.clearRetainingCapacity();
+        self.mismatch_evidence = .{};
         self.gathered_fields.items.clearRetainingCapacity();
         self.only_in_a_fields.items.clearRetainingCapacity();
         self.only_in_b_fields.items.clearRetainingCapacity();

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -257,6 +257,15 @@ pub const FieldPresenceRelation = enum {
     required_access,
 };
 
+/// Which semantic side of an owning record diagnostic contains the nominal.
+/// Alias expansion may reverse the unifier's algorithmic operand order, so
+/// retained structural evidence must not infer this role from local ordering.
+pub const NominalRecordMismatchRole = enum {
+    none,
+    expected,
+    actual,
+};
+
 /// Controls what a top-level type mismatch does to the two operands.
 pub const MismatchBehavior = enum {
     /// Merge both operands into a single `.err` type. This is the default: it
@@ -278,9 +287,9 @@ pub const Options = struct {
     root_relation: RootRelation = .ordinary,
     row_width_relation: RowWidthRelation = .construction,
     field_presence_relation: FieldPresenceRelation = .ordinary,
-    /// Retain the outer nominal record opening if this relation rejects and
-    /// its reporter needs to inspect the instantiated backing.
-    retain_record_mismatch: bool = false,
+    /// Retain the outer nominal record opening with this semantic role if the
+    /// relation rejects and its reporter needs the instantiated backing.
+    nominal_record_mismatch_role: NominalRecordMismatchRole = .none,
     /// Source-backed record construction whose omission decisions this
     /// relation owns. The checker publishes successful default absorptions
     /// against this exact expression when the empty row operand is an
@@ -317,7 +326,7 @@ pub fn unify(env: *const Env, a: Var, b: Var, opts: Options) std.mem.Allocator.E
         env.occurs_scratch,
         opts.row_width_relation,
         opts.field_presence_relation,
-        opts.retain_record_mismatch,
+        opts.nominal_record_mismatch_role,
         env.construction_probe,
         opts.record_construction_var,
     );
@@ -402,7 +411,7 @@ const Unifier = struct {
     occurs_scratch: *occurs.Scratch,
     row_width_relation: RowWidthRelation,
     field_presence_relation: FieldPresenceRelation,
-    retain_record_mismatch: bool,
+    nominal_record_mismatch_role: NominalRecordMismatchRole,
     /// The unresolved "actual" var before resolution, used for deferred constraint origin tracking.
     /// This allows error messages to point to the original expression rather than the resolved type.
     unresolved_a: ?Var,
@@ -429,7 +438,7 @@ const Unifier = struct {
         occurs_scratch: *occurs.Scratch,
         row_width_relation: RowWidthRelation,
         field_presence_relation: FieldPresenceRelation,
-        retain_record_mismatch: bool,
+        nominal_record_mismatch_role: NominalRecordMismatchRole,
         construction_probe: ?ConstructionProbe,
         record_construction_var: ?Var,
     ) Unifier {
@@ -441,7 +450,7 @@ const Unifier = struct {
             .occurs_scratch = occurs_scratch,
             .row_width_relation = row_width_relation,
             .field_presence_relation = field_presence_relation,
-            .retain_record_mismatch = retain_record_mismatch,
+            .nominal_record_mismatch_role = nominal_record_mismatch_role,
             .unresolved_a = null,
             .unresolved_b = null,
             .enclosing_records = null,
@@ -2099,11 +2108,16 @@ const Unifier = struct {
         opened_backing: Var,
         direction: NominalDirection,
     ) std.mem.Allocator.Error!void {
-        if (!self.retain_record_mismatch or self.enclosing_records != null) return;
+        if (self.nominal_record_mismatch_role == .none or self.enclosing_records != null) return;
 
-        const evidence: RawTypePair = switch (direction) {
-            .a_is_nominal => .{ .expected = opened_backing, .actual = vars.b.var_ },
-            .b_is_nominal => .{ .expected = vars.a.var_, .actual = opened_backing },
+        const anonymous_var = switch (direction) {
+            .a_is_nominal => vars.b.var_,
+            .b_is_nominal => vars.a.var_,
+        };
+        const evidence: RawTypePair = switch (self.nominal_record_mismatch_role) {
+            .none => unreachable,
+            .expected => .{ .expected = opened_backing, .actual = anonymous_var },
+            .actual => .{ .expected = anonymous_var, .actual = opened_backing },
         };
         _ = try self.scratch.unify_work_stack.append(
             self.scratch.gpa,
@@ -3884,7 +3898,7 @@ pub fn partitionFields(
     a_fields_range: RecordFieldSafeList.Range,
     b_fields_range: RecordFieldSafeList.Range,
 ) std.mem.Allocator.Error!Unifier.PartitionedRecordFields {
-    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, false, null, null);
+    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, .none, null, null);
     return try unifier.partitionFields(scratch, a_fields_range, b_fields_range);
 }
 
@@ -3898,7 +3912,7 @@ pub fn partitionTags(
     a_tags_range: TagSafeList.Range,
     b_tags_range: TagSafeList.Range,
 ) std.mem.Allocator.Error!Unifier.PartitionedTags {
-    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, false, null, null);
+    var unifier = Unifier.init(ident_store, self_module_identity, types_store, scratch, occurs_scratch, .construction, .ordinary, .none, null, null);
     return try unifier.partitionTags(scratch, a_tags_range, b_tags_range);
 }
 

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -1452,6 +1452,7 @@ const State = struct {
         "local_dense",
         "pool",
         "result_discriminant",
+        "any_negative",
     };
 
     /// Fields a refill leaves as the recycled state already has them. Every

--- a/test/snapshots/record_optional_defaulted_fields.md
+++ b/test/snapshots/record_optional_defaulted_fields.md
@@ -17,20 +17,17 @@ bad_direct_access : Config -> U16
 bad_direct_access = |c| c.port
 ~~~
 # EXPECTED
-TYPE MISMATCH - record_optional_defaulted_fields.md:10:25:10:26
+TYPE MISMATCH - record_optional_defaulted_fields.md:10:26:10:31
 # PROBLEMS
-── ✗ type mismatch ─────────────────── record_optional_defaulted_fields.md:10:25
+── ✗ type mismatch ─────────────────── record_optional_defaulted_fields.md:10:26
 
-This is not a record, so it does not have any fields to access.
+The port field is optional, but it is being accessed as if it is always present.
 
 bad_direct_access = |c| c.port
-                        ^
+                         ^^^^^
 
-It is:
-
-    Config
-
-But I need a record with a port field.
+An optional field may be missing from the record. Use .? to access it—that
+produces a Try you can match on or default with ??.
 
 # TOKENS
 ~~~zig


### PR DESCRIPTION
Record-aware diagnostics were trying to rediscover fields from the root mismatch snapshot, which stays nominal and therefore hid its instantiated record backing. This retains the exact outer nominal-opening snapshots only for record update and access errors, allowing the reporter to preserve the named root type while comparing the correct instantiated fields. It also updates the ARC certifier's refill audit to include `any_negative`, which `refillFrom` already copies and whose omission currently prevents clean builds. Fixes #11057.