### PR TITLE
Improve trailing question mark diagnostics

### DIFF
--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -3625,9 +3625,9 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
             const region_info = self.calcRegionInfo(data.region);
 
             var report = try Report.init(allocator, "Trailing `?`", "", .warning);
-            try report.headline.addReflowingText("This ");
+            try report.headline.addReflowingText("It's usually a mistake to use a postfix ");
             try report.headline.addAnnotated("?", .inline_code);
-            try report.headline.addReflowingText(" is applied to the value this function returns:");
+            try report.headline.addReflowingText(" on values being returned implicitly at the end of a function like this:");
 
             try report.document.addSourceRegion(
                 region_info,
@@ -3638,31 +3638,78 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
             );
             try report.document.addLineBreak();
 
-            try report.document.addReflowingText("A ");
+            try report.document.addReflowingText("This is because ");
             try report.document.addAnnotated("?", .inline_code);
-            try report.document.addReflowingText(" here is almost always a mistake. On ");
-            try report.document.addAnnotated("Err", .inline_code);
-            try report.document.addReflowingText(", it returns the error from the function early. On ");
-            try report.document.addAnnotated("Ok", .inline_code);
-            try report.document.addReflowingText(", it unwraps the payload and returns that instead of the ");
+            try report.document.addReflowingText(" is syntax sugar for doing a ");
+            try report.document.addAnnotated("match", .inline_code);
+            try report.document.addReflowingText(" on a ");
             try report.document.addAnnotated("Try", .inline_code);
-            try report.document.addReflowingText(", which only type-checks when the payload is itself a ");
-            try report.document.addAnnotated("Try", .inline_code);
-            try report.document.addReflowingText(".");
+            try report.document.addReflowingText(" value like this:");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try report.document.startAnnotation(.code_block);
+            try report.document.addIndent(1);
+            try report.document.addKeyword("match");
+            try report.document.addText(" ");
+            try report.document.addUnqualifiedSymbol("value_before_question_mark");
+            try report.document.addText(" {");
+            try report.document.addLineBreak();
+            try report.document.addIndent(2);
+            try report.document.addTagName("Ok");
+            try report.document.addText("(");
+            try report.document.addUnqualifiedSymbol("ok_payload");
+            try report.document.addText(") ");
+            try report.document.addBinaryOperator("=>");
+            try report.document.addText(" ");
+            try report.document.addUnqualifiedSymbol("ok_payload");
+            try report.document.addLineBreak();
+            try report.document.addIndent(2);
+            try report.document.addTagName("Err");
+            try report.document.addText("(");
+            try report.document.addUnqualifiedSymbol("err_payload");
+            try report.document.addText(") ");
+            try report.document.addBinaryOperator("=>");
+            try report.document.addText(" ");
+            try report.document.addKeyword("return");
+            try report.document.addText(" ");
+            try report.document.addTagName("Err");
+            try report.document.addText("(");
+            try report.document.addUnqualifiedSymbol("err_payload");
+            try report.document.addText(")");
+            try report.document.addLineBreak();
+            try report.document.addIndent(1);
+            try report.document.addText("}");
+            try report.document.endAnnotation();
             try report.document.addLineBreak();
             try report.document.addLineBreak();
 
-            try report.document.addReflowingText("If you meant to return the ");
-            try report.document.addAnnotated("Try", .inline_code);
-            try report.document.addReflowingText(" as-is, remove the ");
+            try report.document.addReflowingText("When you use ");
             try report.document.addAnnotated("?", .inline_code);
-            try report.document.addReflowingText(". If you really do want to unwrap a nested ");
+            try report.document.addReflowingText(" on the value at the end of a function, it changes \"implicitly return this ");
             try report.document.addAnnotated("Try", .inline_code);
