### PR TITLE
Avoid stale span borrows in hosted Try adapters

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -144,6 +144,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10842_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10848_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10849_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10870_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10935_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10977_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10980_test.zig"));

--- a/src/compile/test/issue_10870_test.zig
+++ b/src/compile/test/issue_10870_test.zig
@@ -1,0 +1,14 @@
+//! Regression test for issue #10870.
+
+const expectAppPathLowersToLirWithOptions = @import("lower_to_lir_harness.zig").expectAppPathLowersToLirWithOptions;
+
+test "issue 10870: mismatched hosted-try argument lowers to a checked crash" {
+    // The app binds a hosted `Try` whose Ok payload is a nominal type and then
+    // passes that value where a `Str` is required. Checking reports the
+    // mismatch, and lowering the rejected program must reach the end instead of
+    // reading a stale borrow while it builds the hosted-try adapter.
+    try expectAppPathLowersToLirWithOptions(
+        "test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/app.roc",
+        .{ .allow_user_errors = true },
+    );
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -162,6 +162,13 @@ pub fn expectAppPathLowersToLir(app_path: []const u8) LowerToLirHarnessError!voi
     try lowerAppPathToLir(std.testing.allocator, app_path, null, .{}, null, null);
 }
 
+/// Lower an app at `app_path` to LIR with explicit lowering options. Reaching
+/// the end without a panic is the assertion, so `allow_user_errors` programs
+/// use this to pin that a rejected app still lowers to a checked crash.
+pub fn expectAppPathLowersToLirWithOptions(app_path: []const u8, opts: LirLoweringOptions) LowerToLirHarnessError!void {
+    try lowerAppPathToLir(std.testing.allocator, app_path, null, opts, null, null);
+}
+
 /// Lower an app at `app_path` through Monotype specialization, without running
 /// later LIR transforms or ARC insertion.
 pub fn expectAppPathLowersToMonotype(app_path: []const u8) LowerToLirHarnessError!void {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -11039,9 +11039,7 @@ const Builder = struct {
         const declared_try = (try self.hostedTryInfoOrNull(hosted_try, declared.ret)) orelse return null;
         const requested_try = (try self.hostedTryInfoOrNull(hosted_try, requested.ret)) orelse return null;
 
-        const declared_args = self.program.types.span(declared.args);
-        const requested_args = self.program.types.span(requested.args);
-        if (declared_args.len != requested_args.len) {
+        if (declared.args.len != requested.args.len) {
             Common.invariant("hosted function use changed arity from the declared ABI");
         }
 
@@ -11078,9 +11076,7 @@ const Builder = struct {
         defer transaction_result.deinit();
         const narrowed_err_ty = transaction_result.root;
         const narrowed_try_ty = try self.hostedTryTypeLike(hosted_try, requested.ret, requested_try.ok_ty, narrowed_err_ty);
-        const source_args = try GuardedList.dupe(self.allocator, Type.TypeId, requested_args);
-        defer self.allocator.free(source_args);
-        return try self.closedFunctionType(source_args, narrowed_try_ty);
+        return try self.program.types.internFuncFromSpan(&self.program.names, requested.args, narrowed_try_ty);
     }
 
     fn hostedTryAdapterBody(

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -4,6 +4,7 @@
 //! defaulting have been finalized. It has no lambda sets and no layout data.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const check = @import("check");
 const collections = @import("collections");
 
@@ -2166,6 +2167,15 @@ pub const Store = struct {
         errdefer self.restore(mark_);
         const span_ = try self.addSpan(args);
         const ty = try self.add(.{ .func = .{ .args = span_, .ret = ret } });
+        return try self.internCandidate(name_store, mark_, ty);
+    }
+
+    /// Intern a function while reusing an argument span already owned by this
+    /// store. Immutable side-pool spans may be shared between type nodes.
+    pub fn internFuncFromSpan(self: *Store, name_store: *const names.NameStore, args: Span, ret: TypeId) std.mem.Allocator.Error!TypeId {
+        if (builtin.mode == .Debug) requireEpochSpan(args, @intCast(self.spans.len()));
+        const mark_ = self.mark();
+        const ty = try self.add(.{ .func = .{ .args = args, .ret = ret } });
         return try self.internCandidate(name_store, mark_, ty);
     }
 
@@ -4591,6 +4601,27 @@ test "monotype type store acyclic interning reuses child-first function nodes" {
     try std.testing.expectEqual(@as(usize, 2), store.view().types.len);
     try std.testing.expect(store.view().type_digests[@intFromEnum(first)] != null);
     try std.testing.expect(store.specializationDigestsView()[@intFromEnum(first)] != null);
+}
+
+test "monotype type store function interning reuses an existing argument span" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const unit = try store.internZst(&name_store);
+    const str = try store.internPrimitive(&name_store, .str);
+    const original = try store.internFunc(&name_store, &.{unit}, unit);
+    const args = store.get(original).func.args;
+    const spans_len = store.spans.len();
+
+    const with_str_return = try store.internFuncFromSpan(&name_store, args, str);
+    const reused_args = store.get(with_str_return).func.args;
+
+    try std.testing.expectEqual(args, reused_args);
+    try std.testing.expectEqual(spans_len, store.spans.len());
+    try std.testing.expectEqual(with_str_return, try store.internFunc(&name_store, &.{unit}, str));
 }
 
 test "monotype type store recursive transaction interns equal SCC positions" {

--- a/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/app.roc
+++ b/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/app.roc
@@ -1,0 +1,17 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+# Repro for https://github.com/roc-lang/roc/issues/10870
+#
+# `Env.var!` produces an `OsStr`, so handing it to `Stdout.line!`, which needs
+# a `Str`, is a type mismatch. Checking reports that mismatch; lowering the
+# checked program has to reach the same conclusion instead of crashing while it
+# builds the hosted-try adapter for these `?`s.
+
+import pf.Env
+import pf.Stdout
+
+main! = |_args| {
+	home = Env.var!("HOME")?
+	Stdout.line!(home)?
+	Ok({})
+}

--- a/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/Env.roc
+++ b/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/Env.roc
@@ -1,0 +1,7 @@
+import OsStr exposing [OsStr]
+import Host
+
+Env := [].{
+	var! : Str => Try(OsStr, [VarNotFound(Str), ..])
+	var! = |name| Ok(Host.var!(name)?)
+}

--- a/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/Host.roc
+++ b/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/Host.roc
@@ -1,0 +1,9 @@
+import OsStr exposing [OsStr]
+
+# Hosted declarations. `var!` hands the app a nominal type, and both functions
+# return `Try` at a closed error row, so `?` on either one widens through a
+# generated hosted-try adapter.
+Host := [].{
+	var! : Str => Try(OsStr, [VarNotFound(Str)])
+	line! : Str => Try({}, [StdoutErr(Str)])
+}

--- a/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/OsStr.roc
+++ b/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/OsStr.roc
@@ -1,0 +1,1 @@
+OsStr := [Utf8(Str)]

--- a/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/Stdout.roc
+++ b/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/Stdout.roc
@@ -1,0 +1,6 @@
+import Host
+
+Stdout := [].{
+	line! : Str => Try({}, [StdoutErr(Str), ..])
+	line! = |text| Ok(Host.line!(text)?)
+}

--- a/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/main.roc
+++ b/test/postcheck/issue_10870_hosted_try_nominal_arg_mismatch/platform/main.roc
@@ -1,0 +1,26 @@
+platform ""
+    requires {} { main! : List(Str) => Try({}, [Exit(I32), ..]) }
+    exposes [OsStr, Env, Stdout]
+    packages {}
+    provides { "roc_main": main_for_host! }
+    hosted {
+        "roc_env_var": Host.var!,
+        "roc_stdout_line": Host.line!,
+    }
+    targets: {}
+
+import OsStr
+import Host
+import Env
+import Stdout
+
+main_for_host! : List(Str) => I32
+main_for_host! = |args|
+    match main!(args) {
+        Ok({}) => 0
+        Err(Exit(code)) => code
+        Err(other) => {
+            _ = Host.line!(Str.inspect(other))
+            1
+        }
+    }


### PR DESCRIPTION
Hosted Try adapter construction retained an argument-span borrow while building narrowed result types, allowing type-store growth to invalidate it and causing release compiler segfaults. Reuse the immutable argument span directly when interning the adapter function, eliminating the invalid lifetime and the temporary allocation and copies. Fixes #10870.