### PR TITLE
Widen parallel Monotype specialization batches

### DIFF
--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -281,10 +281,12 @@ pub fn expectPreparedFiniteCaptureFreeDirectCallsParallelismDeterministicLir() L
         .tasks_committed = 33,
         .tasks_retried_serial = 44,
     };
+    var serial_timing: lir.CheckedPipeline.TimingSnapshot = .{};
     try runToLir(prepared_finite_capture_free_direct_call_fixture, &reference_writer, .{
         .specialization_workers = 1,
         .prepared_direct_call_root_fixture = true,
         .solved_lir_parallel_metrics_out = &serial_metrics,
+        .timing_out = &serial_timing,
     }, null);
     try std.testing.expectEqual(@as(u64, 0), serial_metrics.task_waves);
     try std.testing.expectEqual(@as(u64, 0), serial_metrics.tasks_submitted);
@@ -292,25 +294,38 @@ pub fn expectPreparedFiniteCaptureFreeDirectCallsParallelismDeterministicLir() L
     try std.testing.expectEqual(@as(u64, 0), serial_metrics.tasks_retried_serial);
     try std.testing.expectEqual(@as(u64, 0), serial_metrics.workspace_initializations);
     try std.testing.expectEqual(@as(u64, 0), serial_metrics.workspace_reuses);
+    const serial_parallel = serial_timing.monotype_parallel;
+    try std.testing.expectEqual(@as(u64, 0), serial_parallel.root_tasks_submitted);
+    try std.testing.expectEqual(@as(u64, 0), serial_parallel.root_tasks_committed);
+    try std.testing.expectEqual(@as(u64, 0), serial_parallel.specialization_tasks_submitted);
+    try std.testing.expectEqual(@as(u64, 0), serial_parallel.specialization_tasks_committed);
+    try std.testing.expectEqual(@as(u64, 0), serial_parallel.task_waves);
+    try std.testing.expectEqual(@as(u64, 0), serial_parallel.within_lowering_lane_reuse_tasks);
 
-    for ([_]struct { specialization_workers: usize, task_waves: u64 }{
-        .{ .specialization_workers = 2, .task_waves = 7 },
-        .{ .specialization_workers = 4, .task_waves = 4 },
+    for ([_]struct {
+        specialization_workers: usize,
+        solved_lir_task_waves: u64,
+        monotype_task_waves: u64,
+    }{
+        .{ .specialization_workers = 2, .solved_lir_task_waves = 7, .monotype_task_waves = 5 },
+        .{ .specialization_workers = 4, .solved_lir_task_waves = 4, .monotype_task_waves = 4 },
     }) |case| {
         for ([_]bool{ false, true }) |reverse_post_check_completions| {
             const candidate = try gpa.alloc(u8, cap);
             defer gpa.free(candidate);
             var candidate_writer = std.Io.Writer.fixed(candidate);
             var metrics: lir.CheckedPipeline.SolvedLirParallelMetrics = .{};
+            var timing: lir.CheckedPipeline.TimingSnapshot = .{};
             try runToLir(prepared_finite_capture_free_direct_call_fixture, &candidate_writer, .{
                 .specialization_workers = case.specialization_workers,
                 .prepared_direct_call_root_fixture = true,
                 .reverse_post_check_completions = reverse_post_check_completions,
                 .solved_lir_parallel_metrics_out = &metrics,
+                .timing_out = &timing,
             }, null);
 
             try std.testing.expectEqualStrings(reference_writer.buffered(), candidate_writer.buffered());
-            try std.testing.expectEqual(case.task_waves, metrics.task_waves);
+            try std.testing.expectEqual(case.solved_lir_task_waves, metrics.task_waves);
             try std.testing.expectEqual(@as(u64, 14), metrics.tasks_submitted);
             try std.testing.expectEqual(@as(u64, 14), metrics.tasks_committed);
             try std.testing.expectEqual(@as(u64, 0), metrics.tasks_retried_serial);
@@ -320,6 +335,25 @@ pub fn expectPreparedFiniteCaptureFreeDirectCallsParallelismDeterministicLir() L
             );
             try std.testing.expect(metrics.workspace_initializations > 0);
             try std.testing.expect(metrics.workspace_reuses > 0);
+
+            const parallel = timing.monotype_parallel;
+            try std.testing.expectEqual(@as(u64, 5), parallel.root_tasks_submitted);
+            try std.testing.expectEqual(parallel.root_tasks_submitted, parallel.root_tasks_committed);
+            try std.testing.expectEqual(@as(u64, 0), parallel.root_tasks_retried_serial);
+            try std.testing.expectEqual(@as(u64, 10), parallel.specialization_tasks_submitted);
+            try std.testing.expect(
+                parallel.specialization_tasks_submitted > parallel.peak_worker_lanes_available,
+            );
+            try std.testing.expectEqual(
+                parallel.specialization_tasks_submitted,
+                parallel.specialization_tasks_committed,
+            );
+            try std.testing.expectEqual(@as(u64, 0), parallel.specialization_tasks_retried_serial);
+            try std.testing.expectEqual(@as(u64, 0), parallel.specialization_tasks_discarded_ready);
+            // Ten specializations complete in two specialization waves after
+            // the fixed root waves, proving each run can exceed lane count.
+            try std.testing.expectEqual(case.monotype_task_waves, parallel.task_waves);
+            try std.testing.expect(parallel.within_lowering_lane_reuse_tasks > 0);
         }
     }
 }

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -2205,6 +2205,12 @@ const TemplateReservation = struct {
 /// reserves the identity and queues the body for the scheduler's wave drain.
 const TemplateBodyScheduling = enum { immediate, queued };
 
+/// Keep more ready jobs in each executor run than there are worker lanes.
+/// Dynamic lane reuse smooths procedure-size skew and amortizes each frozen
+/// coordinator barrier without changing dispatch-order commit. Four bounds
+/// the completed shards retained until each batch reaches its commit barrier.
+const parallel_spec_jobs_per_lane: usize = 4;
+
 /// One reserved specialization whose body has not lowered yet, in the
 /// deterministic scheduler FIFO. Every field is durable for the builder's
 /// lifetime: evidence lives in the evidence arena, the requested type is
@@ -2404,9 +2410,9 @@ const SpecJobWorkspace = struct {
     }
 };
 