-            try report.document.addReflowingText(" here, write that as a ");
+            try report.document.addReflowingText(" value\" to \"return this ");
+            try report.document.addAnnotated("Try", .inline_code);
+            try report.document.addReflowingText(" value if it's an ");
+            try report.document.addAnnotated("Err", .inline_code);
+            try report.document.addReflowingText(", but if it's ");
+            try report.document.addAnnotated("Ok", .inline_code);
+            try report.document.addReflowingText(", unwrap its ");
+            try report.document.addAnnotated("Ok", .inline_code);
+            try report.document.addReflowingText(" payload and return that instead\" - which can only possibly type-check when returning ");
+            try report.document.addAnnotated("Try(Try(..., ...), ...)", .inline_code);
+            try report.document.addReflowingText(", which is so unusual that using ");
+            try report.document.addAnnotated("?", .inline_code);
+            try report.document.addReflowingText(" here is almost always a mistake in practice.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            try report.document.addReflowingText("Usually removing the ");
+            try report.document.addAnnotated("?", .inline_code);
+            try report.document.addReflowingText(" here is what makes the most sense, but if you really want this behavior, make it clear by using an explicit ");
             try report.document.addAnnotated("match", .inline_code);
-            try report.document.addReflowingText(" instead, because a trailing ");
+            try report.document.addReflowingText(" instead of the ");
             try report.document.addAnnotated("?", .inline_code);
-            try report.document.addReflowingText(" is confusing to read.");
+            try report.document.addReflowingText(" syntax sugar.");
 
             break :blk report;
         },

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -1655,11 +1655,14 @@ pub const ReportBuilder = struct {
         try self.addSourceHighlight(&report, regionIdxFrom(types.actual_var));
         try report.document.addLineBreak();
 
-        if (try self.addTryErrorPayloadType(&report, types)) {
+        const has_error_payload_type = try self.addTryErrorPayloadType(&report, types);
+        if (has_error_payload_type) {
             try D.renderSlice(&.{
-                D.bytes("So this function must return a"),
+                D.bytes("Returning an"),
+                D.bytes("Err").withAnnotation(.inline_code),
+                D.bytes("with that type only works if the function itself returns a"),
                 D.bytes("Try").withAnnotation(.inline_code),
-                D.bytes("with a compatible error type."),
+                D.bytes("with a compatible error type, but this function's return type is:"),
             }, self, &report);
         } else {
             try D.renderSlice(&.{
@@ -1672,9 +1675,11 @@ pub const ReportBuilder = struct {
                 D.bytes(".").withNoPrecedingSpace(),
             }, self, &report);
         }
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
-        try D.renderSlice(&.{D.bytes("But its body evaluates to:")}, self, &report);
+        if (!has_error_payload_type) {
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try D.renderSlice(&.{D.bytes("But its body evaluates to:")}, self, &report);
+        }
         try report.document.addLineBreak();
         try report.document.addLineBreak();
         const body_type_str = try report.addOwnedString(self.getFormattedString(types.expected_snapshot));
@@ -1744,13 +1749,16 @@ pub const ReportBuilder = struct {
         const err_type = self.getFormattedString(err_snapshot);
 
         try D.renderSlice(&.{
-            D.bytes("On error, this"),
+            D.bytes("If this"),
+            D.bytes("Try").withAnnotation(.inline_code),
+            D.bytes("is an"),
+            D.bytes("Err").withAnnotation(.inline_code),
+            D.bytes(",").withNoPrecedingSpace(),
+            D.bytes("then the"),
             D.bytes("?").withAnnotation(.inline_code),
-            D.bytes("returns"),
-            D.bytes("Err(e)").withAnnotation(.inline_code),
-            D.bytes("where"),
-            D.bytes("e").withAnnotation(.inline_code),
-            D.bytes("has the type:"),
+            D.bytes("after it immediately returns an"),
+            D.bytes("Err").withAnnotation(.inline_code),
+            D.bytes("whose payload has this type:"),
         }, self, report);
         try report.document.addLineBreak();
         try report.document.addLineBreak();

--- a/src/reporting/renderer.zig
+++ b/src/reporting/renderer.zig
@@ -952,6 +952,13 @@ const RenderCtx = struct {
     annotation_stack: *std.array_list.Managed(Annotation),
 };
 
+fn hasOpenAnnotation(ctx: *const RenderCtx, annotation: Annotation) bool {
+    for (ctx.annotation_stack.items) |open_annotation| {
+        if (open_annotation == annotation) return true;
+    }
+    return false;
+}
+
 /// Inline markup written immediately before and after a span of annotated
 /// content.
 const Span = struct {
@@ -1308,12 +1315,16 @@ const MarkdownStyle = struct {
         try writer.writeAll(text);
     }
 
-    fn openInline(_: *RenderCtx, writer: *std.Io.Writer, annotation: Annotation) error{WriteFailed}!void {
-        try writer.writeAll(markdown_spans.get(annotation).open);
+    fn openInline(ctx: *RenderCtx, writer: *std.Io.Writer, annotation: Annotation) error{WriteFailed}!void {
+        if (!hasOpenAnnotation(ctx, .code_block)) {
+            try writer.writeAll(markdown_spans.get(annotation).open);
+        }
     }
 
-    fn closeInline(_: *RenderCtx, writer: *std.Io.Writer, annotation: Annotation) error{WriteFailed}!void {
-        try writer.writeAll(markdown_spans.get(annotation).close);
+    fn closeInline(ctx: *RenderCtx, writer: *std.Io.Writer, annotation: Annotation) error{WriteFailed}!void {
+        if (!hasOpenAnnotation(ctx, .code_block)) {
+            try writer.writeAll(markdown_spans.get(annotation).close);
+        }
     }
 
     fn openRegion(_: *RenderCtx, _: *std.Io.Writer, _: Annotation) error{WriteFailed}!void {}
@@ -1540,6 +1551,47 @@ test "render document with annotations to markdown" {
     try renderDocumentToMarkdown(&doc, &writer.writer, ReportingConfig.initMarkdown());
 
     try testing.expectEqualStrings("Hello **world**!", writer.written());
+}
+
+test "styled Roc code block renders colors and clean markdown" {
+    var doc = Document.init(testing.allocator);
+    defer doc.deinit();
+
+    try doc.startAnnotation(.code_block);
+    try doc.addIndent(1);
+    try doc.addKeyword("match");
+    try doc.addText(" ");
+    try doc.addUnqualifiedSymbol("value");
+    try doc.addText(" {");
+    try doc.addLineBreak();
+    try doc.addIndent(2);
+    try doc.addTagName("Ok");
+    try doc.addText("(");
+    try doc.addUnqualifiedSymbol("payload");
+    try doc.addText(") ");
+    try doc.addBinaryOperator("=>");
+    try doc.addText(" ");
+    try doc.addUnqualifiedSymbol("payload");
+    try doc.addLineBreak();
+    try doc.addIndent(1);
+    try doc.addText("}");
+    try doc.endAnnotation();
+
+    var writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer writer.deinit();
+
+    try renderDocumentToMarkdown(&doc, &writer.writer, ReportingConfig.initMarkdown());
+    try testing.expectEqualStrings(
+        \\    match value {
+        \\        Ok(payload) => payload
+        \\    }
+    , writer.written());
+
+    writer.clearRetainingCapacity();
+    try renderDocumentToTerminal(&doc, &writer.writer, ColorPalette.ANSI, ReportingConfig.initColorTerminal());
+    try testing.expect(std.mem.find(u8, writer.written(), "\x1b[35mmatch") != null);
+    try testing.expect(std.mem.find(u8, writer.written(), "\x1b[34mOk") != null);
+    try testing.expect(std.mem.find(u8, writer.written(), "\x1b[36mpayload") != null);
 }
 
 test "render HTML escaping" {

--- a/test/snapshots/try_suffix_return_mismatch.md
+++ b/test/snapshots/try_suffix_return_mismatch.md
@@ -48,18 +48,28 @@ TYPE MISMATCH - try_suffix_return_mismatch.md:30:8:30:18
 # PROBLEMS
 ── ● trailing `?` ─────────────────────────── try_suffix_return_mismatch.md:9:10
 
-This ? is applied to the value this function returns:
+It's usually a mistake to use a postfix ? on values being returned implicitly
+at the end of a function like this:
 
 parse(t)?
         ^
 
-A ? here is almost always a mistake. On Err, it returns the error from the
-function early. On Ok, it unwraps the payload and returns that instead of the
-Try, which only type-checks when the payload is itself a Try.
+This is because ? is syntax sugar for doing a match on a Try value like this:
 
-If you meant to return the Try as-is, remove the ?. If you really do want to
-unwrap a nested Try here, write that as a match instead, because a trailing ?
-is confusing to read.
+    match value_before_question_mark {
+        Ok(ok_payload) => ok_payload
+        Err(err_payload) => return Err(err_payload)
+    }
+
+When you use ? on the value at the end of a function, it changes "implicitly
+return this Try value" to "return this Try value if it's an Err, but if it's
+Ok, unwrap its Ok payload and return that instead" - which can only possibly
+type-check when returning Try(Try(..., ...), ...), which is so unusual that
+using ? here is almost always a mistake in practice.
+
+Usually removing the ? here is what makes the most sense, but if you really
+want this behavior, make it clear by using an explicit match instead of the ?
+syntax sugar.
 
 ── ✗ type mismatch ─────────────────────────── try_suffix_return_mismatch.md:8:6
 
@@ -68,13 +78,11 @@ This ? may return early with a type that doesn't match the function body.
 t = parse(s)?
     ^^^^^^^^^
 
-On error, this ? returns Err(e) where e has the type:
+If this Try is an Err, then the ? after it immediately returns an Err whose payload has this type:
 
     [BadInput]
 
-So this function must return a Try with a compatible error type.
-
-But its body evaluates to:
+Returning an Err with that type only works if the function itself returns a Try with a compatible error type, but this function's return type is:
 
     Str
 
@@ -92,13 +100,13 @@ This ? may return early with a type that doesn't match the function body.
 t = parse(s)?
     ^^^^^^^^^
 
-On error, this ? returns Err(e) where e has the type:
+If this Try is an Err, then the ? after it immediately returns an Err whose
+payload has this type:
 
     [BadInput]
 
-So this function must return a Try with a compatible error type.
-
-But its body evaluates to:
+Returning an Err with that type only works if the function itself returns a Try
+with a compatible error type, but this function's return type is:
 
     Str
 
@@ -112,13 +120,13 @@ This ? may return early with a type that doesn't match the function body.
 _x = xs.first()?
      ^^^^^^^^^^^
 
-On error, this ? returns Err(e) where e has the type:
+If this Try is an Err, then the ? after it immediately returns an Err whose
+payload has this type:
 
     [ListWasEmpty, ..]
 
-So this function must return a Try with a compatible error type.
-
-But its body evaluates to:
+Returning an Err with that type only works if the function itself returns a Try
+with a compatible error type, but this function's return type is:
 
     U64
 
@@ -132,13 +140,13 @@ This ? may return early with a type that doesn't match the function body.
 _x = l.first()?
      ^^^^^^^^^^
 
-On error, this ? returns Err(e) where e has the type:
+If this Try is an Err, then the ? after it immediately returns an Err whose
+payload has this type:
 
     [ListWasEmpty, ..]
 
-So this function must return a Try with a compatible error type.
-
-But its body evaluates to:
+Returning an Err with that type only works if the function itself returns a Try
+with a compatible error type, but this function's return type is:
 
     {}
 

--- a/test/snapshots/try_suffix_trailing_warning.md
+++ b/test/snapshots/try_suffix_trailing_warning.md
@@ -30,48 +30,78 @@ TRAILING `?` - try_suffix_trailing_warning.md:16:23:16:24
 # PROBLEMS
 ── ● trailing `?` ────────────────────────── try_suffix_trailing_warning.md:8:11
 
-This ? is applied to the value this function returns:
+It's usually a mistake to use a postfix ? on values being returned implicitly
+at the end of a function like this:
 
 nested(s)?
          ^
 
-A ? here is almost always a mistake. On Err, it returns the error from the
-function early. On Ok, it unwraps the payload and returns that instead of the
-Try, which only type-checks when the payload is itself a Try.
+This is because ? is syntax sugar for doing a match on a Try value like this:
 
-If you meant to return the Try as-is, remove the ?. If you really do want to
-unwrap a nested Try here, write that as a match instead, because a trailing ?
-is confusing to read.
+    match value_before_question_mark {
+        Ok(ok_payload) => ok_payload
+        Err(err_payload) => return Err(err_payload)
+    }
+
+When you use ? on the value at the end of a function, it changes "implicitly
+return this Try value" to "return this Try value if it's an Err, but if it's
+Ok, unwrap its Ok payload and return that instead" - which can only possibly
+type-check when returning Try(Try(..., ...), ...), which is so unusual that
+using ? here is almost always a mistake in practice.
+
+Usually removing the ? here is what makes the most sense, but if you really
+want this behavior, make it clear by using an explicit match instead of the ?
+syntax sugar.
 
 ── ● trailing `?` ───────────────────────── try_suffix_trailing_warning.md:14:19
 
-This ? is applied to the value this function returns:
+It's usually a mistake to use a postfix ? on values being returned implicitly
+at the end of a function like this:
 
 return nested(s)?
                 ^
 
-A ? here is almost always a mistake. On Err, it returns the error from the
-function early. On Ok, it unwraps the payload and returns that instead of the
-Try, which only type-checks when the payload is itself a Try.
+This is because ? is syntax sugar for doing a match on a Try value like this:
 
-If you meant to return the Try as-is, remove the ?. If you really do want to
-unwrap a nested Try here, write that as a match instead, because a trailing ?
-is confusing to read.
+    match value_before_question_mark {
+        Ok(ok_payload) => ok_payload
+        Err(err_payload) => return Err(err_payload)
+    }
+
+When you use ? on the value at the end of a function, it changes "implicitly
+return this Try value" to "return this Try value if it's an Err, but if it's
+Ok, unwrap its Ok payload and return that instead" - which can only possibly
+type-check when returning Try(Try(..., ...), ...), which is so unusual that
+using ? here is almost always a mistake in practice.
+
+Usually removing the ? here is what makes the most sense, but if you really
+want this behavior, make it clear by using an explicit match instead of the ?
+syntax sugar.
 
 ── ● trailing `?` ───────────────────────── try_suffix_trailing_warning.md:16:23
 
-This ? is applied to the value this function returns:
+It's usually a mistake to use a postfix ? on values being returned implicitly
+at the end of a function like this:
 
 if s == "y" nested(s)? else Ok(s)
                      ^
 
-A ? here is almost always a mistake. On Err, it returns the error from the
-function early. On Ok, it unwraps the payload and returns that instead of the
-Try, which only type-checks when the payload is itself a Try.
+This is because ? is syntax sugar for doing a match on a Try value like this:
 
-If you meant to return the Try as-is, remove the ?. If you really do want to
-unwrap a nested Try here, write that as a match instead, because a trailing ?
-is confusing to read.
+    match value_before_question_mark {
+        Ok(ok_payload) => ok_payload
+        Err(err_payload) => return Err(err_payload)
+    }
+
+When you use ? on the value at the end of a function, it changes "implicitly
+return this Try value" to "return this Try value if it's an Err, but if it's
+Ok, unwrap its Ok payload and return that instead" - which can only possibly
+type-check when returning Try(Try(..., ...), ...), which is so unusual that
+using ? here is almost always a mistake in practice.
+
+Usually removing the ? here is what makes the most sense, but if you really
+want this behavior, make it clear by using an explicit match instead of the ?
+syntax sugar.
 
 # TOKENS
 ~~~zig


### PR DESCRIPTION
Clarifies why a postfix question mark at a function return is usually a mistake by showing its formatted, syntax-highlighted match expansion and explaining the nested Try type it requires. It also makes the related early-return mismatch explain the Err payload and incompatible function return type more directly.