### PR TITLE
Fix duplicate associated type forward lookup

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -188,6 +188,12 @@ const ParserTypeDeclState = union(enum) {
     rejected,
 };
 
+const ForwardTypeScopeStep = union(enum) {
+    done,
+    parent: AST.DeclIndex.ScopeIdx,
+    ineligible,
+};
+
 const TypeDeclRegistration = union(enum) {
     registered: Statement.Idx,
     redeclared: Statement.Idx,
@@ -313,6 +319,9 @@ import_indices: std.AutoHashMapUnmanaged(Ident.Idx, Import.Idx),
 parser_type_decl_states: std.AutoHashMapUnmanaged(AST.Statement.Idx, ParserTypeDeclState) = .{},
 /// Type declarations whose CIR statements were prepared by a forward reference.
 forward_prepared_type_decls: std.ArrayListUnmanaged(Statement.Idx) = .empty,
+/// Whether an associated parser scope belongs to the selected occurrence of each
+/// enclosing type declaration. Populated only by nested forward type lookup.
+forward_type_scope_eligibility: std.AutoHashMapUnmanaged(AST.DeclIndex.ScopeIdx, bool) = .{},
 /// All canonical type-declaration statements produced by this module.
 type_decl_statements: std.ArrayListUnmanaged(Statement.Idx) = .empty,
 /// Parser alias-cycle members keyed by the AST alias statement, with the member
@@ -682,6 +691,7 @@ pub fn deinit(
     self.builtin_auto_imported_types.deinit(gpa);
     self.parser_type_decl_states.deinit(gpa);
     self.forward_prepared_type_decls.deinit(gpa);
+    self.forward_type_scope_eligibility.deinit(gpa);
     self.type_decl_statements.deinit(gpa);
     self.alias_cycle_references.deinit(gpa);
     self.alias_cycle_scopes.deinit(gpa);
@@ -1559,6 +1569,71 @@ fn firstUsableParserTypeDecl(self: *const Self, bucket: AST.DeclIndex.NameBucket
         if (self.parserTypeDeclCanPrepare(decl)) return decl_idx;
     }
     return null;
+}
+
+fn parserTypeDeclIsSelected(self: *const Self, decl_idx: AST.DeclIndex.DeclIdx) bool {
+    const decl_index = &self.parse_ir.decl_index;
+    const decl = decl_index.decls.items[@intFromEnum(decl_idx)];
+    const path = decl.type_path orelse return false;
+    const selected = self.firstUsableParserTypeDecl(decl_index.typeDeclsForPath(path)) orelse return false;
+    return selected == decl_idx;
+}
+
+fn forwardTypeScopeStep(
+    self: *const Self,
+    scope_idx: AST.DeclIndex.ScopeIdx,
+) ForwardTypeScopeStep {
+    const decl_index = &self.parse_ir.decl_index;
+    const scope = decl_index.scopes.items[@intFromEnum(scope_idx)];
+    switch (scope.kind) {
+        .module, .block => return .done,
+        .associated => {},
+    }
+    const owner_statement = switch (scope.owner) {
+        .associated_type_decl => |statement| statement,
+        .none, .file, .expr => return .ineligible,
+    };
+    const owner_decl_idx = decl_index.declForStatement(owner_statement) orelse return .ineligible;
+    if (!self.parserTypeDeclIsSelected(owner_decl_idx)) return .ineligible;
+    const owner_decl = decl_index.decls.items[@intFromEnum(owner_decl_idx)];
+    return .{ .parent = owner_decl.scope };
+}
+
+fn parserScopeCanSupplyForwardTypeDecl(
+    self: *Self,
+    start_scope: AST.DeclIndex.ScopeIdx,
+) std.mem.Allocator.Error!bool {
+    switch (self.parse_ir.decl_index.scopes.items[@intFromEnum(start_scope)].kind) {
+        .module, .block => return true,
+        .associated => {},
+    }
+
+    var scope_idx = start_scope;
+    const eligible = while (true) {
+        if (self.forward_type_scope_eligibility.get(scope_idx)) |cached| break cached;
+        switch (self.forwardTypeScopeStep(scope_idx)) {
+            .done => break true,
+            .parent => |parent| scope_idx = parent,
+            .ineligible => break false,
+        }
+    };
+
+    scope_idx = start_scope;
+    while (!self.forward_type_scope_eligibility.contains(scope_idx)) {
+        switch (self.forwardTypeScopeStep(scope_idx)) {
+            .done => break,
+            .parent => |parent| {
+                try self.forward_type_scope_eligibility.put(self.env.gpa, scope_idx, eligible);
+                scope_idx = parent;
+            },
+            .ineligible => {
+                try self.forward_type_scope_eligibility.put(self.env.gpa, scope_idx, false);
+                break;
+            },
+        }
+    }
+
+    return eligible;
 }
 
 fn activeWholeScopeBindingForDeclScope(
@@ -2871,6 +2946,8 @@ fn ensureParserTypeDeclBinding(
     const decl_index = &self.parse_ir.decl_index;
     const decl = decl_index.decls.items[@intFromEnum(decl_idx)];
     if (!self.parserTypeDeclCanPrepare(decl)) return null;
+    if (!self.parserTypeDeclIsSelected(decl_idx)) return null;
+    if (!try self.parserScopeCanSupplyForwardTypeDecl(decl.scope)) return null;
     const kind = declIndexTypeKind(decl.kind) orelse return null;
     const name_ident = decl.name_ident orelse return null;
     const ast_stmt_idx: AST.Statement.Idx = @enumFromInt(decl.statement);
@@ -20223,7 +20300,7 @@ fn canonicalizeTypeAnnoBasicType(
         // Check if this is a module alias
         const module_info = (try self.scopeLookupOrPrepareModule(module_alias)) orelse {
             // Module is not in current scope - but check if it's a type name first
-            if (try self.scopeLookupTypeBinding(module_alias)) |_| {
+            if (try self.scopeLookupOrPrepareTypeBinding(module_alias)) |_| {
                 // This is in scope as a type/value, but doesn't expose the nested type being requested
                 if (self.internalBuiltinTypeKind(module_alias, self.env.getIdent(qualified_name_ident))) |kind| {
                     return try self.env.pushMalformed(TypeAnno.Idx, CIR.Diagnostic{ .internal_builtin_type = .{

--- a/src/check/mod.zig
+++ b/src/check/mod.zig
@@ -97,6 +97,7 @@ test "check tests" {
     std.testing.refAllDecls(@import("test/issue_10759_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10804_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10824_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10853_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11057_test.zig"));
     std.testing.refAllDecls(@import("test/nominal_decl_growth_test.zig"));
 

--- a/src/check/test/issue_10853_test.zig
+++ b/src/check/test/issue_10853_test.zig
@@ -1,0 +1,54 @@
+//! Regression tests for issue #10853.
+
+const std = @import("std");
+const TestEnv = @import("./TestEnv.zig");
+
+test "issue 10853: a declaration in a duplicate associated owner cannot satisfy a forward lookup" {
+    const src =
+        \\T := [].{
+        \\    A : T.A
+        \\}
+        \\T := [].{
+        \\    A : A
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("T", src);
+    defer test_env.deinit();
+
+    try test_env.assertCanErrors(&.{ "Missing Nested Type", "Type Redeclared" });
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.problems.problems.items.len);
+    try std.testing.expectEqual(@as(u32, 0), test_env.module_env.forward_type_decls.span.len);
+}
+
+test "issue 10853: a duplicate declaration cannot satisfy its earlier alias lookup" {
+    const src =
+        \\T := [].{
+        \\    A : T.A
+        \\    A : U8
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("T", src);
+    defer test_env.deinit();
+
+    try test_env.assertCanErrors(&.{ "Missing Nested Type", "Type Redeclared" });
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.problems.problems.items.len);
+    try std.testing.expectEqual(@as(u32, 0), test_env.module_env.forward_type_decls.span.len);
+}
+
+test "issue 10853: the selected associated owner still supports a valid forward lookup" {
+    const src =
+        \\T := [].{
+        \\    A : T.B
+        \\    B : U8
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("T", src);
+    defer test_env.deinit();
+
+    try test_env.assertCanErrors(&.{});
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.problems.problems.items.len);
+    try std.testing.expectEqual(@as(u32, 1), test_env.module_env.forward_type_decls.span.len);
+}

--- a/test/snapshots/record_default_duplicate_associated_forward_lookup.md
+++ b/test/snapshots/record_default_duplicate_associated_forward_lookup.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=A forward reference prepares a nested type declaration as a placeholder; when its owner is then redeclared, the owner's associated block is skipped and the placeholder survives to end of mod unfilled. The defaulted-fields passes and the checker's decl generation must treat it as declaring nothing (its `.placeholder` anno used to be read as a TypeAnno and crash).
+description=A forward lookup must not use nested type declarations from a duplicate associated owner. The selected owner has neither Baz nor Qux, so both references are malformed and the duplicate Foo is reported.
 type=snippet
 ~~~
 # SOURCE
@@ -21,9 +21,25 @@ Foo := [B].{
 }
 ~~~
 # EXPECTED
-TYPE REDECLARED - record_default_forward_placeholder_survives.md:11:1:14:2
+MISSING NESTED TYPE - record_default_duplicate_associated_forward_lookup.md:1:5:1:12
+MISSING NESTED TYPE - record_default_duplicate_associated_forward_lookup.md:4:5:4:12
+TYPE REDECLARED - record_default_duplicate_associated_forward_lookup.md:11:1:14:2
 # PROBLEMS
-── ✗ type redeclared ─────── record_default_forward_placeholder_survives.md:11:1
+── ✗ missing nested type ─ record_default_duplicate_associated_forward_lookup.md:1:5
+
+Foo is in scope, but it doesn't have a nested type named Baz.
+
+f : Foo.Baz -> U8
+    ^^^^^^^
+
+── ✗ missing nested type ─ record_default_duplicate_associated_forward_lookup.md:4:5
+
+Foo is in scope, but it doesn't have a nested type named Qux.
+
+g : Foo.Qux -> U8
+    ^^^^^^^
+
+── ✗ type redeclared ─ record_default_duplicate_associated_forward_lookup.md:11:1
 
 The type Foo is being redeclared.
 
@@ -32,7 +48,7 @@ Foo := [B].{
     Qux : { z : U8 }
 }
 
-But Foo was already declared in record_default_forward_placeholder_survives.md:7:1:
+But Foo was already declared in record_default_duplicate_associated_forward_lookup.md:7:1:
 
 Foo := [A].{
     Bar := { x : U8 }
@@ -136,21 +152,21 @@ Foo := [B].{
 		(e-runtime-error (tag "erroneous_value_expr"))
 		(annotation
 			(ty-fn (effectful false)
-				(ty-lookup (name "Foo.Baz") (local))
+				(ty-malformed)
 				(ty-lookup (name "U8") (builtin)))))
 	(d-let
 		(p-assign (ident "g"))
 		(e-runtime-error (tag "erroneous_value_expr"))
 		(annotation
 			(ty-fn (effectful false)
-				(ty-lookup (name "Foo.Qux") (local))
+				(ty-malformed)
 				(ty-lookup (name "U8") (builtin)))))
 	(s-nominal-decl
 		(ty-header (name "Foo"))
 		(ty-tag-union
 			(ty-tag-name (name "A"))))
 	(s-nominal-decl
-		(ty-header (name "record_default_forward_placeholder_survives.Foo.Bar"))
+		(ty-header (name "record_default_duplicate_associated_forward_lookup.Foo.Bar"))
 		(ty-record
 			(field (field "x")
 				(ty-lookup (name "U8") (builtin)))))
@@ -169,7 +185,7 @@ Foo := [B].{
 		(nominal (type "Foo")
 			(ty-header (name "Foo")))
 		(nominal (type "Foo.Bar")
-			(ty-header (name "record_default_forward_placeholder_survives.Foo.Bar")))
+			(ty-header (name "record_default_duplicate_associated_forward_lookup.Foo.Bar")))
 		(nominal (type "Foo")
 			(ty-header (name "Foo"))))
 	(expressions


### PR DESCRIPTION
Fixes #10853.

Forward type lookup could prepare a declaration from a duplicate associated owner whose body would never be processed, leaving an unfilled CIR placeholder. This validates the exact declaration and its enclosing owner chain before preparation, so the invalid lookup produces `Missing Nested Type` without affecting the common resolved-lookup path.