### PR TITLE
Fix named-underscore list rest aliases

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -6534,13 +6534,13 @@ fn runExprStatementKernel(
                     self.advance();
                     if (self.peek() == .KwAs) {
                         self.advance();
-                        if (self.peek() != .LowerIdent) {
+                        if (self.peek() != .LowerIdent and self.peek() != .NamedUnderscore) {
                             last_pattern = try self.pushMalformed(AST.Pattern.Idx, .pattern_unexpected_token, start);
                             continue :expr_kernel .pattern_complete;
                         }
                         name = self.pos;
                         self.advance();
-                    } else if (self.peek() == .LowerIdent) {
+                    } else if (self.peek() == .LowerIdent or self.peek() == .NamedUnderscore) {
                         last_pattern = try self.pushMalformed(AST.Pattern.Idx, .pattern_list_rest_old_syntax, self.pos);
                         continue :expr_kernel .pattern_complete;
                     }
@@ -6842,11 +6842,11 @@ fn runExprStatementKernel(
                 var rest_name: ?Token.Idx = null;
                 if (self.peek() == .KwAs) {
                     self.advance();
-                    if (self.peek() == .LowerIdent) {
+                    if (self.peek() == .LowerIdent or self.peek() == .NamedUnderscore) {
                         rest_name = self.pos;
                         self.advance();
                     }
-                } else if (self.peek() == .LowerIdent) {
+                } else if (self.peek() == .LowerIdent or self.peek() == .NamedUnderscore) {
                     rest_name = self.pos;
                     self.advance();
                     try self.pushDiagnostic(.pattern_list_rest_old_syntax, .{ .start = rest_start, .end = self.pos });

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -1120,3 +1120,40 @@ test "parser does not create a type path for malformed associated type headers" 
         }
     }
 }
+
+test "issue 11109: list rest aliases accept ordinary and named-underscore identifiers" {
+    const gpa = std.testing.allocator;
+    const sources = [_][]const u8{
+        \\b = |lst| {
+        \\    match lst {
+        \\        [h, .. as tail] if h < 4 => "a"
+        \\        _ => ""
+        \\    }
+        \\}
+        \\
+        \\expect [3] |> b |> Str.is_eq("a")
+        \\expect [] |> b |> Str.is_eq("")
+        ,
+        \\b = |lst| {
+        \\    match lst {
+        \\        [h, .. as _tail] if h < 4 => "a"
+        \\        _ => ""
+        \\    }
+        \\}
+        \\
+        \\expect [3] |> b |> Str.is_eq("a")
+        \\expect [] |> b |> Str.is_eq("")
+        ,
+    };
+
+    for (sources) |source| {
+        var env = try CommonEnv.init(gpa, source);
+        defer env.deinit(gpa);
+
+        const ast = try file(gpa, &env);
+        defer ast.deinit();
+
+        try std.testing.expectEqual(@as(usize, 0), ast.tokenize_diagnostics.items.len);
+        try std.testing.expectEqual(@as(usize, 0), ast.parse_diagnostics.items.len);
+    }
+}


### PR DESCRIPTION
List rest aliases only accepted `LowerIdent` after `as`, so a named underscore such as `_tail` remained unconsumed and produced cascading parse errors. Accept `NamedUnderscore` in both list-rest parser paths and add a regression covering both forms.

Fixes #11109