### PR TITLE
Avoid tombstone buildup in nominal backing lookups

### DIFF
--- a/design.md
+++ b/design.md
@@ -6838,6 +6838,11 @@ columns, not hash tables keyed by node id. Union-find redirects may change which
 node is a class root, but they never renumber a node; root-owned columns are
 updated explicitly when a union moves that ownership.
 
+Declaration-backed nominal reuse is indexed by declaration identity plus the
+current argument-root tuple. Root unions rekey affected entries, so lookup cost
+must depend only on the current live index: the history of earlier root
+migrations must not lengthen future probe paths.
+
 A context-free callee body never joins the caller group's graph. Instead
 CheckedModule stores a complete specialization-interface relation table for
 every procedure template. Its records explicitly name checked equalities,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -15821,6 +15821,7 @@ test "post-check diagnostics preserve labeled Monotype counts" {
     diagnostics.specialization.nested_misses = 102;
     diagnostics.graph.nodes_created = 201;
     diagnostics.graph.generated_private_nodes_visited = 202;
+    diagnostics.graph.nominal_backing_tombstone_deletions = 203;
     diagnostics.body.instantiation_scopes_created = 303;
     diagnostics.body.checked_node_cache_hits = 301;
     diagnostics.body.deferred_template_reuses = 305;
@@ -15837,6 +15838,8 @@ test "post-check diagnostics preserve labeled Monotype counts" {
     try std.testing.expectEqual(@as(u64, 201), graph[1].count);
     try std.testing.expectEqualStrings("Generated-private nodes visited", graph[16].name);
     try std.testing.expectEqual(@as(u64, 202), graph[16].count);
+    try std.testing.expectEqualStrings("Nominal backing tombstone deletions", graph[21].name);
+    try std.testing.expectEqual(@as(u64, 203), graph[21].count);
 
     const body = monotypeBodyCounters(diagnostics);
     try std.testing.expectEqualStrings("Type instantiation scopes", body[1].name);

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -15663,7 +15663,7 @@ fn monotypeSpecializationCounters(diagnostics: postcheck.Monotype.Lower.Diagnost
     };
 }
 
-fn monotypeGraphCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [22]progress.Counter {
+fn monotypeGraphCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [23]progress.Counter {
     const graph = diagnostics.graph;
     return .{
         .{ .name = "Graphs created", .count = diagnostics.body.graphs_created },
@@ -15687,6 +15687,7 @@ fn monotypeGraphCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [22]
         .{ .name = "Finished-Monotype nodes visited", .count = graph.finished_mono_nodes_visited },
         .{ .name = "Nominal backing lookups", .count = graph.nominal_backing_lookups },
         .{ .name = "Nominal backing instances scanned", .count = graph.nominal_backing_instances_scanned },
+        .{ .name = "Nominal backing tombstone deletions", .count = graph.nominal_backing_tombstone_deletions },
         .{ .name = "Union-find resolutions", .count = graph.union_find_resolutions },
     };
 }

--- a/src/collections/README.md
+++ b/src/collections/README.md
@@ -9,3 +9,6 @@ This module provides:
 - **Memory Efficiency**: Data structures designed to minimize memory overhead during compilation
 - **Performance**: Fast access patterns for common compiler operations
 - **Type Safety**: Safe, generic collections that work with Roc's type system
+
+`RekeyingHashMap` keeps lookup cost independent of deletion history for indexes
+whose keys are repeatedly removed and reinserted as compiler identities evolve.

--- a/src/collections/RekeyingHashMap.zig
+++ b/src/collections/RekeyingHashMap.zig
@@ -1,0 +1,287 @@
+//! Linear-probing hash map for indexes whose keys are repeatedly removed and
+//! reinserted under new hashes.
+//!
+//! Backward-shift deletion closes each removed key's probe cluster immediately,
+//! so lookup cost depends on the current entries rather than historical rekeys.
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+/// An open-addressed map whose backward-shift deletion leaves no tombstones.
+pub fn RekeyingHashMap(
+    comptime K: type,
+    comptime V: type,
+    comptime Context: type,
+    comptime max_load_percentage: u64,
+) type {
+    if (max_load_percentage == 0 or max_load_percentage >= 100) {
+        @compileError("max_load_percentage must be between 0 and 100");
+    }
+
+    return struct {
+        const Self = @This();
+        const minimum_capacity = 8;
+
+        /// Whether deletion leaves occupied metadata in the probe cluster.
+        pub const removal_leaves_tombstones = false;
+
+        pub const KV = struct {
+            key: K,
+            value: V,
+        };
+
+        const Entry = struct {
+            hash: u64,
+            key: K,
+            value: V,
+        };
+
+        allocator: Allocator,
+        context: Context,
+        slots: []?Entry,
+        size: usize,
+
+        pub fn init(allocator: Allocator, context: Context) Self {
+            return .{
+                .allocator = allocator,
+                .context = context,
+                .slots = &.{},
+                .size = 0,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            if (self.slots.len != 0) self.allocator.free(self.slots);
+            self.* = undefined;
+        }
+
+        pub fn count(self: *const Self) usize {
+            return self.size;
+        }
+
+        pub fn capacity(self: *const Self) usize {
+            return self.slots.len;
+        }
+
+        pub fn ensureTotalCapacity(self: *Self, expected_count: usize) Allocator.Error!void {
+            if (expected_count <= usableCount(self.slots.len)) return;
+
+            var new_capacity: usize = if (self.slots.len == 0) minimum_capacity else self.slots.len;
+            while (expected_count > usableCount(new_capacity)) {
+                new_capacity = std.math.mul(usize, new_capacity, 2) catch return error.OutOfMemory;
+            }
+            try self.resize(new_capacity);
+        }
+
+        pub fn putNoClobber(self: *Self, key: K, value: V) Allocator.Error!void {
+            try self.ensureTotalCapacity(self.size + 1);
+            self.putAssumeCapacityNoClobber(key, value);
+        }
+
+        pub fn putAssumeCapacityNoClobber(self: *Self, key: K, value: V) void {
+            std.debug.assert(self.size < usableCount(self.slots.len));
+            std.debug.assert(self.get(key) == null);
+            self.insertEntry(.{
+                .hash = self.context.hash(key),
+                .key = key,
+                .value = value,
+            });
+        }
+
+        pub fn get(self: *const Self, key: K) ?V {
+            return self.getAdapted(key, self.context);
+        }
+
+        pub fn getAdapted(self: *const Self, key: anytype, context: anytype) ?V {
+            const index = self.getIndexAdapted(key, context) orelse return null;
+            return self.slots[index].?.value;
+        }
+
+        pub fn fetchRemove(self: *Self, key: K) ?KV {
+            const index = self.getIndexAdapted(key, self.context) orelse return null;
+            const removed = self.slots[index].?;
+            self.removeAt(index);
+            return .{ .key = removed.key, .value = removed.value };
+        }
+
+        fn usableCount(capacity_: usize) usize {
+            const load: usize = max_load_percentage;
+            return capacity_ / 100 * load + capacity_ % 100 * load / 100;
+        }
+
+        fn slotIndex(hash: u64, mask: usize) usize {
+            return @as(usize, @truncate(hash)) & mask;
+        }
+
+        fn probeDistance(ideal: usize, actual: usize, mask: usize) usize {
+            return (actual -% ideal) & mask;
+        }
+
+        fn getIndexAdapted(self: *const Self, key: anytype, context: anytype) ?usize {
+            if (self.size == 0) return null;
+
+            const hash = context.hash(key);
+            const mask = self.slots.len - 1;
+            var index = slotIndex(hash, mask);
+            var remaining = self.slots.len;
+            while (remaining != 0) : (remaining -= 1) {
+                const entry = self.slots[index] orelse return null;
+                if (entry.hash == hash and context.eql(key, entry.key)) return index;
+                index = (index + 1) & mask;
+            }
+            return null;
+        }
+
+        fn insertEntry(self: *Self, entry: Entry) void {
+            const mask = self.slots.len - 1;
+            var index = slotIndex(entry.hash, mask);
+            while (self.slots[index] != null) {
+                index = (index + 1) & mask;
+            }
+            self.slots[index] = entry;
+            self.size += 1;
+        }
+
+        fn removeAt(self: *Self, removed_index: usize) void {
+            const mask = self.slots.len - 1;
+            var hole = removed_index;
+            var scan = (hole + 1) & mask;
+
+            while (self.slots[scan]) |entry| {
+                const ideal = slotIndex(entry.hash, mask);
+                if (probeDistance(ideal, hole, mask) < probeDistance(ideal, scan, mask)) {
+                    self.slots[hole] = entry;
+                    hole = scan;
+                }
+                scan = (scan + 1) & mask;
+            }
+
+            self.slots[hole] = null;
+            self.size -= 1;
+        }
+
+        fn resize(self: *Self, new_capacity: usize) Allocator.Error!void {
+            std.debug.assert(std.math.isPowerOfTwo(new_capacity));
+            std.debug.assert(new_capacity > self.size);
+
+            const new_slots = try self.allocator.alloc(?Entry, new_capacity);
+            @memset(new_slots, null);
+
+            const old_slots = self.slots;
+            const old_size = self.size;
+            self.slots = new_slots;
+            self.size = 0;
+            for (old_slots) |slot| {
+                if (slot) |entry| self.insertEntry(entry);
+            }
+            std.debug.assert(self.size == old_size);
+            if (old_slots.len != 0) self.allocator.free(old_slots);
+        }
+    };
+}
+
+const TestContext = struct {
+    pub fn hash(_: TestContext, key: u32) u64 {
+        return key;
+    }
+
+    pub fn eql(_: TestContext, left: u32, right: u32) bool {
+        return left == right;
+    }
+};
+
+const CollisionContext = struct {
+    pub fn hash(_: CollisionContext, _: u32) u64 {
+        return 7;
+    }
+
+    pub fn eql(_: CollisionContext, left: u32, right: u32) bool {
+        return left == right;
+    }
+};
+
+const WideLookupContext = struct {
+    pub fn hash(_: WideLookupContext, key: u64) u64 {
+        return key;
+    }
+
+    pub fn eql(_: WideLookupContext, left: u64, right: u32) bool {
+        return left == right;
+    }
+};
+
+test "rekeying hash map preserves wrapped collision clusters after deletion" {
+    const Map = RekeyingHashMap(u32, u32, CollisionContext, 80);
+    var map = Map.init(std.testing.allocator, .{});
+    defer map.deinit();
+
+    for (1..6) |key| try map.putNoClobber(@intCast(key), @intCast(key * 10));
+    try std.testing.expectEqual(@as(usize, 8), map.capacity());
+
+    try std.testing.expectEqual(@as(u32, 10), map.fetchRemove(1).?.value);
+    try std.testing.expectEqual(@as(u32, 30), map.fetchRemove(3).?.value);
+    try std.testing.expectEqual(@as(u32, 20), map.get(2).?);
+    try std.testing.expectEqual(@as(u32, 40), map.get(4).?);
+    try std.testing.expectEqual(@as(u32, 50), map.get(5).?);
+    try std.testing.expectEqual(@as(?u32, null), map.get(1));
+    try std.testing.expectEqual(@as(?u32, null), map.get(3));
+}
+
+test "rekeying hash map grows and supports adapted lookup" {
+    const Map = RekeyingHashMap(u32, u32, TestContext, 80);
+    var map = Map.init(std.testing.allocator, .{});
+    defer map.deinit();
+
+    for (0..100) |key| try map.putNoClobber(@intCast(key), @intCast(key * 2));
+    try std.testing.expectEqual(@as(usize, 100), map.count());
+    try std.testing.expectEqual(@as(u32, 84), map.getAdapted(@as(u64, 42), WideLookupContext{}).?);
+
+    for (0..100) |key| {
+        try std.testing.expectEqual(@as(u32, @intCast(key * 2)), map.fetchRemove(@intCast(key)).?.value);
+    }
+    try std.testing.expectEqual(@as(usize, 0), map.count());
+}
+
+test "rekeying hash map matches an oracle through repeated collision churn" {
+    const Map = RekeyingHashMap(u32, u32, CollisionContext, 80);
+    var map = Map.init(std.testing.allocator, .{});
+    defer map.deinit();
+
+    var oracle: [128]?u32 = @splat(null);
+    var expected_count: usize = 0;
+    var prng = std.Random.DefaultPrng.init(0x11103);
+    const random = prng.random();
+
+    for (0..10_000) |step| {
+        const key = random.intRangeLessThan(u32, 0, @intCast(oracle.len));
+        const index: usize = @intCast(key);
+        switch (random.intRangeLessThan(u8, 0, 3)) {
+            0 => try std.testing.expectEqual(oracle[index], map.get(key)),
+            1 => {
+                if (oracle[index] == null) {
+                    const value: u32 = @intCast(step);
+                    try map.putNoClobber(key, value);
+                    oracle[index] = value;
+                    expected_count += 1;
+                }
+            },
+            2 => {
+                const removed = map.fetchRemove(key);
+                if (oracle[index]) |expected| {
+                    try std.testing.expectEqual(expected, removed.?.value);
+                    oracle[index] = null;
+                    expected_count -= 1;
+                } else {
+                    try std.testing.expectEqual(@as(?Map.KV, null), removed);
+                }
+            },
+            else => unreachable,
+        }
+
+        try std.testing.expectEqual(expected_count, map.count());
+        for (oracle, 0..) |expected, expected_key| {
+            try std.testing.expectEqual(expected, map.get(@intCast(expected_key)));
+        }
+    }
+}

--- a/src/collections/RekeyingHashMap.zig
+++ b/src/collections/RekeyingHashMap.zig
@@ -75,7 +75,8 @@ pub fn RekeyingHashMap(
         }
 
         pub fn putNoClobber(self: *Self, key: K, value: V) Allocator.Error!void {
-            try self.ensureTotalCapacity(self.size + 1);
+            const required_count = std.math.add(usize, self.size, 1) catch return error.OutOfMemory;
+            try self.ensureTotalCapacity(required_count);
             self.putAssumeCapacityNoClobber(key, value);
         }
 
@@ -201,6 +202,16 @@ const CollisionContext = struct {
     }
 };
 
+const ClusteredContext = struct {
+    pub fn hash(_: ClusteredContext, key: u32) u64 {
+        return key % 17;
+    }
+
+    pub fn eql(_: ClusteredContext, left: u32, right: u32) bool {
+        return left == right;
+    }
+};
+
 const WideLookupContext = struct {
     pub fn hash(_: WideLookupContext, key: u64) u64 {
         return key;
@@ -244,7 +255,7 @@ test "rekeying hash map grows and supports adapted lookup" {
 }
 
 test "rekeying hash map matches an oracle through repeated collision churn" {
-    const Map = RekeyingHashMap(u32, u32, CollisionContext, 80);
+    const Map = RekeyingHashMap(u32, u32, ClusteredContext, 80);
     var map = Map.init(std.testing.allocator, .{});
     defer map.deinit();
 

--- a/src/collections/mod.zig
+++ b/src/collections/mod.zig
@@ -36,6 +36,7 @@ pub const SafeStringHashMap = @import("safe_hash_map.zig").SafeStringHashMap;
 
 pub const DenseMap = @import("DenseMap.zig").DenseMap;
 pub const DenseMapPool = @import("DenseMap.zig").DenseMapPool;
+pub const RekeyingHashMap = @import("RekeyingHashMap.zig").RekeyingHashMap;
 
 pub const SortedArrayBuilder = @import("SortedArrayBuilder.zig").SortedArrayBuilder;
 pub const ExposedItems = @import("ExposedItems.zig").ExposedItems;
@@ -145,4 +146,5 @@ test "collections tests" {
     std.testing.refAllDecls(@import("SortedArrayBuilder.zig"));
     std.testing.refAllDecls(@import("SingleThreadArena.zig"));
     std.testing.refAllDecls(@import("DenseMap.zig"));
+    std.testing.refAllDecls(@import("RekeyingHashMap.zig"));
 }

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -149,6 +149,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10980_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11004_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10991_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11103_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11062_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));

--- a/src/compile/test/issue_11103_test.zig
+++ b/src/compile/test/issue_11103_test.zig
@@ -1,0 +1,40 @@
+//! Regression coverage for nominal-backing index fragmentation while
+//! specializing generated record-payload codecs.
+
+const std = @import("std");
+const postcheck = @import("postcheck");
+const harness = @import("lower_to_lir_harness.zig");
+
+test "issue 11103: distinct record payload codecs do not fragment the nominal backing index" {
+    var diagnostics: postcheck.Monotype.Lower.Diagnostics = .{};
+
+    try harness.expectLowersToLirWithOptions(
+        \\U : [
+        \\    V0({ f0 : Str }),
+        \\    V1({ f1 : Str }),
+        \\    V2({ f2 : Str }),
+        \\    V3({ f3 : Str }),
+        \\    V4({ f4 : Str }),
+        \\    V5({ f5 : Str }),
+        \\    V6({ f6 : Str }),
+        \\    V7({ f7 : Str }),
+        \\]
+        \\
+        \\main! = |args| {
+        \\    parsed : Try(U, _)
+        \\    parsed = Json.parse(args.get(0) ?? "")
+        \\    match parsed {
+        \\        Ok(_) => Ok({})
+        \\        Err(_) => Err(Exit(1))
+        \\    }
+        \\}
+    , .{
+        .monotype_only = true,
+        .monotype_diagnostics_out = &diagnostics,
+    });
+
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        diagnostics.graph.nominal_backing_tombstone_deletions,
+    );
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -140,6 +140,9 @@ pub const LirLoweringOptions = struct {
     /// Stop after Monotype lowering. Focused postcheck regressions use this
     /// boundary when later LIR passes are outside the behavior under test.
     monotype_only: bool = false,
+    /// Receives deterministic Monotype work counters. This is independent of
+    /// elapsed-time measurement and is available at the `monotype_only` boundary.
+    monotype_diagnostics_out: ?*postcheck.Monotype.Lower.Diagnostics = null,
 };
 
 /// Lower an app whose body is `app_body` (everything after the platform header
@@ -628,6 +631,7 @@ fn lowerAppPathToLir(
     }
 
     if (opts.monotype_only) {
+        var diagnostics: postcheck.Monotype.Lower.Diagnostics = .{};
         var mono = try postcheck.Monotype.Lower.run(
             gpa,
             .{
@@ -635,9 +639,10 @@ fn lowerAppPathToLir(
                 .imports = imports,
             },
             .{ .requests = lir_roots },
-            .{},
+            .{ .diagnostics = if (opts.monotype_diagnostics_out != null) &diagnostics else null },
         );
         mono.deinit();
+        if (opts.monotype_diagnostics_out) |out| out.* = diagnostics;
         return;
     }
 

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -269,6 +269,10 @@ pub const GraphDiagnostics = struct {
     /// 10978 hit exactly that).
     nominal_backing_lookups: u64 = 0,
     nominal_backing_instances_scanned: u64 = 0,
+    /// Nominal-backing deletions that leave tombstones in the lookup index.
+    /// This must remain zero: rekeying cannot make lookup cost depend on the
+    /// graph's history of root migrations.
+    nominal_backing_tombstone_deletions: u64 = 0,
     /// Union-find resolutions across all graph operations: the broadest
     /// deterministic proxy for total solver work.
     union_find_resolutions: u64 = 0,
@@ -360,6 +364,13 @@ const NominalBackingKeyContext = struct {
             std.mem.eql(NodeId, left.args, right.args);
     }
 };
+
+const NominalBackingIndex = collections.RekeyingHashMap(
+    NominalBackingKey,
+    NominalBackingInstanceId,
+    NominalBackingKeyContext,
+    80,
+);
 
 const NominalBackingLookup = struct {
     declaration: NominalBackingDeclaration,
@@ -538,7 +549,7 @@ pub const InstGraph = struct {
     /// Exact declaration-plus-current-argument-roots index for instantiated
     /// nominal backings. Keys point into the stable argument storage owned by
     /// `nominal_backing_instances`.
-    nominal_backing_index: std.HashMap(NominalBackingKey, NominalBackingInstanceId, NominalBackingKeyContext, 80),
+    nominal_backing_index: NominalBackingIndex,
     nominal_backing_instances: std.ArrayList(NominalBackingInstance),
     /// Argument positions by their current root. This is the precise
     /// invalidation index used to rekey affected instances in `union_`.
@@ -631,7 +642,7 @@ pub const InstGraph = struct {
             .imported_type_nodes = collections.DenseMap(Type.TypeId, NodeId).init(allocator),
             .provisional_view_shareable = collections.DenseMap(Type.TypeId, bool).init(allocator),
             .imported_monos = collections.DenseMap(NodeId, Type.TypeId).init(allocator),
-            .nominal_backing_index = std.HashMap(NominalBackingKey, NominalBackingInstanceId, NominalBackingKeyContext, 80).init(allocator),
+            .nominal_backing_index = NominalBackingIndex.init(allocator, .{}),
             .nominal_backing_instances = .empty,
             .nominal_backings_by_root = collections.DenseMap(NodeId, std.ArrayList(NominalBackingOccurrence)).init(allocator),
             .nominal_backing_affected = .empty,
@@ -671,6 +682,12 @@ pub const InstGraph = struct {
     fn countDiagnosticBy(self: *InstGraph, comptime field: []const u8, amount: usize) void {
         if (self.diagnostics) |diagnostics| {
             @field(diagnostics, field) += @intCast(amount);
+        }
+    }
+
+    fn countNominalBackingIndexRemoval(self: *InstGraph) void {
+        if (NominalBackingIndex.removal_leaves_tombstones) {
+            self.countDiagnostic("nominal_backing_tombstone_deletions");
         }
     }
 
@@ -1909,6 +1926,7 @@ pub const InstGraph = struct {
             };
             const removed = self.nominal_backing_index.fetchRemove(old_key) orelse
                 Common.invariant("active nominal backing instance was absent from its index");
+            self.countNominalBackingIndexRemoval();
             if (removed.value != instance_id) {
                 Common.invariant("nominal backing key referenced the wrong instance");
             }
@@ -1950,6 +1968,7 @@ pub const InstGraph = struct {
                 if (retained_id == instance_id) {
                     const removed = self.nominal_backing_index.fetchRemove(new_key) orelse
                         Common.invariant("colliding nominal backing key disappeared during migration");
+                    self.countNominalBackingIndexRemoval();
                     if (removed.value != existing_id) {
                         Common.invariant("colliding nominal backing key referenced the wrong instance");
                     }


### PR DESCRIPTION
Repeated nominal-backing rekeys used tombstone deletions, making lookup probe chains depend on all prior union-find root migrations. This replaces that index with a backward-shift-deletion hash map and adds deterministic regression coverage; on the 48-variant case from #11103, retired instructions drop from 878.7B to 23.1B (about 38× less work). Fixes #11103.