-/// Lowering-owned persistent state for one executor worker. It is scoped to a
-/// Monotype batch rather than executor opaque state, so no `Program` relocation
-/// capability survives the batch completion barrier.
+/// Lowering-owned persistent state for one executor worker across the complete
+/// Monotype run. Executor barriers end task-result ownership, while the
+/// workspace retains cumulative relocation state for later tasks on its lane.
 pub const SpecJobWorkerState = struct {
     worker_id: SpecJobWorkerId,
     allocator: Allocator,
@@ -2579,6 +2585,23 @@ const SpecJobTaskContext = struct {
     retry_serial: bool = false,
     completed: bool = false,
     worker_work_ns: u64 = 0,
+};
+
+/// Reusable caller-owned scheduler storage. Executor runs are synchronous, so
+/// no callback retains these task descriptors after a batch completes.
+const SpecJobTaskBuffers = struct {
+    prepared: []PreparedSpecJob = &.{},
+    contexts: []SpecJobTaskContext = &.{},
+    tasks: []base.post_check_task_executor.Task = &.{},
+    completions: []base.post_check_task_executor.Completion = &.{},
+
+    fn deinit(self: *SpecJobTaskBuffers, allocator: Allocator) void {
+        if (self.completions.len != 0) allocator.free(self.completions);
+        if (self.tasks.len != 0) allocator.free(self.tasks);
+        if (self.contexts.len != 0) allocator.free(self.contexts);
+        if (self.prepared.len != 0) allocator.free(self.prepared);
+        self.* = .{};
+    }
 };
 
 /// Caller-owned root task storage lets unordered executor completion be
@@ -2912,6 +2935,7 @@ const Builder = struct {
     /// Fixed worker-indexed ownership for executor-backed ordinary jobs.
     spec_job_parallel_workers: []?SpecJobWorkerState = &.{},
     spec_job_parallel_commit_domains: []SpecJobCommitDomain = &.{},
+    spec_job_task_buffers: SpecJobTaskBuffers = .{},
     spec_store: specialize.SpecBuilder,
     lowered_templates: collections.DenseMap(Ast.FnId, LoweredTemplate),
     /// Nested-fn specialization records keyed by function id; the durable
@@ -3150,6 +3174,7 @@ const Builder = struct {
     }
 
     fn deinit(self: *Builder) void {
+        self.spec_job_task_buffers.deinit(self.allocator);
         for (self.spec_job_parallel_workers) |*worker| {
             if (worker.*) |*initialized| initialized.deinit();
         }
@@ -4799,14 +4824,12 @@ const Builder = struct {
         }
 
         try self.ensureParallelSpecJobState(executor.worker_count);
-        const prepared = try self.allocator.alloc(PreparedSpecJob, executor.worker_count);
-        defer self.allocator.free(prepared);
-        const contexts = try self.allocator.alloc(SpecJobTaskContext, executor.worker_count);
-        defer self.allocator.free(contexts);
-        const tasks = try self.allocator.alloc(base.post_check_task_executor.Task, executor.worker_count);
-        defer self.allocator.free(tasks);
-        const completions = try self.allocator.alloc(base.post_check_task_executor.Completion, executor.worker_count);
-        defer self.allocator.free(completions);
+        const batch_capacity = executor.worker_count *| parallel_spec_jobs_per_lane;
+        const buffers = try self.ensureSpecJobTaskBuffers(batch_capacity);
+        const prepared = buffers.prepared;
+        const contexts = buffers.contexts;
+        const tasks = buffers.tasks;
+        const completions = buffers.completions;
 
         const inputs = SpecJobWorkerInputs{
             .modules = self.modules,
@@ -4843,7 +4866,7 @@ const Builder = struct {
             }
 
             var batch_len: usize = 0;
-            while (batch_len < executor.worker_count and
+            while (batch_len < batch_capacity and
                 self.pending_spec_jobs_head < self.pending_spec_jobs.items.len)
             {
                 const job = self.pending_spec_jobs.items[self.pending_spec_jobs_head];
@@ -5241,6 +5264,38 @@ const Builder = struct {
         for (domains) |*domain| domain.* = SpecJobCommitDomain.init(self.allocator);
         self.spec_job_parallel_workers = workers;
         self.spec_job_parallel_commit_domains = domains;
+    }
+
+    fn ensureSpecJobTaskBuffers(
+        self: *Builder,
+        batch_capacity: usize,
+    ) Allocator.Error!*SpecJobTaskBuffers {
+        const buffers = &self.spec_job_task_buffers;
+        if (buffers.prepared.len != 0) {
+            if (buffers.prepared.len != batch_capacity or
+                buffers.contexts.len != batch_capacity or
+                buffers.tasks.len != batch_capacity or
+                buffers.completions.len != batch_capacity)
+            {
+                Common.compilerBug("Monotype specialization task buffer capacity changed");
+            }
+            return buffers;
+        }
+        if (buffers.contexts.len != 0 or
+            buffers.tasks.len != 0 or
+            buffers.completions.len != 0)
+        {
+            Common.compilerBug("Monotype specialization task buffers were only partially initialized");
+        }
+
+        var initialized: SpecJobTaskBuffers = .{};
+        errdefer initialized.deinit(self.allocator);
+        initialized.prepared = try self.allocator.alloc(PreparedSpecJob, batch_capacity);
+        initialized.contexts = try self.allocator.alloc(SpecJobTaskContext, batch_capacity);
+        initialized.tasks = try self.allocator.alloc(base.post_check_task_executor.Task, batch_capacity);
+        initialized.completions = try self.allocator.alloc(base.post_check_task_executor.Completion, batch_capacity);
+        buffers.* = initialized;
+        return buffers;
     }
 
     fn specJobCommitDomainFor(self: *Builder, worker_id: SpecJobWorkerId) *SpecJobCommitDomain {


### PR DESCRIPTION
## Summary

- queue up to four ordinary specialization jobs per worker lane in each executor run
- preserve frozen-frontier execution and deterministic dispatch-order commit
- retain and reuse scheduler task buffers across specialization drains
- extend the direct-call regression to cover oversubscribed batches, same-lane epoch reuse, reversed completions, and serial/parallel LIR equivalence

## Why

The previous scheduler submitted at most one specialization per lane before a full executor barrier. Uneven body sizes left lanes idle behind stragglers. A bounded four-jobs-per-lane frontier gives the executor enough queued work to reuse lanes while limiting completed shards retained until ordered commit.

## Benchmark

ReleaseFast compiler, `roc-deflate/benchmark/ctime.roc`, `--opt=dev --no-cache`, five warmed runs:

| Workers | Baseline specialization | This PR | Change | Baseline wait | This PR |
|---:|---:|---:|---:|---:|---:|
| 2 | 7,035 ms | 6,545 ms | -7.0% | 2,848 ms | 2,410 ms |
| 4 | 6,624 ms | 6,181 ms | -6.7% | 2,446 ms | 2,110 ms |
| 8 | 6,269 ms | 6,274 ms | +0.1% | 2,125 ms | 2,085 ms |

Eight jobs per lane was also measured, but did not justify doubling the maximum number of retained results.

## Validation

- `zig build run-test-zig-module-postcheck -- --test-filter "specialization"`
- `zig build run-test-zig-module-compile -- --test-filter "prepared finite capture-free direct calls lower in deterministic discovery waves"`
- `zig build run-check-semantic-audit`
- `zig build run-check-unused-suppression`
- `zig build run-check-snapshots`
- `zig build run-test-zig` (4,992 tests)
- ReleaseFast compiler build and local ctime compilation

## Stack

This draft is stacked on #11075 and should be retargeted to `main` after that PR lands.