### PR TITLE
Fix ARC certifier state refill inventory

### DIFF
--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -1452,6 +1452,7 @@ const State = struct {
         "local_dense",
         "pool",
         "result_discriminant",
+        "any_negative",
     };
 
     /// Fields a refill leaves as the recycled state already has them. Every


### PR DESCRIPTION
The ARC certifier’s compile-time refill inventory omitted `any_negative` even though `refillFrom` copies that field, causing LIR-dependent tests on main to fail during compilation. This records the field in the inventory so the invariant check and affected test suites compile again.