### PR TITLE
Fix duplicate platform declaration publication

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -213,6 +213,8 @@ const PendingProvidesEntry = struct {
     region: Region,
 };
 
+const TopLevelValueDefMap = std.AutoHashMapUnmanaged(Ident.Idx, CIR.Def.Idx);
+
 const MethodRegistrationKind = enum {
     declaration_owner,
     receiver_extension,
@@ -955,7 +957,7 @@ fn recordGlobalValueDef(self: *Self, def_idx: CIR.Def.Idx) std.mem.Allocator.Err
 
 fn topLevelDefIsSelected(
     self: *const Self,
-    selected_by_ident: *const std.AutoHashMapUnmanaged(Ident.Idx, CIR.Def.Idx),
+    selected_by_ident: *const TopLevelValueDefMap,
     def_idx: CIR.Def.Idx,
 ) bool {
     const def = self.env.store.getDef(def_idx);
@@ -966,7 +968,7 @@ fn topLevelDefIsSelected(
 
 fn globalDefIntroducesValueBinding(
     self: *const Self,
-    selected_by_ident: *const std.AutoHashMapUnmanaged(Ident.Idx, CIR.Def.Idx),
+    selected_by_ident: *const TopLevelValueDefMap,
     def_idx: CIR.Def.Idx,
 ) bool {
     const def = self.env.store.getDef(def_idx);
@@ -4639,8 +4641,30 @@ pub fn canonicalizeFile(
         }
     }
 
-    try self.resolvePlatformProvides();
-    try self.resolvePlatformHosted();
+    // Associated forward-reference adoption can rewrite a placeholder's ident
+    // while canonicalization is in progress. Select source-visible values only
+    // after those rewrites are complete, so every name-sensitive output below
+    // consumes the same final definition identity.
+    var top_level_value_defs_by_ident = TopLevelValueDefMap{};
+    defer top_level_value_defs_by_ident.deinit(self.env.gpa);
+    for (self.scratch_global_value_defs.items) |def_idx| {
+        const def = self.env.store.getDef(def_idx);
+        const pattern = self.env.store.getPattern(def.pattern);
+        if (pattern != .assign) continue;
+
+        const selected = try top_level_value_defs_by_ident.getOrPut(self.env.gpa, pattern.assign.ident);
+        if (!selected.found_existing) {
+            selected.value_ptr.* = def_idx;
+        } else {
+            const prior = self.env.store.getDef(selected.value_ptr.*);
+            if (self.env.store.getExpr(prior.expr) == .e_anno_only and self.env.store.getExpr(def.expr) != .e_anno_only) {
+                selected.value_ptr.* = def_idx;
+            }
+        }
+    }
+
+    try self.resolvePlatformProvides(&top_level_value_defs_by_ident);
+    try self.resolvePlatformHosted(&top_level_value_defs_by_ident);
     try self.resolveQualifiedExposedTypes();
 
     // Check for exposed but not implemented items
@@ -4673,28 +4697,6 @@ pub fn canonicalizeFile(
         try self.env.store.addScratchDef(def_idx);
     }
     self.env.global_value_defs = try self.env.store.defSpanFrom(global_value_defs_start);
-
-    // Associated forward-reference adoption can rewrite a placeholder's ident
-    // while canonicalization is in progress. Select source-visible values only
-    // after those rewrites are complete, so the retained identifiers and
-    // definition identities are final.
-    var top_level_value_defs_by_ident = std.AutoHashMapUnmanaged(Ident.Idx, CIR.Def.Idx){};
-    defer top_level_value_defs_by_ident.deinit(self.env.gpa);
-    for (self.scratch_global_value_defs.items) |def_idx| {
-        const def = self.env.store.getDef(def_idx);
-        const pattern = self.env.store.getPattern(def.pattern);
-        if (pattern != .assign) continue;
-
-        const selected = try top_level_value_defs_by_ident.getOrPut(self.env.gpa, pattern.assign.ident);
-        if (!selected.found_existing) {
-            selected.value_ptr.* = def_idx;
-        } else {
-            const prior = self.env.store.getDef(selected.value_ptr.*);
-            if (self.env.store.getExpr(prior.expr) == .e_anno_only and self.env.store.getExpr(def.expr) != .e_anno_only) {
-                selected.value_ptr.* = def_idx;
-            }
-        }
-    }
 
     var value_binding_defs_match_global = true;
     var top_level_value_defs_match_global = true;
@@ -6110,22 +6112,10 @@ fn addPlatformHostedItems(
 /// Resolve hosted mappings once imports and exposed definitions are known.
 /// The resulting target is the same explicit external-definition identity
 /// used by ordinary qualified value lookups.
-/// This module's own top-level definition of `ident`, for a hosted entry that
-/// named no module. A later definition wins, the way a duplicate top-level
-/// value's later definition does.
-fn platformOwnDefForIdent(self: *const Self, ident: Ident.Idx) ?CIR.Def.Idx {
-    var found: ?CIR.Def.Idx = null;
-    for (self.scratch_global_value_defs.items) |def_idx| {
-        const def = self.env.store.getDef(def_idx);
-        const pattern = self.env.store.getPattern(def.pattern);
-        if (pattern != .assign) continue;
-        if (!pattern.assign.ident.eql(ident)) continue;
-        found = def_idx;
-    }
-    return found;
-}
-
-fn resolvePlatformHosted(self: *Self) std.mem.Allocator.Error!void {
+fn resolvePlatformHosted(
+    self: *Self,
+    selected_by_ident: *const TopLevelValueDefMap,
+) std.mem.Allocator.Error!void {
     if (self.env.module_kind != .platform) return;
 
     for (self.env.hosted_entries.items.items) |*entry| {
@@ -6134,7 +6124,7 @@ fn resolvePlatformHosted(self: *Self) std.mem.Allocator.Error!void {
             // platform module. Such a target has no import, so a resolved entry
             // with no `target_import` is how later stages read "the platform's
             // own definition".
-            const own_def = self.platformOwnDefForIdent(entry.func_ident) orelse {
+            const own_def = selected_by_ident.get(entry.func_ident) orelse {
                 entry.target_status = .missing_value;
                 continue;
             };
@@ -6246,12 +6236,12 @@ fn addPlatformProvidesItems(
 
 /// Resolve `provides` declarations once all platform top-level definitions are
 /// known. Only platform-local definitions are published to later stages.
-fn resolvePlatformProvides(self: *Self) std.mem.Allocator.Error!void {
+fn resolvePlatformProvides(
+    self: *Self,
+    selected_by_ident: *const TopLevelValueDefMap,
+) std.mem.Allocator.Error!void {
     for (self.pending_provides_entries.items) |entry| {
-        const local_def: ?CIR.Def.Idx = if (self.env.getExposedValueNodeIndexById(entry.ident)) |node_idx|
-            @enumFromInt(@as(u32, @intCast(node_idx)))
-        else
-            null;
+        const local_def = selected_by_ident.get(entry.ident);
         _ = try self.env.provides_entries.append(self.env.gpa, .{
             .ident = entry.ident,
             .ffi_symbol = entry.ffi_symbol,

--- a/src/canonicalize/HostedCompiler.zig
+++ b/src/canonicalize/HostedCompiler.zig
@@ -30,14 +30,13 @@ pub fn replaceAnnoOnlyWithHosted(env: *ModuleEnv) Allocator.Error!void {
         }
     }
 
-    // Iterate through all defs and replace ordinary anno-only defs with hosted implementations.
-    // Copy the def indices locally first: sliceDefs returns a slice backed by
-    // store.index_data, which patternSpanFrom appends to inside the loop. A reallocation
-    // there would invalidate a directly-held slice.
-    const defs_slice = env.store.sliceDefs(env.all_defs);
-    const all_defs = try gpa.dupe(CIR.Def.Idx, defs_slice);
-    defer gpa.free(all_defs);
-    for (all_defs) |def_idx| {
+    // Only annotation-only defs selected as value bindings become hosted. A
+    // superseded annotation remains in all_defs for checking diagnostics, but
+    // has no value and therefore must not become a host obligation. Fetch each
+    // def by span offset because patternSpanFrom below can reallocate the shared
+    // index_data backing without invalidating the span itself.
+    for (0..env.value_binding_defs.span.len) |def_offset| {
+        const def_idx = env.store.defAt(env.value_binding_defs, def_offset);
         const def = env.store.getDef(def_idx);
         const expr = env.store.getExpr(def.expr);
 

--- a/src/canonicalize/test/value_binding_selection_test.zig
+++ b/src/canonicalize/test/value_binding_selection_test.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const parse = @import("parse");
 const CIR = @import("../CIR.zig");
 const Can = @import("../Can.zig");
+const HostedCompiler = @import("../HostedCompiler.zig");
 const ModuleEnv = @import("../ModuleEnv.zig");
 const BuiltinTestContext = @import("BuiltinTestContext.zig").BuiltinTestContext;
 const CoreCtx = @import("ctx").CoreCtx;
@@ -33,6 +34,23 @@ fn countDefsWithExprTag(env: *const ModuleEnv, span: CIR.Def.Span, expr_tag: std
         if (std.meta.activeTag(env.store.getExpr(def.expr)) == expr_tag) count += 1;
     }
     return count;
+}
+
+fn findAssignedDef(env: *const ModuleEnv, span: CIR.Def.Span, name: []const u8) ?CIR.Def.Idx {
+    for (env.store.sliceDefs(span)) |def_idx| {
+        const def = env.store.getDef(def_idx);
+        const pattern = env.store.getPattern(def.pattern);
+        if (pattern != .assign) continue;
+        if (std.mem.eql(u8, env.getIdent(pattern.assign.ident), name)) return def_idx;
+    }
+    return null;
+}
+
+fn spanContainsDef(env: *const ModuleEnv, span: CIR.Def.Span, needle: CIR.Def.Idx) bool {
+    for (env.store.sliceDefs(span)) |def_idx| {
+        if (def_idx == needle) return true;
+    }
+    return false;
 }
 
 test "canonicalization owns top-level name and value-binding selection" {
@@ -72,6 +90,66 @@ test "canonicalization owns top-level name and value-binding selection" {
     try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.value_binding_defs, "a", .e_empty_record));
     try std.testing.expectEqual(@as(usize, 0), countDefs(&env, env.value_binding_defs, "a", .e_anno_only));
     try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.value_binding_defs, "orphan", .e_anno_only));
+}
+
+test "platform header targets and hosted rewrite share top-level selection" {
+    const source =
+        \\platform ""
+        \\    requires {}
+        \\    exposes []
+        \\    packages {}
+        \\    provides { "roc_main": main }
+        \\    hosted { "roc_helper": helper! }
+        \\
+        \\main : {}
+        \\
+        \\main : {}
+        \\
+        \\helper! : () => {}
+        \\
+        \\helper! : () => {}
+        \\
+        \\implemented : {}
+        \\
+        \\implemented : {}
+        \\implemented = {}
+    ;
+
+    const allocator = std.testing.allocator;
+    var builtin_ctx = try BuiltinTestContext.init(allocator);
+    defer builtin_ctx.deinit();
+
+    var env = try ModuleEnv.init(allocator, source);
+    defer env.deinit();
+    try env.initCIRFields("Test");
+
+    const ast = try parse.file(allocator, &env.common);
+    defer ast.deinit();
+
+    const roc_ctx = CoreCtx.testing(allocator, allocator);
+    var can = try Can.initModule(roc_ctx, &env, ast, builtin_ctx.canInitContext());
+    defer can.deinit();
+    try can.canonicalizeFile();
+
+    const selected_main = findAssignedDef(&env, env.top_level_value_defs, "main") orelse return error.TestUnexpectedResult;
+    const selected_helper = findAssignedDef(&env, env.top_level_value_defs, "helper!") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 1), env.provides_entries.items.items.len);
+    try std.testing.expectEqual(selected_main, env.provides_entries.items.items[0].local_def.?);
+    try std.testing.expectEqual(@as(usize, 1), env.hosted_entries.items.items.len);
+    try std.testing.expectEqual(selected_helper, env.hosted_entries.items.items[0].target_def.?);
+
+    try HostedCompiler.replaceAnnoOnlyWithHosted(&env);
+
+    try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.global_value_defs, "main", .e_hosted_lambda));
+    try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.global_value_defs, "main", .e_anno_only));
+    try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.global_value_defs, "helper!", .e_hosted_lambda));
+    try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.global_value_defs, "helper!", .e_anno_only));
+    try std.testing.expectEqual(@as(usize, 0), countDefs(&env, env.global_value_defs, "implemented", .e_hosted_lambda));
+    try std.testing.expectEqual(@as(usize, 1), countDefs(&env, env.global_value_defs, "implemented", .e_anno_only));
+    try std.testing.expectEqual(@as(usize, 2), env.store.sliceDefs(env.hosted_defs).len);
+    for (env.store.sliceDefs(env.hosted_defs)) |hosted_def| {
+        try std.testing.expect(spanContainsDef(&env, env.value_binding_defs, hosted_def));
+    }
 }
 
 test "generated associated method markers are not value bindings" {

--- a/src/canonicalize/test/value_binding_selection_test.zig
+++ b/src/canonicalize/test/value_binding_selection_test.zig
@@ -133,10 +133,10 @@ test "platform header targets and hosted rewrite share top-level selection" {
 
     const selected_main = findAssignedDef(&env, env.top_level_value_defs, "main") orelse return error.TestUnexpectedResult;
     const selected_helper = findAssignedDef(&env, env.top_level_value_defs, "helper!") orelse return error.TestUnexpectedResult;
-    try std.testing.expectEqual(@as(usize, 1), env.provides_entries.items.items.len);
-    try std.testing.expectEqual(selected_main, env.provides_entries.items.items[0].local_def.?);
-    try std.testing.expectEqual(@as(usize, 1), env.hosted_entries.items.items.len);
-    try std.testing.expectEqual(selected_helper, env.hosted_entries.items.items[0].target_def.?);
+    try std.testing.expectEqual(@as(u64, 1), env.provides_entries.len());
+    try std.testing.expectEqual(selected_main, env.provides_entries.get(.first).local_def.?);
+    try std.testing.expectEqual(@as(u64, 1), env.hosted_entries.len());
+    try std.testing.expectEqual(selected_helper, env.hosted_entries.get(.first).target_def.?);
 
     try HostedCompiler.replaceAnnoOnlyWithHosted(&env);
 

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1051,6 +1051,11 @@ const subcommand_cases = [_]CliCase{
     // pointing at an implemented function should explain that implementation.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10423: hosted entry reports implemented function as not hosted", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/hosted-section-errors/issue_10423_hosted_implementation/main.roc", .exit = .failure, .stderr_min_len = 1, .contains = &.{ .{ .stream = .stderr, .text = "invalid hosted section" }, .{ .stream = .stderr, .text = "Pages.list" }, .{ .stream = .stderr, .text = "has an implementation" } }, .not_contains = &.{.{ .stream = .stderr, .text = "no exposed module declares a hosted function with that name" }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check accepts a valid hosted section", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/fx/platform/main.roc", .not_contains = &.{.{ .stream = .stderr, .text = "invalid hosted section" }} } } },
+    // Repro for https://github.com/roc-lang/roc/issues/10850: a platform root
+    // that declares its provided entrypoint twice reports the duplicate through
+    // checking's diagnostics instead of publishing a hosted procedure whose def
+    // has no checked template.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10850: duplicate platform entrypoint declaration reports without panic", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10850_duplicate_platform_entrypoint_annotation.roc", .exit = .failure, .stderr_min_len = 1, .not_contains = &.{ .{ .stream = .stderr, .text = "hosted procedure def has no checked template" }, .{ .stream = .stderr, .text = "checked artifact invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
     // A hosted declaration the platform header never bound has no linker symbol,
     // so building one reports the invalid hosted section instead of lowering a
     // host boundary that cannot link.

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1055,7 +1055,7 @@ const subcommand_cases = [_]CliCase{
     // that declares its provided entrypoint twice reports the duplicate through
     // checking's diagnostics instead of publishing a hosted procedure whose def
     // has no checked template.
-    .{ .id = 0, .suite = .subcommands, .name = "issue 10850: duplicate platform entrypoint declaration reports without panic", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10850_duplicate_platform_entrypoint_annotation.roc", .exit = .failure, .stderr_min_len = 1, .not_contains = &.{ .{ .stream = .stderr, .text = "hosted procedure def has no checked template" }, .{ .stream = .stderr, .text = "checked artifact invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10850: duplicate platform entrypoint declaration reports without panic", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10850_duplicate_platform_entrypoint_annotation.roc", .exit = .failure, .stderr_min_len = 1, .contains = &.{.{ .stream = .stderr, .text = "duplicate definition" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "hosted procedure def has no checked template" }, .{ .stream = .stderr, .text = "checked artifact invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
     // A hosted declaration the platform header never bound has no linker symbol,
     // so building one reports the invalid hosted section instead of lowering a
     // host boundary that cannot link.

--- a/test/cli/issue_10850_duplicate_platform_entrypoint_annotation.roc
+++ b/test/cli/issue_10850_duplicate_platform_entrypoint_annotation.roc
@@ -1,0 +1,14 @@
+# Repro for https://github.com/roc-lang/roc/issues/10850:
+# a platform root that declares its provided entrypoint twice must be reported
+# as an error, not published as a hosted procedure without a checked template.
+platform ""
+    requires {
+        [Model : model] for main : { init : model }
+    }
+    exposes []
+    packages {}
+    provides { "roc_main": main }
+
+main : { init : Model }
+
+main : { init : Model }


### PR DESCRIPTION
Fixes #10850 by making platform `provides` and unqualified `hosted` entries consume canonicalization's single selected top-level definition, and by applying the hosted rewrite only to definitions that actually introduce value bindings. This keeps superseded annotations available for diagnostics without publishing them as host procedures, preventing checked-artifact invariants from failing on duplicate declarations.