### PR TITLE
Make ARC path state sparse and persistent

### DIFF
--- a/design.md
+++ b/design.md
@@ -10487,6 +10487,14 @@ and metadata have been committed. `ArcPlan` is the phase boundary: dependency
 solving may query ownership and liveness while filling a slot; its materializer
 accepts neither and only follows the explicit decisions.
 
+Exact ownership and certifier path snapshots use persistent sparse proc-local
+state. A control-flow fork shares the unchanged state root, and a transition
+stores only bounded-depth paths to changed resource, local, or value facts.
+Fresh one-owner states update their paths in place until the first fork; meets
+share equal subtrees and allocate only changed subtrees. Procedure width is
+therefore paid once by the producer-owned domains and summaries, not once per
+branch, join arrival, plan endpoint, or certifier work item.
+
 Immediate `incref`/matching-`decref` cancellation is part of retain
 construction: count one cancels the pair and larger counts are reduced by one.
 The completed graph is never rewritten by a later RC-elision traversal. Final

--- a/design.md
+++ b/design.md
@@ -10489,7 +10489,8 @@ accepts neither and only follows the explicit decisions.
 
 Exact ownership and certifier path snapshots use persistent sparse proc-local
 state. A control-flow fork shares the unchanged state root, and a transition
-stores only bounded-depth paths to changed resource, local, or value facts.
+stores only bounded-depth paths to changed `OwnedEntry` values, liveness words,
+or certifier `State` entries.
 Fresh one-owner states update their paths in place until the first fork; meets
 share equal subtrees and allocate only changed subtrees. Procedure width is
 therefore paid once by the producer-owned domains and summaries, not once per

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -29,6 +29,70 @@ const TestError = helpers.TestHelperError || eval.BuiltinModules.InitError || li
     MissingSpecializedWorker,
 };
 
+const PeakAllocator = struct {
+    child: Allocator,
+    mutex: std.atomic.Mutex = .unlocked,
+    current_bytes: usize = 0,
+    peak_bytes: usize = 0,
+
+    fn allocator(self: *PeakAllocator) Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .remap = remap,
+                .free = free,
+            },
+        };
+    }
+
+    fn lock(self: *PeakAllocator) void {
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+    }
+
+    fn noteResize(self: *PeakAllocator, old_len: usize, new_len: usize) void {
+        self.current_bytes -= old_len;
+        self.current_bytes += new_len;
+        self.peak_bytes = @max(self.peak_bytes, self.current_bytes);
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *PeakAllocator = @ptrCast(@alignCast(ctx));
+        self.lock();
+        defer self.mutex.unlock();
+        const result = self.child.rawAlloc(len, alignment, ret_addr);
+        if (result != null) self.noteResize(0, len);
+        return result;
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *PeakAllocator = @ptrCast(@alignCast(ctx));
+        self.lock();
+        defer self.mutex.unlock();
+        if (!self.child.rawResize(memory, alignment, new_len, ret_addr)) return false;
+        self.noteResize(memory.len, new_len);
+        return true;
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *PeakAllocator = @ptrCast(@alignCast(ctx));
+        self.lock();
+        defer self.mutex.unlock();
+        const result = self.child.rawRemap(memory, alignment, new_len, ret_addr);
+        if (result != null) self.noteResize(memory.len, new_len);
+        return result;
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *PeakAllocator = @ptrCast(@alignCast(ctx));
+        self.lock();
+        defer self.mutex.unlock();
+        self.child.rawFree(memory, alignment, ret_addr);
+        self.noteResize(memory.len, 0);
+    }
+};
+
 var shared_test_builtins: ?eval.BuiltinModules = null;
 var shared_test_builtins_mutex: std.Io.Mutex = .init;
 
@@ -470,6 +534,18 @@ fn structuralJsonLirStats(
         .decrefs = decrefs,
         .conditional_decrefs = conditional_decrefs,
     };
+}
+
+fn structuralJsonLirPeakBytes(field_count: usize) TestError!usize {
+    const source = try structuralJsonSource(std.testing.allocator, field_count, "Str", .parse);
+    defer std.testing.allocator.free(source);
+
+    var peak_allocator = PeakAllocator{ .child = std.testing.allocator };
+    const allocator = peak_allocator.allocator();
+    var lowered = try lowerModule(allocator, source, .wrappers);
+    lowered.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), peak_allocator.current_bytes);
+    return peak_allocator.peak_bytes;
 }
 
 fn expectEquivalentMonotypeProgramViews(lhs: postcheck.Monotype.Ast.ProgramView, rhs: postcheck.Monotype.Ast.ProgramView) error{TestExpectedEqual}!void {
@@ -1922,6 +1998,31 @@ test "issue 10979 flat JSON record parser growth is linear in field count" {
         );
     }
     try std.testing.expect(wide_per_field <= narrow_per_field * 2);
+}
+
+test "issue 11100 flat JSON record parser peak allocation is linear in field count" {
+    // Repro for https://github.com/roc-lang/roc/issues/11100.
+    // Peak live requested bytes are deterministic allocator accounting, not
+    // wall time. A whole-pipeline peak is the maximum of several phases, so
+    // compare adjacent totals: subtracting them becomes invalid when the
+    // dominating phase changes between input sizes. A doubling may use at
+    // most three times the memory, allowing 50% per-field variance while
+    // still rejecting the issue's greater-than-fourfold 16-to-32 growth.
+    const sizes = [_]usize{ 8, 16, 32 };
+    var peaks: [sizes.len]usize = undefined;
+    for (sizes, &peaks) |field_count, *peak| {
+        peak.* = try structuralJsonLirPeakBytes(field_count);
+    }
+
+    if (peaks[1] > peaks[0] * 3 or peaks[2] > peaks[1] * 3) {
+        std.debug.print(
+            "flat JSON parser peak allocation grew nonlinearly: " ++
+                "{d}/{d}/{d} fields used {d}/{d}/{d} peak bytes\n",
+            .{ sizes[0], sizes[1], sizes[2], peaks[0], peaks[1], peaks[2] },
+        );
+    }
+    try std.testing.expect(peaks[1] <= peaks[0] * 3);
+    try std.testing.expect(peaks[2] <= peaks[1] * 3);
 }
 
 test "issue 10979 flat JSON record parser ARC growth is linear in field count" {

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -829,7 +829,7 @@ const ExactBitSet = struct {
 
     fn initEmpty(allocator: Allocator, bit_len: usize) Allocator.Error!ExactBitSet {
         const word_len = std.math.divCeil(usize, bit_len, 64) catch unreachable;
-        if (word_len > @as(usize, std.math.maxInt(u32)) + 1) {
+        if (word_len != 0 and word_len - 1 > std.math.maxInt(u32)) {
             arcInvariant("ARC liveness bit domain exceeded the snapshot index representation");
         }
         return .{ .bit_len = bit_len, .words = ArcSnapshot(u64, 0).init(allocator, word_len) };

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -26,6 +26,7 @@ const arc_sig = @import("arc_sig.zig");
 const arc_solve = @import("arc_solve.zig");
 const arc_certify = @import("arc_certify.zig");
 const arc_dismantle = @import("arc_dismantle.zig");
+const ArcSnapshot = @import("arc_state.zig").Snapshot;
 const debug_print = @import("debug_print.zig");
 
 const LIR = core.LIR;
@@ -453,10 +454,10 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
             const param = GuardedList.at(emit_params_for_overrides, position);
             const bit = arc_sig.paramBit(position) orelse break;
             if (solved_sig.paramMode(position) == .borrowed and emit_sig.paramMode(position) == .owned) {
-                owned_binding_override.set(param);
+                try owned_binding_override.set(param);
             }
             if ((emit_sig.unique_params & bit) != 0) {
-                unique_param_override.set(param);
+                try unique_param_override.set(param);
             }
         }
         // A recursive tail argument can borrow across frame replacement only
@@ -468,11 +469,11 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
             for (0..arc_sig.tracked_param_count) |position| {
                 const carrier = tail_call.carrier(position) orelse continue;
                 if (tail_call.argumentOutlivesScc(position, emit_sig)) continue;
-                owned_binding_override.set(carrier);
+                try owned_binding_override.set(carrier);
             }
         }
         for (domain.frame_locals) |local| {
-            if (dismantles.isTakeBinding(local)) owned_binding_override.set(local);
+            if (dismantles.isTakeBinding(local)) try owned_binding_override.set(local);
         }
         // A field read solved borrowed in the unconditional base signature
         // becomes an owned binding exactly when the explicit dismantle plan
@@ -481,7 +482,7 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
         // specialization.
         for (domain.frame_locals) |local| {
             const root = dismantles.ownedOnlyBindingRoot(local) orelse continue;
-            if (owned_binding_override.contains(root)) owned_binding_override.set(local);
+            if (owned_binding_override.contains(root)) try owned_binding_override.set(local);
         }
 
         const join_bodies = solution.joinBodiesOf(source_proc);
@@ -497,7 +498,7 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
         for (0..GuardedList.borrowLen(emit_params_for_owned)) |position| {
             const param = GuardedList.at(emit_params_for_owned, position);
             if (emit_sig.paramMode(position) == .owned) {
-                if (inserter.localContainsRefcounted(param)) owned.set(param);
+                if (inserter.localContainsRefcounted(param)) try owned.set(param);
             }
         }
 
@@ -820,132 +821,134 @@ const LoopLivenessCache = struct {
     dirty: bool = false,
 };
 
-/// One exact finite-lattice bit set. Procedure-local ARC domains commonly fit
-/// in one machine word; those sets stay inline and wider producer-authored
-/// domains allocate exact words. Ownership and liveness use the same
-/// representation so snapshots preserve identical operations and ordering.
+/// One exact finite-lattice bit set. Rows share persistent sparse subtrees;
+/// adding or killing one liveness fact copies one bounded-depth radix path.
 const ExactBitSet = struct {
     bit_len: usize,
-    storage: union(enum) {
-        inline_word: usize,
-        allocated: std.bit_set.DynamicBitSetUnmanaged,
-    },
+    words: ArcSnapshot(u64, 0),
 
     fn initEmpty(allocator: Allocator, bit_len: usize) Allocator.Error!ExactBitSet {
-        if (bit_len <= @bitSizeOf(usize)) {
-            return .{ .bit_len = bit_len, .storage = .{ .inline_word = 0 } };
+        const word_len = std.math.divCeil(usize, bit_len, 64) catch unreachable;
+        if (word_len > @as(usize, std.math.maxInt(u32)) + 1) {
+            arcInvariant("ARC liveness bit domain exceeded the snapshot index representation");
         }
-        return .{
-            .bit_len = bit_len,
-            .storage = .{ .allocated = try std.bit_set.DynamicBitSetUnmanaged.initEmpty(allocator, bit_len) },
-        };
+        return .{ .bit_len = bit_len, .words = ArcSnapshot(u64, 0).init(allocator, word_len) };
     }
 
-    fn deinit(self: *ExactBitSet, allocator: Allocator) void {
-        switch (self.storage) {
-            .inline_word => {},
-            .allocated => |*bits| bits.deinit(allocator),
-        }
-        self.* = undefined;
-    }
+    fn deinit(_: *ExactBitSet, _: Allocator) void {}
 
     fn clone(self: *const ExactBitSet, allocator: Allocator) Allocator.Error!ExactBitSet {
-        return switch (self.storage) {
-            .inline_word => |bits| .{ .bit_len = self.bit_len, .storage = .{ .inline_word = bits } },
-            .allocated => |bits| .{ .bit_len = self.bit_len, .storage = .{ .allocated = try bits.clone(allocator) } },
-        };
+        var cloned = self.*;
+        cloned.words.allocator = allocator;
+        return cloned;
     }
 
-    fn set(self: *ExactBitSet, bit: usize) void {
+    fn set(self: *ExactBitSet, bit: usize) Allocator.Error!void {
         std.debug.assert(bit < self.bit_len);
-        switch (self.storage) {
-            .inline_word => |*bits| bits.* |= @as(usize, 1) << @intCast(bit),
-            .allocated => |*bits| bits.set(bit),
-        }
+        const word_index: u32 = @intCast(bit / 64);
+        const mask = @as(u64, 1) << @intCast(bit % 64);
+        try self.words.put(word_index, self.words.get(word_index) | mask);
     }
 
-    fn unset(self: *ExactBitSet, bit: usize) void {
+    fn unset(self: *ExactBitSet, bit: usize) Allocator.Error!void {
         std.debug.assert(bit < self.bit_len);
-        switch (self.storage) {
-            .inline_word => |*bits| bits.* &= ~(@as(usize, 1) << @intCast(bit)),
-            .allocated => |*bits| bits.unset(bit),
-        }
+        const word_index: u32 = @intCast(bit / 64);
+        const mask = @as(u64, 1) << @intCast(bit % 64);
+        try self.words.put(word_index, self.words.get(word_index) & ~mask);
     }
 
     fn isSet(self: *const ExactBitSet, bit: usize) bool {
         std.debug.assert(bit < self.bit_len);
-        return switch (self.storage) {
-            .inline_word => |bits| bits & (@as(usize, 1) << @intCast(bit)) != 0,
-            .allocated => |bits| bits.isSet(bit),
-        };
+        const word_index: u32 = @intCast(bit / 64);
+        const mask = @as(u64, 1) << @intCast(bit % 64);
+        return self.words.get(word_index) & mask != 0;
     }
 
     fn unsetAll(self: *ExactBitSet) void {
-        switch (self.storage) {
-            .inline_word => |*bits| bits.* = 0,
-            .allocated => |*bits| bits.unsetAll(),
-        }
+        self.words.clear();
     }
 
-    fn setUnion(self: *ExactBitSet, other: ExactBitSet) void {
+    fn setUnion(self: *ExactBitSet, other: ExactBitSet) Allocator.Error!void {
         std.debug.assert(self.bit_len == other.bit_len);
-        switch (self.storage) {
-            .inline_word => |*bits| bits.* |= other.storage.inline_word,
-            .allocated => |*bits| bits.setUnion(other.storage.allocated),
-        }
+        _ = try self.words.joinWith(&other.words, {}, unionWord);
     }
 
-    fn setIntersection(self: *ExactBitSet, other: ExactBitSet) void {
+    fn setIntersection(self: *ExactBitSet, other: ExactBitSet) Allocator.Error!void {
         std.debug.assert(self.bit_len == other.bit_len);
-        switch (self.storage) {
-            .inline_word => |*bits| bits.* &= other.storage.inline_word,
-            .allocated => |*bits| bits.setIntersection(other.storage.allocated),
-        }
+        _ = try self.words.meetWith(&other.words, {}, intersectWord);
     }
 
     fn count(self: *const ExactBitSet) usize {
-        return switch (self.storage) {
-            .inline_word => |bits| @popCount(bits),
-            .allocated => |bits| bits.count(),
-        };
+        var total: usize = 0;
+        const word_len = std.math.divCeil(usize, self.bit_len, 64) catch unreachable;
+        for (0..word_len) |word_index| total += @popCount(self.words.get(@intCast(word_index)));
+        return total;
     }
 
     fn Iterator(comptime options: std.bit_set.IteratorOptions) type {
         if (options.kind != .set) @compileError("ARC exact sets iterate only set bits");
-        return union(enum) {
-            inline_word: usize,
-            allocated: std.bit_set.DynamicBitSetUnmanaged.Iterator(options),
+        return struct {
+            set: *const ExactBitSet,
+            word_cursor: usize,
+            word_base: usize = 0,
+            pending: u64 = 0,
 
             fn next(self: *@This()) ?usize {
-                return switch (self.*) {
-                    .inline_word => |*remaining| {
-                        if (remaining.* == 0) return null;
-                        const bit = switch (options.direction) {
-                            .forward => @ctz(remaining.*),
-                            .reverse => @bitSizeOf(usize) - 1 - @clz(remaining.*),
-                        };
-                        remaining.* &= ~(@as(usize, 1) << @intCast(bit));
-                        return bit;
+                return switch (options.direction) {
+                    .forward => {
+                        const word_len = std.math.divCeil(usize, self.set.bit_len, 64) catch unreachable;
+                        while (true) {
+                            if (self.pending != 0) {
+                                const word_bit: usize = @intCast(@ctz(self.pending));
+                                self.pending &= self.pending - 1;
+                                return self.word_base + word_bit;
+                            }
+                            if (self.word_cursor >= word_len) return null;
+                            self.word_base = self.word_cursor * 64;
+                            self.pending = self.set.words.get(@intCast(self.word_cursor));
+                            self.word_cursor += 1;
+                        }
                     },
-                    .allocated => |*iter| iter.next(),
+                    .reverse => {
+                        while (true) {
+                            if (self.pending != 0) {
+                                const word_bit: usize = @intCast(63 - @clz(self.pending));
+                                self.pending &= ~(@as(u64, 1) << @intCast(word_bit));
+                                const bit = self.word_base + word_bit;
+                                if (bit < self.set.bit_len) return bit;
+                            }
+                            if (self.word_cursor == 0) return null;
+                            self.word_cursor -= 1;
+                            self.word_base = self.word_cursor * 64;
+                            self.pending = self.set.words.get(@intCast(self.word_cursor));
+                        }
+                    },
                 };
             }
         };
     }
 
     fn iterator(self: *const ExactBitSet, comptime options: std.bit_set.IteratorOptions) Iterator(options) {
-        return switch (self.storage) {
-            .inline_word => |bits| .{ .inline_word = bits },
-            .allocated => |*bits| .{ .allocated = bits.iterator(options) },
+        return .{
+            .set = self,
+            .word_cursor = switch (options.direction) {
+                .forward => 0,
+                .reverse => std.math.divCeil(usize, self.bit_len, 64) catch unreachable,
+            },
         };
     }
 
     fn eql(self: *const ExactBitSet, other: ExactBitSet) bool {
         if (self.bit_len != other.bit_len) return false;
-        return switch (self.storage) {
-            .inline_word => |bits| bits == other.storage.inline_word,
-            .allocated => |bits| bits.eql(other.storage.allocated),
-        };
+        return self.words.eql(&other.words);
+    }
+
+    fn unionWord(_: void, lhs: u64, rhs: u64) u64 {
+        return lhs | rhs;
+    }
+
+    fn intersectWord(_: void, lhs: u64, rhs: u64) u64 {
+        return lhs & rhs;
     }
 };
 
@@ -1129,33 +1132,28 @@ const SolveTask = union(enum) {
 };
 
 fn cloneOwnedSetWith(allocator: Allocator, source: *const OwnedSet) ResourceError!OwnedSet {
-    const bits = try source.bits.clone(allocator);
-    const residual_masks = try allocator.dupe(u64, source.residual_masks);
-    return .{ .allocator = allocator, .domain = source.domain, .bits = bits, .residual_masks = residual_masks };
+    @constCast(source).unique = false;
+    var cloned = source.*;
+    cloned.entries.allocator = allocator;
+    cloned.unique = false;
+    return cloned;
 }
 
 fn assignOwnedSet(target: *OwnedSet, source: *const OwnedSet) void {
     target.requireSameDomain(source);
-    target.bits.unsetAll();
-    target.bits.setUnion(source.bits);
-    @memcpy(target.residual_masks, source.residual_masks);
+    @constCast(source).unique = false;
+    target.entries.assignShared(&source.entries);
+    target.unique = false;
 }
 
 /// Intersects `target` with `other` in place, reporting whether any bit
 /// dropped. Intersection never adds bits, so a changed population count is
 /// exactly a changed set.
-fn intersectOwnedSetChanged(target: *OwnedSet, other: *const OwnedSet) bool {
+fn intersectOwnedSetChanged(target: *OwnedSet, other: *const OwnedSet) ResourceError!bool {
     target.requireSameDomain(other);
-    var changed = false;
-    var before = target.bits.iterator(.{});
-    while (before.next()) |bit| {
-        if (!other.bits.isSet(bit) or (target.residual_masks[bit] & ~other.residual_masks[bit]) != 0) {
-            changed = true;
-            break;
-        }
-    }
-    target.intersect(other);
-    return changed;
+    target.unique = false;
+    @constCast(other).unique = false;
+    return target.entries.meetWith(&other.entries, {}, OwnedSet.meetEntry);
 }
 
 /// Sentinel outside the compact plan-index domain.
@@ -2196,7 +2194,7 @@ const Inserter = struct {
                 const summary = maybe_summary orelse continue;
                 if (summary.body_reachable) continue;
                 var params_only = try OwnedSet.init(self.solve_allocator, self.domain());
-                self.placeSolveJoinParamsInto(summary, &params_only);
+                try self.placeSolveJoinParamsInto(summary, &params_only);
                 if (params_only.eql(&summary.body_keep)) continue;
                 assignOwnedSet(&summary.body_keep, &params_only);
                 try self.refreshJumpPlans(summary);
@@ -2296,7 +2294,7 @@ const Inserter = struct {
                             .tag_payload_struct,
                             .list_reinterpret,
                             .nominal,
-                            => transfer.release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            => transfer.release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         }
                     }
                     // A partial field take consumes the container's stored
@@ -2317,7 +2315,7 @@ const Inserter = struct {
                                 // moves only this stored unit and leaves the
                                 // exact residual shell behind.
                                 transfer.retain_target = false;
-                                segment.owned.takeResidualField(take_root, take.field_mask);
+                                try segment.owned.takeResidualField(take_root, take.field_mask);
                             }
                         }
                     }
@@ -2329,12 +2327,12 @@ const Inserter = struct {
                 },
                 .init_uninitialized => |uninit| {
                     const step = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
-                    step.pre_release = if (self.transferForInit(&segment.owned, uninit.target)) self.releaseDecision(uninit.target) else null;
+                    step.pre_release = if (try self.transferForInit(&segment.owned, uninit.target)) self.releaseDecision(uninit.target) else null;
                     segment.cursor = uninit.next;
                 },
                 .assign_literal => |assign| {
                     const step = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
-                    step.pre_release = if (self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
+                    step.pre_release = if (try self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
                     const singles = [_]LIR.LocalId{assign.target};
                     try self.finishArcPlanStepDeaths(step, &segment.owned, &singles, null, assign.next, segment.ctx.loop_keep);
                     segment.cursor = assign.next;
@@ -2372,7 +2370,7 @@ const Inserter = struct {
                         if (assign.closure == assign.target) arcInvariant("owned erased call cannot consume and rebind the same local");
                         const reuse_source = assign.reuse_source orelse arcInvariant("owned erased call lacked its explicit reuse ownership source");
                         preserve_reuse_source = try self.groupUsedInPath(assign.next, reuse_source, segment.ctx.loop_keep);
-                        if (!preserve_reuse_source) _ = self.takeUnit(&segment.owned, reuse_source);
+                        if (!preserve_reuse_source) _ = try self.takeUnit(&segment.owned, reuse_source);
                     }
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     try step.pre_retain.appendSlice(self.solve_allocator, transfer.args.retain_args);
@@ -2405,7 +2403,7 @@ const Inserter = struct {
                         segment.ctx.loop_keep,
                         &step.pre_release_extra,
                     );
-                    step.pre_release = if (self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
+                    step.pre_release = if (try self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
                     self.death_scratch.clearRetainingCapacity();
                     const desc_local = assign.desc.localOrNull() orelse assign.target;
                     const residual_local = if (assign.tag_residual_for) |desc| desc.localOrNull() orelse assign.target else assign.target;
@@ -2416,7 +2414,7 @@ const Inserter = struct {
                 },
                 .assign_boxy_dict_ref => |assign| {
                     const step = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
-                    step.pre_release = if (self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
+                    step.pre_release = if (try self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
                     const dict_local = assign.dict.localOrNull() orelse assign.target;
                     const singles = [_]LIR.LocalId{ dict_local, assign.target };
                     try self.finishArcPlanStepDeaths(step, &segment.owned, &singles, null, assign.next, segment.ctx.loop_keep);
@@ -2429,7 +2427,7 @@ const Inserter = struct {
                     else
                         SingleTransfer{
                             .transfer_single = false,
-                            .release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            .release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         };
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     step.transfer_single = transfer.transfer_single;
@@ -2457,7 +2455,7 @@ const Inserter = struct {
                     else
                         SingleTransfer{
                             .transfer_single = false,
-                            .release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            .release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         };
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     step.transfer_single = transfer.transfer_single;
@@ -2476,7 +2474,7 @@ const Inserter = struct {
                     else
                         SingleTransfer{
                             .transfer_single = false,
-                            .release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            .release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         };
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     step.transfer_single = transfer.transfer_single;
@@ -2494,7 +2492,7 @@ const Inserter = struct {
                     else
                         SingleTransfer{
                             .transfer_single = false,
-                            .release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            .release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         };
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     step.transfer_single = transfer.transfer_single;
@@ -2511,7 +2509,7 @@ const Inserter = struct {
                         _ = try self.singleTransfer(assign.lhs, assign.next, assign.target, &segment.owned, segment.ctx.loop_keep);
                         _ = try self.singleTransfer(assign.rhs, assign.next, assign.target, &segment.owned, segment.ctx.loop_keep);
                     }
-                    step.pre_release = if (self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
+                    step.pre_release = if (try self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
                     const singles = [_]LIR.LocalId{ assign.lhs, assign.rhs, assign.target };
                     try self.finishArcPlanStepDeaths(step, &segment.owned, &singles, null, assign.next, segment.ctx.loop_keep);
                     segment.cursor = assign.next;
@@ -2523,7 +2521,7 @@ const Inserter = struct {
                     else
                         SingleTransfer{
                             .transfer_single = false,
-                            .release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            .release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         };
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     step.transfer_single = transfer.transfer_single;
@@ -2541,7 +2539,7 @@ const Inserter = struct {
                     else
                         SingleTransfer{
                             .transfer_single = false,
-                            .release_old_target = self.transferForFreshBind(&segment.owned, assign.target),
+                            .release_old_target = try self.transferForFreshBind(&segment.owned, assign.target),
                         };
                     step.pre_release = if (transfer.release_old_target) self.releaseDecision(assign.target) else null;
                     step.transfer_single = transfer.transfer_single;
@@ -2563,7 +2561,7 @@ const Inserter = struct {
                 .assign_call_dict => |assign| {
                     const step = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
                     step.transfer_mask = try self.spanTransferMask(assign.args, ~@as(u64, 0), assign.next, assign.target, &segment.owned, segment.ctx.loop_keep, .no);
-                    step.pre_release = if (self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
+                    step.pre_release = if (try self.transferForFreshBind(&segment.owned, assign.target)) self.releaseDecision(assign.target) else null;
                     self.death_scratch.clearRetainingCapacity();
                     const singles = [_]LIR.LocalId{assign.target};
                     try self.postStmtDeaths(&segment.owned, &singles, assign.args, assign.next, segment.ctx.loop_keep, self.death_scratch);
@@ -2676,7 +2674,7 @@ const Inserter = struct {
                 },
                 .decref_if_initialized => |rc| {
                     _ = try self.nextArcPlanStep(segment.plan_index, segment.cursor);
-                    self.noteEmittedRelease(&segment.owned, rc.value);
+                    try self.noteEmittedRelease(&segment.owned, rc.value);
                     segment.cursor = rc.next;
                 },
                 .incref, .decref, .free => arcInvariant("ARC summary solver received already-reference-counted LIR"),
@@ -2727,7 +2725,7 @@ const Inserter = struct {
                             const branch = GuardedList.at(branches, branch_index);
                             if (restoration) |restored| {
                                 var branch_owned = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
-                                restoreOutcomeResources(&branch_owned, restored.branch_resources[branch_index].items);
+                                try restoreOutcomeResources(&branch_owned, restored.branch_resources[branch_index].items);
                                 try self.pushSolveSegment(tasks, branch.body, &branch_owned, branch_ctx, child_plans.branch_plans[branch_index]);
                             } else {
                                 try self.pushSolveSegment(tasks, branch.body, &segment.owned, branch_ctx, child_plans.branch_plans[branch_index]);
@@ -2735,7 +2733,7 @@ const Inserter = struct {
                         }
                         if (restoration) |restored| {
                             var default_owned = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
-                            restoreOutcomeResources(&default_owned, restored.default_resources.items);
+                            try restoreOutcomeResources(&default_owned, restored.default_resources.items);
                             try self.pushSolveSegment(tasks, switch_stmt.default_branch, &default_owned, branch_ctx, child_plans.default_plan);
                         } else {
                             try self.pushSolveSegment(tasks, switch_stmt.default_branch, &segment.owned, branch_ctx, child_plans.default_plan);
@@ -2750,7 +2748,7 @@ const Inserter = struct {
                         const branch = GuardedList.at(branches, branch_index);
                         if (restoration) |restored| {
                             var branch_owned = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
-                            restoreOutcomeResources(&branch_owned, restored.branch_resources[branch_index].items);
+                            try restoreOutcomeResources(&branch_owned, restored.branch_resources[branch_index].items);
                             try self.pushSolveSegment(tasks, branch.body, &branch_owned, segment.ctx, child_plans.branch_plans[branch_index]);
                         } else {
                             try self.pushSolveSegment(tasks, branch.body, &segment.owned, segment.ctx, child_plans.branch_plans[branch_index]);
@@ -2758,7 +2756,7 @@ const Inserter = struct {
                     }
                     if (restoration) |restored| {
                         var default_owned = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
-                        restoreOutcomeResources(&default_owned, restored.default_resources.items);
+                        try restoreOutcomeResources(&default_owned, restored.default_resources.items);
                         try self.pushSolveSegment(tasks, switch_stmt.default_branch, &default_owned, segment.ctx, child_plans.default_plan);
                     } else {
                         try self.pushSolveSegment(tasks, switch_stmt.default_branch, &segment.owned, segment.ctx, child_plans.default_plan);
@@ -2774,12 +2772,12 @@ const Inserter = struct {
                     );
                     const child_plans = terminal.initialized_payload_switch;
                     var initialized_owned = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
-                    self.placeUnit(&initialized_owned, switch_stmt.payload);
+                    try self.placeUnit(&initialized_owned, switch_stmt.payload);
 
                     var uninitialized_owned = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
                     // The branch proves the cell uninitialized: the payload
                     // binding ends with nothing to release.
-                    _ = self.transferForInit(&uninitialized_owned, switch_stmt.payload);
+                    _ = try self.transferForInit(&uninitialized_owned, switch_stmt.payload);
 
                     try self.pushSolveSegment(tasks, switch_stmt.initialized_branch, &initialized_owned, segment.ctx, child_plans.initialized_plan);
                     try self.pushSolveSegment(tasks, switch_stmt.uninitialized_branch, &uninitialized_owned, segment.ctx, child_plans.uninitialized_plan);
@@ -2794,7 +2792,7 @@ const Inserter = struct {
                         const step = GuardedList.at(steps, step_index);
                         switch (step.capture) {
                             .discard => {},
-                            .view => |local| self.placeUnit(&match_owned, local),
+                            .view => |local| try self.placeUnit(&match_owned, local),
                         }
                     }
                     try self.pushSolveSegment(tasks, str_match.on_match, &match_owned, segment.ctx, child_plans.match_plan);
@@ -2813,7 +2811,7 @@ const Inserter = struct {
                             const step = GuardedList.at(steps, step_index);
                             switch (step.capture) {
                                 .discard => {},
-                                .view => |local| self.placeUnit(&match_owned, local),
+                                .view => |local| try self.placeUnit(&match_owned, local),
                             }
                         }
                         try self.pushSolveSegment(tasks, arm.on_match, &match_owned, segment.ctx, child_plans.match_plans[arm_index]);
@@ -2835,7 +2833,7 @@ const Inserter = struct {
                 },
                 .crash => |crash_stmt| {
                     const retain_value = if (crash_stmt.msg.localId()) |message|
-                        if (self.consumeAtTerminal(&segment.owned, message)) null else message
+                        if (try self.consumeAtTerminal(&segment.owned, message)) null else message
                     else
                         null;
                     try self.setArcPlanTerminal(segment.plan_index, segment.cursor, &segment.owned, null, retain_value);
@@ -2853,7 +2851,7 @@ const Inserter = struct {
                     var retain_value: ?LIR.LocalId = null;
                     if (self.current_sig.ret_mode == .borrowed) {
                         // No ownership unit transfers to the caller.
-                    } else if (!self.consumeAtTerminal(&segment.owned, ret_stmt.value)) {
+                    } else if (!try self.consumeAtTerminal(&segment.owned, ret_stmt.value)) {
                         retain_value = ret_stmt.value;
                     }
                     const restitution_mask = if (self.current_sig.outcomes.isEmpty())
@@ -2864,13 +2862,13 @@ const Inserter = struct {
                         try self.setArcPlanTerminal(segment.plan_index, segment.cursor, &segment.owned, null, retain_value);
                     } else {
                         var keep = try OwnedSet.init(self.solve_allocator, self.domain());
-                        self.addRestitutionKeep(segment.cursor, &segment.owned, &keep);
+                        try self.addRestitutionKeep(segment.cursor, &segment.owned, &keep);
                         try self.setArcPlanTerminal(segment.plan_index, segment.cursor, &segment.owned, &keep, retain_value);
                     }
                     return;
                 },
                 .expect_err => |expect_err_stmt| {
-                    const retain_value = if (self.consumeAtTerminal(&segment.owned, expect_err_stmt.message))
+                    const retain_value = if (try self.consumeAtTerminal(&segment.owned, expect_err_stmt.message))
                         null
                     else
                         expect_err_stmt.message;
@@ -2987,14 +2985,16 @@ const Inserter = struct {
     fn collectReleaseDifferenceInto(self: *Inserter, releases: *std.ArrayList(ReleaseDecision), owned: *const OwnedSet, keep: *const OwnedSet) ResourceError!void {
         owned.requireSameDomain(keep);
         releases.clearRetainingCapacity();
-        var iter = owned.bits.iterator(.{ .direction = .reverse });
+        var iter = owned.iterator(.{ .direction = .reverse });
         while (iter.next()) |bit| {
             const local = owned.domain.resourceLocalAt(bit);
-            if (!keep.bits.isSet(bit)) {
+            const owned_entry = owned.entryAt(bit);
+            const keep_entry = keep.entryAt(bit);
+            if (!keep_entry.present) {
                 try releases.append(self.solve_allocator, self.releaseDecisionFrom(owned, local));
                 continue;
             }
-            const residual_difference = owned.residual_masks[bit] & ~keep.residual_masks[bit];
+            const residual_difference = owned_entry.residual_mask & ~keep_entry.residual_mask;
             if (residual_difference != 0) {
                 try releases.append(self.solve_allocator, .{ .residual = .{
                     .value = local,
@@ -3006,7 +3006,7 @@ const Inserter = struct {
 
     fn collectReleaseAllInto(self: *Inserter, releases: *std.ArrayList(ReleaseDecision), owned: *const OwnedSet) ResourceError!void {
         releases.clearRetainingCapacity();
-        var iter = owned.bits.iterator(.{ .direction = .reverse });
+        var iter = owned.iterator(.{ .direction = .reverse });
         while (iter.next()) |bit| {
             const local = owned.domain.resourceLocalAt(bit);
             try releases.append(self.solve_allocator, self.releaseDecisionFrom(owned, local));
@@ -3023,16 +3023,15 @@ const Inserter = struct {
         releases: *std.ArrayList(ReleaseDecision),
     ) ResourceError!void {
         const result_bit = owned.domain.resourceBitOf(result);
-        const keep_result = if (result_bit) |bit| owned.bits.isSet(bit) else false;
-        var iter = owned.bits.iterator(.{ .direction = .reverse });
+        const result_entry: OwnedEntry = if (result_bit) |bit| owned.entryAt(bit) else .{};
+        var iter = owned.iterator(.{ .direction = .reverse });
         while (iter.next()) |bit| {
             if (result_bit != null and bit == result_bit.?) continue;
             const local = owned.domain.resourceLocalAt(bit);
             try releases.append(self.emission_allocator, self.releaseDecisionFrom(owned, local));
-            owned.residual_masks[bit] = 0;
         }
-        owned.bits.unsetAll();
-        if (keep_result) owned.bits.set(result_bit.?);
+        owned.clear();
+        if (result_entry.present) try owned.putEntry(@intCast(result_bit.?), result_entry);
     }
 
     fn addRestitutionKeep(
@@ -3040,7 +3039,7 @@ const Inserter = struct {
         stmt: LIR.CFStmtId,
         owned: *const OwnedSet,
         keep: *OwnedSet,
-    ) void {
+    ) ResourceError!void {
         if (self.current_sig.outcomes.isEmpty()) return;
         const mask = self.solution.restitutionParamsAt(stmt);
         if (mask == 0) return;
@@ -3055,17 +3054,17 @@ const Inserter = struct {
             if (!owned.contains(param)) {
                 arcInvariant("ARC restitution boundary did not carry its exact entry parameter unit");
             }
-            keep.copyResourceFrom(owned, param);
+            try keep.copyResourceFrom(owned, param);
         }
     }
 
-    fn restoreOutcomeResources(owned: *OwnedSet, resources: []const RestoredResource) void {
+    fn restoreOutcomeResources(owned: *OwnedSet, resources: []const RestoredResource) ResourceError!void {
         for (resources) |resource| switch (resource) {
             .unit => |unit| {
                 if (owned.contains(unit)) arcInvariant("ARC outcome restoration duplicated a live ownership unit");
-                owned.set(unit);
+                try owned.set(unit);
             },
-            .field => |field| owned.restoreResidualField(field.root, field.field_mask),
+            .field => |field| try owned.restoreResidualField(field.root, field.field_mask),
         };
     }
 
@@ -3073,7 +3072,7 @@ const Inserter = struct {
         self: *Inserter,
         reads: *ExactBitSet,
         stmt: LIR.CFStmtId,
-    ) void {
+    ) ResourceError!void {
         if (self.current_sig.outcomes.isEmpty()) return;
         const mask = self.solution.restitutionParamsAt(stmt);
         if (mask == 0) return;
@@ -3081,7 +3080,7 @@ const Inserter = struct {
         for (0..GuardedList.borrowLen(params)) |position| {
             const bit = arc_sig.paramBit(position) orelse break;
             if ((mask & bit) == 0) continue;
-            self.noteLivenessUseLocal(reads, GuardedList.at(params, position));
+            try self.noteLivenessUseLocal(reads, GuardedList.at(params, position));
         }
     }
 
@@ -3093,7 +3092,7 @@ const Inserter = struct {
         body_keep: *const OwnedSet,
     ) ResourceError!void {
         var keep = try cloneOwnedSetWith(self.solve_allocator, body_keep);
-        self.addRestitutionKeep(stmt, owned, &keep);
+        try self.addRestitutionKeep(stmt, owned, &keep);
         try self.collectReleaseDifferenceInto(releases, owned, &keep);
     }
 
@@ -3652,10 +3651,10 @@ const Inserter = struct {
     fn seedSolveBodyKeep(self: *Inserter, summary: *JoinSummary) ResourceError!void {
         const reads = try self.computeReadsBeforeRebind(summary.body, null, 0);
         for (self.domain().refcounted_locals) |local| {
-            if (self.groupUsedFromTable(reads, local)) summary.body_keep.set(local);
+            if (self.groupUsedFromTable(reads, local)) try summary.body_keep.set(local);
         }
-        self.placeJoinRetainedInto(summary, null, &summary.body_keep);
-        self.placeSolveJoinParamsInto(summary, &summary.body_keep);
+        try self.placeJoinRetainedInto(summary, null, &summary.body_keep);
+        try self.placeSolveJoinParamsInto(summary, &summary.body_keep);
     }
 
     /// Add the producer-declared ownership environment of a shared body. When
@@ -3666,14 +3665,14 @@ const Inserter = struct {
         summary: *const JoinSummary,
         source: ?*const OwnedSet,
         keep: *OwnedSet,
-    ) void {
+    ) ResourceError!void {
         const retained = self.store.getLocalSpan(summary.retained);
         for (0..GuardedList.borrowLen(retained)) |index| {
             const local = GuardedList.at(retained, index);
             if (source) |owned| {
-                if (owned.contains(local)) keep.copyResourceFrom(owned, local);
+                if (owned.contains(local)) try keep.copyResourceFrom(owned, local);
             } else {
-                self.placeUnit(keep, local);
+                try self.placeUnit(keep, local);
             }
         }
     }
@@ -3690,18 +3689,18 @@ const Inserter = struct {
     /// param set and narrowed by the lattice's exact resource intersection,
     /// so filtering by it keeps this placement monotone and carries residual
     /// field masks through.
-    fn placeSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) void {
+    fn placeSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) ResourceError!void {
         if (!summary.back_edge_seen) {
-            self.placeAllSolveJoinParamsInto(summary, keep);
+            try self.placeAllSolveJoinParamsInto(summary, keep);
             return;
         }
         const params = self.store.getLocalSpan(summary.params);
         for (0..GuardedList.borrowLen(params)) |index| {
-            placeSurvivingParam(keep, &summary.back_edge_params, GuardedList.at(params, index));
+            try placeSurvivingParam(keep, &summary.back_edge_params, GuardedList.at(params, index));
         }
         const maybe_params = self.store.getLocalSpan(summary.maybe_uninitialized_params);
         for (0..GuardedList.borrowLen(maybe_params)) |index| {
-            placeSurvivingParam(keep, &summary.back_edge_params, GuardedList.at(maybe_params, index));
+            try placeSurvivingParam(keep, &summary.back_edge_params, GuardedList.at(maybe_params, index));
         }
     }
 
@@ -3709,20 +3708,20 @@ const Inserter = struct {
     /// presence plus its surviving residual field mask. Placing full
     /// ownership here would re-authorize releasing aggregate fields a back
     /// edge already took, so the mask travels with the bit.
-    fn placeSurvivingParam(keep: *OwnedSet, meet: *const OwnedSet, local: LIR.LocalId) void {
+    fn placeSurvivingParam(keep: *OwnedSet, meet: *const OwnedSet, local: LIR.LocalId) ResourceError!void {
         if (!meet.contains(local)) return;
-        keep.setWithResidual(local, meet.residualMask(local));
+        try keep.setWithResidual(local, meet.residualMask(local));
     }
 
     /// Unfiltered param placement: the seed for the back-edge meet.
-    fn placeAllSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) void {
+    fn placeAllSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) ResourceError!void {
         const params = self.store.getLocalSpan(summary.params);
         for (0..GuardedList.borrowLen(params)) |index| {
-            self.placeUnit(keep, GuardedList.at(params, index));
+            try self.placeUnit(keep, GuardedList.at(params, index));
         }
         const maybe_params = self.store.getLocalSpan(summary.maybe_uninitialized_params);
         for (0..GuardedList.borrowLen(maybe_params)) |index| {
-            self.placeConditionalUnit(keep, GuardedList.at(maybe_params, index));
+            try self.placeConditionalUnit(keep, GuardedList.at(maybe_params, index));
         }
     }
 
@@ -3732,17 +3731,17 @@ const Inserter = struct {
         self: *Inserter,
         summary: *JoinSummary,
         owned: *const OwnedSet,
-    ) bool {
+    ) ResourceError!bool {
         var changed = false;
         if (!summary.back_edge_seen) {
             summary.back_edge_seen = true;
-            self.placeAllSolveJoinParamsInto(summary, &summary.back_edge_params);
+            try self.placeAllSolveJoinParamsInto(summary, &summary.back_edge_params);
             changed = true;
         }
         // The same exact resource meet the rest of the lattice uses: a param
         // survives only with the residual field places every back edge still
         // proves, not merely its presence bit.
-        if (intersectOwnedSetChanged(&summary.back_edge_params, owned)) changed = true;
+        if (try intersectOwnedSetChanged(&summary.back_edge_params, owned)) changed = true;
         return changed;
     }
 
@@ -3761,14 +3760,14 @@ const Inserter = struct {
         var merged = try OwnedSet.init(self.solve_allocator, self.domain());
         assignOwnedSet(&merged, &summary.jump_common);
         var retained = try OwnedSet.init(self.solve_allocator, self.domain());
-        self.placeJoinRetainedInto(summary, &merged, &retained);
+        try self.placeJoinRetainedInto(summary, &merged, &retained);
         const reads = try self.computeReadsBeforeRebind(summary.body, null, 0);
-        var owned_iter = merged.bits.iterator(.{});
+        var owned_iter = merged.iterator(.{});
         while (owned_iter.next()) |index| {
             const local = merged.domain.resourceLocalAt(index);
-            if (!self.groupUsedFromTable(reads, local) and !retained.contains(local)) merged.unset(local);
+            if (!self.groupUsedFromTable(reads, local) and !retained.contains(local)) try merged.unset(local);
         }
-        self.placeSolveJoinParamsInto(summary, &merged);
+        try self.placeSolveJoinParamsInto(summary, &merged);
         if (merged.eql(&summary.body_keep)) return .{ .changed = false, .purged = false };
         assignOwnedSet(&summary.body_keep, &merged);
         try self.refreshJumpPlans(summary);
@@ -3781,11 +3780,11 @@ const Inserter = struct {
     fn recomputeSolveEntryKeep(self: *Inserter, summary: *JoinSummary) ResourceError!bool {
         var keep = try OwnedSet.init(self.solve_allocator, self.domain());
         const remainder_reads = try self.computeReadsBeforeRebind(summary.remainder, null, 0);
-        var entry_iter = summary.entry_state.bits.iterator(.{});
+        var entry_iter = summary.entry_state.iterator(.{});
         while (entry_iter.next()) |index| {
             const local = summary.entry_state.domain.resourceLocalAt(index);
             if (self.groupUsedFromTable(remainder_reads, local) or summary.body_keep.contains(local)) {
-                keep.copyResourceFrom(&summary.entry_state, local);
+                try keep.copyResourceFrom(&summary.entry_state, local);
             }
         }
         if (keep.eql(&summary.entry_keep)) return false;
@@ -3858,7 +3857,7 @@ const Inserter = struct {
             try self.activateLatentSwitchStopPlans(summary);
             changed = true;
         } else {
-            changed = intersectOwnedSetChanged(&summary.common, owned);
+            changed = try intersectOwnedSetChanged(&summary.common, owned);
         }
         if (changed and !summary.resume_queued) {
             try self.refreshSwitchStopPlans(summary);
@@ -3923,7 +3922,7 @@ const Inserter = struct {
             arcInvariant("ARC solver saw one join id with conflicting metadata");
         }
         try self.updateJoinArrivalPlan(summary, segment.plan_index, segment.cursor, &segment.owned);
-        if (intersectOwnedSetChanged(&summary.entry_state, &segment.owned)) {
+        if (try intersectOwnedSetChanged(&summary.entry_state, &segment.owned)) {
             try self.scheduleSolveJoinProcess(tasks, summary);
         }
     }
@@ -3949,7 +3948,7 @@ const Inserter = struct {
                 // the keep—but it does constrain which params the body may
                 // treat as freshly owned, because a param it leaves alone
                 // still holds the value the body already released.
-                if (self.absorbBackEdgeParams(summary, &segment.owned)) {
+                if (try self.absorbBackEdgeParams(summary, &segment.owned)) {
                     try self.applySolveBodyKeepUpdate(tasks, summary);
                 }
                 return;
@@ -3963,7 +3962,7 @@ const Inserter = struct {
             summary.jump_states[site_index] = try cloneOwnedSetWith(self.solve_allocator, &segment.owned);
             changed = true;
         } else {
-            changed = intersectOwnedSetChanged(&summary.jump_states[site_index].?, &segment.owned);
+            changed = try intersectOwnedSetChanged(&summary.jump_states[site_index].?, &segment.owned);
         }
         const site = &summary.jump_states[site_index].?;
         const first_reach = !summary.body_reachable;
@@ -3973,7 +3972,7 @@ const Inserter = struct {
             try self.refreshJoinArrivalPlans(summary);
             assignOwnedSet(&summary.jump_common, site);
             break :blk true;
-        } else intersectOwnedSetChanged(&summary.jump_common, site);
+        } else try intersectOwnedSetChanged(&summary.jump_common, site);
         if (!common_changed) return;
         try self.applySolveBodyKeepUpdate(tasks, summary);
         if (first_reach) try self.scheduleSolveBodyWalk(tasks, summary);
@@ -4058,33 +4057,33 @@ const Inserter = struct {
     }
 
     /// Test-and-clear by unit key; returns whether a unit moved.
-    fn takeUnit(self: *const Inserter, owned: *OwnedSet, local: LIR.LocalId) bool {
+    fn takeUnit(self: *const Inserter, owned: *OwnedSet, local: LIR.LocalId) ResourceError!bool {
         const unit = self.unitOf(local);
         if (!owned.contains(unit)) return false;
-        owned.unset(unit);
+        try owned.unset(unit);
         return true;
     }
 
-    fn unsetOwnedUnit(self: *const Inserter, owned: *OwnedSet, local: LIR.LocalId) void {
-        owned.unset(self.unitOf(local));
+    fn unsetOwnedUnit(self: *const Inserter, owned: *OwnedSet, local: LIR.LocalId) ResourceError!void {
+        try owned.unset(self.unitOf(local));
     }
 
     /// Places a fresh ownership unit on the name being bound. Borrowed
     /// bindings carry no unit: the lender's liveness group keeps the value
     /// alive across every use.
-    fn placeUnit(self: *Inserter, owned: *OwnedSet, local: LIR.LocalId) void {
+    fn placeUnit(self: *Inserter, owned: *OwnedSet, local: LIR.LocalId) ResourceError!void {
         if (!self.localContainsRefcounted(local)) return;
         if (self.isBindingBorrowed(local)) return;
-        owned.set(local);
+        try owned.set(local);
     }
 
     /// Places a conditionally-present unit (maybe-initialized join payload
     /// cells). The overwrite of such a cell is still the lifetime end of the
     /// previous payload, so the unit is placed even on a solved-borrowed
     /// binding.
-    fn placeConditionalUnit(self: *Inserter, owned: *OwnedSet, local: LIR.LocalId) void {
+    fn placeConditionalUnit(self: *Inserter, owned: *OwnedSet, local: LIR.LocalId) ResourceError!void {
         if (!self.localContainsRefcounted(local)) return;
-        owned.set(local);
+        try owned.set(local);
     }
 
     /// Places the unit a call result carries: an owned return always hands
@@ -4095,12 +4094,12 @@ const Inserter = struct {
         owned: *OwnedSet,
         local: LIR.LocalId,
         ret_mode: arc_sig.Mode,
-    ) void {
+    ) ResourceError!void {
         if (!self.localContainsRefcounted(local)) return;
         if (ret_mode == .owned) {
-            owned.set(local);
+            try owned.set(local);
         } else if (!self.isBindingBorrowed(local)) {
-            owned.set(local);
+            try owned.set(local);
         }
     }
 
@@ -4109,16 +4108,16 @@ const Inserter = struct {
     /// id on purpose: rebinding a name kills only that name's own binding,
     /// never the unit of a value the name merely borrowed (audited for
     /// issue 9703's keying class—see the layer comment above).
-    fn takeRebindTarget(_: *const Inserter, owned: *OwnedSet, target: LIR.LocalId) bool {
+    fn takeRebindTarget(_: *const Inserter, owned: *OwnedSet, target: LIR.LocalId) ResourceError!bool {
         if (!owned.contains(target)) return false;
-        owned.unset(target);
+        try owned.unset(target);
         return true;
     }
 
     /// Replays an already-emitted decref/free into the state during a
     /// boundary re-walk. Emitted RC statements name unit locals directly.
-    fn noteEmittedRelease(_: *const Inserter, owned: *OwnedSet, value: LIR.LocalId) void {
-        owned.unset(value);
+    fn noteEmittedRelease(_: *const Inserter, owned: *OwnedSet, value: LIR.LocalId) ResourceError!void {
+        try owned.unset(value);
     }
 
     const AliasBindTransfer = struct {
@@ -4140,18 +4139,18 @@ const Inserter = struct {
         loop_keep: ?LoopKeep,
     ) ResourceError!AliasBindTransfer {
         const move_value = try self.canMoveAliasBindValue(owned, source, target, next, loop_keep);
-        const release_old_target = self.takeRebindTarget(owned, target);
-        if (move_value) _ = self.takeUnit(owned, source);
-        self.placeUnit(owned, target);
+        const release_old_target = try self.takeRebindTarget(owned, target);
+        if (move_value) _ = try self.takeUnit(owned, source);
+        try self.placeUnit(owned, target);
         return .{ .retain_target = !move_value, .release_old_target = release_old_target };
     }
 
     /// A binding whose value is freshly produced by the statement itself
     /// (literals, payload reads): the new binding owns one unit; the old
     /// binding, if any, dies here.
-    fn transferForFreshBind(self: *Inserter, owned: *OwnedSet, target: LIR.LocalId) bool {
-        const release_old_target = self.takeRebindTarget(owned, target);
-        self.placeUnit(owned, target);
+    fn transferForFreshBind(self: *Inserter, owned: *OwnedSet, target: LIR.LocalId) ResourceError!bool {
+        const release_old_target = try self.takeRebindTarget(owned, target);
+        try self.placeUnit(owned, target);
         return release_old_target;
     }
 
@@ -4166,7 +4165,7 @@ const Inserter = struct {
         root: LIR.LocalId,
         next: LIR.CFStmtId,
     ) ResourceError!AliasBindTransfer {
-        const release_old_target = self.takeRebindTarget(owned, target);
+        const release_old_target = try self.takeRebindTarget(owned, target);
         const unit = self.unitOf(root);
         // The path query follows loop edges itself and stops at a rebind of
         // this exact place definition. A loop keep-set cannot make that
@@ -4180,8 +4179,8 @@ const Inserter = struct {
             null;
         const move_root = has_unit and (!root_used or restitution != null);
         if (restitution) |claim| try self.setOutcomeRestoration(claim, move_root);
-        if (move_root) owned.unset(unit);
-        self.placeUnit(owned, target);
+        if (move_root) try owned.unset(unit);
+        try self.placeUnit(owned, target);
         return .{
             .retain_target = !move_root,
             .release_old_target = release_old_target,
@@ -4278,7 +4277,7 @@ const Inserter = struct {
 
     /// `init_uninitialized`: the target's previous binding dies and nothing
     /// replaces it.
-    fn transferForInit(self: *Inserter, owned: *OwnedSet, target: LIR.LocalId) bool {
+    fn transferForInit(self: *Inserter, owned: *OwnedSet, target: LIR.LocalId) ResourceError!bool {
         return self.takeRebindTarget(owned, target);
     }
 
@@ -4297,11 +4296,11 @@ const Inserter = struct {
         if (target == value) return .{ .retain_target = false, .release_old_target = false };
         const move_value = try self.canMoveAliasBindValue(owned, value, target, next, loop_keep);
         const release_old_target = switch (mode) {
-            .replace_existing, .initialize_join_param => self.takeRebindTarget(owned, target),
+            .replace_existing, .initialize_join_param => try self.takeRebindTarget(owned, target),
             .initialize_join_result => false,
         };
-        if (move_value) _ = self.takeUnit(owned, value);
-        self.placeUnit(owned, target);
+        if (move_value) _ = try self.takeUnit(owned, value);
+        try self.placeUnit(owned, target);
         return .{ .retain_target = !move_value, .release_old_target = release_old_target };
     }
 
@@ -4338,8 +4337,8 @@ const Inserter = struct {
         const release_old_target = if (target_feeds_call)
             false
         else
-            self.takeRebindTarget(owned, target);
-        self.placeCallResultUnit(owned, target, arg_ownership.demanded.ret_mode);
+            try self.takeRebindTarget(owned, target);
+        try self.placeCallResultUnit(owned, target, arg_ownership.demanded.ret_mode);
         const retain_call_result = arg_ownership.demanded.ret_mode == .borrowed and
             self.localContainsRefcounted(target) and
             !self.isBindingBorrowed(target);
@@ -4367,8 +4366,8 @@ const Inserter = struct {
         transfer_positions: ?*std.ArrayList(u32),
     ) ResourceError!AggregateTransfer {
         try self.spanTransferPositions(operands, next, target, owned, loop_keep, transfer_positions);
-        const release_old_target = self.takeRebindTarget(owned, target);
-        self.placeUnit(owned, target);
+        const release_old_target = try self.takeRebindTarget(owned, target);
+        try self.placeUnit(owned, target);
         return .{ .release_old_target = release_old_target };
     }
 
@@ -4392,8 +4391,8 @@ const Inserter = struct {
         if (payload) |operand| {
             transfer_single = try self.singleTransfer(operand, next, target, owned, loop_keep);
         }
-        const release_old_target = self.takeRebindTarget(owned, target);
-        self.placeUnit(owned, target);
+        const release_old_target = try self.takeRebindTarget(owned, target);
+        try self.placeUnit(owned, target);
         return .{ .transfer_single = transfer_single, .release_old_target = release_old_target };
     }
 
@@ -4419,7 +4418,7 @@ const Inserter = struct {
             if (assign.capture) |capture| {
                 if (self.solution.leaderOf(capture) == self.solution.leaderOf(reuse)) reuse_unique = false;
             }
-            if (!preserve_reuse) _ = self.takeUnit(owned, reuse);
+            if (!preserve_reuse) _ = try self.takeUnit(owned, reuse);
         }
 
         const transfer = try self.transferForSingle(owned, assign.capture, assign.target, assign.next, loop_keep);
@@ -4492,18 +4491,18 @@ const Inserter = struct {
         const target_consumed = self.maskedArgsContainLocal(args, rc_effect.consume_args, target);
         var release_old_target = false;
         if (target_consumed) {
-            _ = self.takeUnit(owned, target);
+            _ = try self.takeUnit(owned, target);
         } else {
-            release_old_target = self.takeRebindTarget(owned, target);
+            release_old_target = try self.takeRebindTarget(owned, target);
         }
         if (rc_effect.consume_args != 0) {
-            self.unsetMaskedArgsExcept(owned, args, rc_effect.consume_args & ~preserve_consumed_args, target);
+            try self.unsetMaskedArgsExcept(owned, args, rc_effect.consume_args & ~preserve_consumed_args, target);
         }
         var transfer_mask: u64 = 0;
         if (rc_effect.retain_args != 0) {
             transfer_mask = try self.spanTransferMask(args, rc_effect.retain_args, next, target, owned, loop_keep, .yes);
         }
-        self.placeUnit(owned, target);
+        try self.placeUnit(owned, target);
         return .{
             .preserve_consumed_args = preserve_consumed_args,
             .transfer_mask = transfer_mask,
@@ -4515,9 +4514,9 @@ const Inserter = struct {
     /// Terminal consumption (`ret` with an owned return mode, `expect_err`):
     /// returns true when the local's own unit moves out with the terminal,
     /// so no retain is needed.
-    fn consumeAtTerminal(self: *Inserter, owned: *OwnedSet, local: LIR.LocalId) bool {
+    fn consumeAtTerminal(self: *Inserter, owned: *OwnedSet, local: LIR.LocalId) ResourceError!bool {
         if (!self.ownsUnit(owned, local)) return false;
-        _ = self.takeUnit(owned, local);
+        _ = try self.takeUnit(owned, local);
         return true;
     }
 
@@ -4533,7 +4532,7 @@ const Inserter = struct {
             if (!owned.contains(local)) continue;
             if (!self.localUsesDescriptorLocal(local, desc_local)) continue;
             if (try self.valueUsedInPath(next, local, loop_keep)) continue;
-            if (!self.takeRebindTarget(owned, local)) arcInvariant("ARC descriptor invalidation lost an owned local");
+            if (!try self.takeRebindTarget(owned, local)) arcInvariant("ARC descriptor invalidation lost an owned local");
             try releases.append(self.solve_allocator, self.releaseDecision(local));
         }
     }
@@ -4579,7 +4578,7 @@ const Inserter = struct {
             if (!self.localContainsRefcounted(local)) continue;
             if (!self.ownsUnit(owned, local)) continue;
             if (try self.groupUsedInPath(next, local, loop_keep)) continue;
-            self.unsetOwnedUnit(owned, local);
+            try self.unsetOwnedUnit(owned, local);
             transfer |= bit;
         }
         return transfer;
@@ -4607,7 +4606,7 @@ const Inserter = struct {
             if (!self.localContainsRefcounted(local)) continue;
             if (!self.ownsUnit(owned, local)) continue;
             if (try self.groupUsedInPath(next, local, loop_keep)) continue;
-            self.unsetOwnedUnit(owned, local);
+            try self.unsetOwnedUnit(owned, local);
             if (transferred_positions) |positions| {
                 try positions.append(self.emission_allocator, @intCast(i));
             }
@@ -4629,7 +4628,7 @@ const Inserter = struct {
         if (!self.localContainsRefcounted(local)) return false;
         if (!self.ownsUnit(owned, local)) return false;
         if (try self.groupUsedInPath(next, local, loop_keep)) return false;
-        self.unsetOwnedUnit(owned, local);
+        try self.unsetOwnedUnit(owned, local);
         return true;
     }
 
@@ -4697,7 +4696,7 @@ const Inserter = struct {
         if (collected) |list| {
             try list.append(self.emission_allocator, self.releaseDecisionFrom(owned, owner));
         }
-        owned.unset(owner);
+        try owned.unset(owner);
     }
 
     fn noteCallResultDeathIfUnused(
@@ -4730,7 +4729,7 @@ const Inserter = struct {
         if (collected) |list| {
             try list.append(self.emission_allocator, self.releaseDecisionFrom(owned, local));
         }
-        owned.unset(local);
+        try owned.unset(local);
     }
 
     fn retainMaskedArgs(self: *Inserter, span: LIR.LocalSpan, mask: u64, next: LIR.CFStmtId) ResourceError!LIR.CFStmtId {
@@ -5554,7 +5553,7 @@ const Inserter = struct {
                     demanded.unique_params |= bit;
                 }
                 if (can_transfer) {
-                    owned.unset(owner);
+                    try owned.unset(owner);
                 } else {
                     // The original carrier cannot move (for example, two
                     // positions name it). Manufacture the callee's unit, then
@@ -5625,7 +5624,7 @@ const Inserter = struct {
                 {
                     demanded.unique_params |= arc_sig.paramBit(position).?;
                 }
-                owned.unset(owner);
+                try owned.unset(owner);
             } else {
                 try self.retain_arg_scratch.append(self.emission_allocator, local);
             }
@@ -5717,14 +5716,14 @@ const Inserter = struct {
         span: LIR.LocalSpan,
         mask: u64,
         except: LIR.LocalId,
-    ) void {
+    ) ResourceError!void {
         if (mask == 0) return;
         const locals = self.store.getLocalSpan(span);
         for (0..GuardedList.borrowLen(locals)) |i| {
             const local = GuardedList.at(locals, i);
             if (i >= 64) break;
             if ((mask & argMaskBit(i)) != 0 and local != except) {
-                self.unsetOwnedUnit(owned, local);
+                try self.unsetOwnedUnit(owned, local);
             }
         }
     }
@@ -5848,8 +5847,8 @@ const Inserter = struct {
         return self.domain().resourceBitOf(local);
     }
 
-    fn noteReadBeforeRebindLocal(self: *const Inserter, reads: *ExactBitSet, local: LIR.LocalId) void {
-        if (self.rawLivenessBitOf(local)) |bit| reads.set(bit);
+    fn noteReadBeforeRebindLocal(self: *const Inserter, reads: *ExactBitSet, local: LIR.LocalId) ResourceError!void {
+        if (self.rawLivenessBitOf(local)) |bit| try reads.set(bit);
     }
 
     /// Group-bit position of a local's multi-member borrow group, if any.
@@ -5867,34 +5866,34 @@ const Inserter = struct {
     /// group bit, and its value-use bit. Reference-count statements record
     /// only the raw bit through `noteReadBeforeRebindLocal`: they must not
     /// extend group or call-result liveness.
-    fn noteLivenessUseLocal(self: *const Inserter, reads: *ExactBitSet, local: LIR.LocalId) void {
-        if (self.rawLivenessBitOf(local)) |bit| reads.set(bit);
-        if (self.groupBitOf(local)) |bit| reads.set(bit);
-        if (self.valueUseBitOf(local)) |bit| reads.set(bit);
+    fn noteLivenessUseLocal(self: *const Inserter, reads: *ExactBitSet, local: LIR.LocalId) ResourceError!void {
+        if (self.rawLivenessBitOf(local)) |bit| try reads.set(bit);
+        if (self.groupBitOf(local)) |bit| try reads.set(bit);
+        if (self.valueUseBitOf(local)) |bit| try reads.set(bit);
     }
 
-    fn noteLivenessUseSpan(self: *const Inserter, reads: *ExactBitSet, span: LIR.LocalSpan) void {
+    fn noteLivenessUseSpan(self: *const Inserter, reads: *ExactBitSet, span: LIR.LocalSpan) ResourceError!void {
         const locals = self.store.getLocalSpan(span);
         for (0..GuardedList.borrowLen(locals)) |index| {
             const local = GuardedList.at(locals, index);
-            self.noteLivenessUseLocal(reads, local);
+            try self.noteLivenessUseLocal(reads, local);
         }
     }
 
-    fn noteLivenessUseRefOp(self: *const Inserter, reads: *ExactBitSet, op: LIR.RefOp) void {
-        self.noteLivenessUseLocal(reads, refOpSource(op));
+    fn noteLivenessUseRefOp(self: *const Inserter, reads: *ExactBitSet, op: LIR.RefOp) ResourceError!void {
+        try self.noteLivenessUseLocal(reads, refOpSource(op));
     }
 
     /// Records the loop keep-set as reads at a `loop_continue`/`loop_break`:
     /// kept units, groups with any kept member, and kept call-result locals
     /// all stay live across the loop edge.
-    fn noteLivenessLoopKeep(self: *const Inserter, reads: *ExactBitSet, keep: *const OwnedSet) void {
+    fn noteLivenessLoopKeep(self: *const Inserter, reads: *ExactBitSet, keep: *const OwnedSet) ResourceError!void {
         // Every kept unit reads as a value use, which also sets its group
         // and value-use bits, so the loop edge keeps a group alive whenever
         // any member is kept.
-        var keep_iter = keep.bits.iterator(.{});
+        var keep_iter = keep.iterator(.{});
         while (keep_iter.next()) |kept| {
-            self.noteLivenessUseLocal(reads, keep.domain.resourceLocalAt(kept));
+            try self.noteLivenessUseLocal(reads, keep.domain.resourceLocalAt(kept));
         }
     }
 
@@ -6038,7 +6037,7 @@ const Inserter = struct {
 
             switch (self.store.getCFStmt(stmt)) {
                 .assign_ref => |assign| {
-                    self.noteLivenessUseRefOp(&graph.nodes.items[node_index].reads, assign.op);
+                    try self.noteLivenessUseRefOp(&graph.nodes.items[node_index].reads, assign.op);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
@@ -6051,174 +6050,174 @@ const Inserter = struct {
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, init.next);
                 },
                 .assign_call => |assign| {
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
                     if (assign.result_desc) |result_desc| {
-                        if (result_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                        if (result_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     }
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_call_erased => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.closure);
-                    if (assign.reuse_source) |reuse_source| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, reuse_source);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.arg_descs);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.closure);
+                    if (assign.reuse_source) |reuse_source| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, reuse_source);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.arg_descs);
                     if (assign.result_desc) |result_desc| {
-                        if (result_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                        if (result_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     }
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     if (assign.out_desc) |out_desc| setReadBeforeRebindDef(&graph, node_index, out_desc);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_packed_erased_fn => |assign| {
-                    if (assign.capture) |capture| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, capture);
-                    if (assign.reuse) |reuse| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, reuse);
+                    if (assign.capture) |capture| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, capture);
+                    if (assign.reuse) |reuse| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, reuse);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_desc_ref => |assign| {
-                    if (assign.desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    if (assign.tag_residual_for) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.captures);
+                    if (assign.desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.tag_residual_for) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.captures);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_dict_ref => |assign| {
-                    if (assign.dict.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.dict.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_box => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.payload);
-                    if (assign.source_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    if (assign.payload_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.payload);
+                    if (assign.source_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.payload_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_reuse_box => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
-                    if (assign.desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
+                    if (assign.desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_unbox => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
-                    if (assign.source_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    if (assign.target_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
+                    if (assign.source_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.target_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_adapt => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
-                    if (assign.source_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    if (assign.target_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
+                    if (assign.source_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.target_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_inspect => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
-                    if (assign.source_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
+                    if (assign.source_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_eq => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.lhs);
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.rhs);
-                    if (assign.source_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.lhs);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.rhs);
+                    if (assign.source_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_tag => |assign| {
-                    if (assign.target_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    if (assign.payload) |payload| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, payload);
-                    if (assign.payload_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.target_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.payload) |payload| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, payload);
+                    if (assign.payload_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_boxy_tag_payload => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
-                    if (assign.source_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.source);
+                    if (assign.source_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     if (assign.target_desc) |target_desc| setReadBeforeRebindDef(&graph, node_index, target_desc);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_call_dict => |assign| {
-                    if (assign.dict.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    if (assign.result_desc) |desc| if (desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.arg_descs);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.hidden_args);
+                    if (assign.dict.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    if (assign.result_desc) |desc| if (desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.arg_descs);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.hidden_args);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_low_level => |assign| {
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.args);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_list => |assign| {
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.elems);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.elems);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_struct => |assign| {
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.fields);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.fields);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .assign_tag => |assign| {
                     if (assign.target_desc) |target_desc| {
-                        if (target_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                        if (target_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     }
-                    if (assign.payload) |payload| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, payload);
+                    if (assign.payload) |payload| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, payload);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .store_struct => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.dest);
-                    self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.fields);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.dest);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[node_index].reads, assign.fields);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .store_tag => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.dest);
-                    if (assign.payload) |payload| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, payload);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.dest);
+                    if (assign.payload) |payload| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, payload);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .set_local => |assign| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.value);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, assign.value);
                     setReadBeforeRebindDef(&graph, node_index, assign.target);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, assign.next);
                 },
                 .debug => |debug_stmt| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, debug_stmt.message);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, debug_stmt.message);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, debug_stmt.next);
                 },
                 .expect => |expect_stmt| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, expect_stmt.condition);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, expect_stmt.condition);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, expect_stmt.next);
                 },
                 .expect_err => |expect_err_stmt| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, expect_err_stmt.message);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, expect_err_stmt.message);
                 },
                 .incref => |rc| {
-                    self.noteReadBeforeRebindLocal(&graph.nodes.items[node_index].reads, rc.value);
+                    try self.noteReadBeforeRebindLocal(&graph.nodes.items[node_index].reads, rc.value);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, rc.next);
                 },
                 .decref => |rc| {
-                    self.noteReadBeforeRebindLocal(&graph.nodes.items[node_index].reads, rc.value);
+                    try self.noteReadBeforeRebindLocal(&graph.nodes.items[node_index].reads, rc.value);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, rc.next);
                 },
                 .decref_if_initialized => |rc| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, rc.cond);
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, rc.value);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, rc.cond);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, rc.value);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, rc.next);
                 },
                 .free => |rc| {
-                    self.noteReadBeforeRebindLocal(&graph.nodes.items[node_index].reads, rc.value);
+                    try self.noteReadBeforeRebindLocal(&graph.nodes.items[node_index].reads, rc.value);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, rc.next);
                 },
                 .switch_stmt => |switch_stmt| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, switch_stmt.cond);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, switch_stmt.cond);
                     if (switch_stmt.continuation) |continuation| {
                         try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, continuation);
                     }
@@ -6230,19 +6229,19 @@ const Inserter = struct {
                     }
                 },
                 .switch_initialized_payload => |switch_stmt| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, switch_stmt.cond);
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, switch_stmt.payload);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, switch_stmt.cond);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, switch_stmt.payload);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, switch_stmt.initialized_branch);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, switch_stmt.uninitialized_branch);
                 },
                 .str_match => |str_match| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, str_match.source);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, str_match.source);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, str_match.on_match);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, str_match.on_miss);
                     try self.attachStrMatchEdgeKills(&graph, node_index, str_match.steps, 0);
                 },
                 .str_match_set => |str_match_set| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, str_match_set.source);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, str_match_set.source);
                     const arms = self.store.getStrMatchArms(str_match_set.arms);
                     for (0..GuardedList.borrowLen(arms)) |arm_index| {
                         const arm = GuardedList.at(arms, arm_index);
@@ -6255,8 +6254,8 @@ const Inserter = struct {
                     }
                 },
                 .boxy_tag_match => |tag_match| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, tag_match.source);
-                    if (tag_match.source_desc.localOrNull()) |local| self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, tag_match.source);
+                    if (tag_match.source_desc.localOrNull()) |local| try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, local);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, tag_match.on_match);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, tag_match.on_miss);
                 },
@@ -6270,22 +6269,22 @@ const Inserter = struct {
                     // the same retained units through its existing successor
                     // edge, instead of expanding the environment per edge.
                     const body_node = try self.ensureReadBeforeRebindNode(&graph, &work, join_stmt.body);
-                    self.noteLivenessUseSpan(&graph.nodes.items[body_node].reads, join_stmt.retained);
+                    try self.noteLivenessUseSpan(&graph.nodes.items[body_node].reads, join_stmt.retained);
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, join_stmt.remainder);
                 },
                 .jump => {
-                    self.noteRestitutionBoundaryReads(&graph.nodes.items[node_index].reads, graph.nodes.items[node_index].stmt);
+                    try self.noteRestitutionBoundaryReads(&graph.nodes.items[node_index].reads, graph.nodes.items[node_index].stmt);
                     const join_index = self.solution.jumpTargetJoinIndexOf(graph.nodes.items[node_index].stmt);
                     if (join_index >= self.join_bodies.len) arcInvariant("ARC liveness jump index exceeded its lifted join table");
                     const target_body = self.join_bodies[join_index].body;
                     try self.appendReadBeforeRebindSuccessor(&graph, &work, node_index, target_body);
                 },
                 .ret => |ret_stmt| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, ret_stmt.value);
-                    self.noteRestitutionBoundaryReads(&graph.nodes.items[node_index].reads, graph.nodes.items[node_index].stmt);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, ret_stmt.value);
+                    try self.noteRestitutionBoundaryReads(&graph.nodes.items[node_index].reads, graph.nodes.items[node_index].stmt);
                 },
                 .crash => |crash_stmt| if (crash_stmt.msg.localId()) |message| {
-                    self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, message);
+                    try self.noteLivenessUseLocal(&graph.nodes.items[node_index].reads, message);
                 },
                 .loop_continue,
                 .loop_break,
@@ -6434,7 +6433,7 @@ const Inserter = struct {
                 }
             }
             if (!cyclic) {
-                _ = self.recomputeLivenessNode(graph, members[0], &scratch, &edge_scratch);
+                _ = try self.recomputeLivenessNode(graph, members[0], &scratch, &edge_scratch);
                 continue;
             }
             for (members) |node_index| {
@@ -6444,7 +6443,7 @@ const Inserter = struct {
             }
             while (node_work.pop()) |node_index| {
                 in_work.unset(node_index);
-                if (!self.recomputeLivenessNode(graph, node_index, &scratch, &edge_scratch)) continue;
+                if (!try self.recomputeLivenessNode(graph, node_index, &scratch, &edge_scratch)) continue;
                 const pred_start = graph.predecessor_starts[node_index];
                 const pred_end = graph.predecessor_starts[node_index + 1];
                 for (graph.predecessors[pred_start..pred_end]) |predecessor| {
@@ -6462,7 +6461,7 @@ const Inserter = struct {
         node_index: usize,
         scratch: *ExactBitSet,
         edge_scratch: *ExactBitSet,
-    ) bool {
+    ) ResourceError!bool {
         const node = &graph.nodes.items[node_index];
         scratch.unsetAll();
         const successor_end = node.successor_start + @as(usize, node.successor_len);
@@ -6472,22 +6471,22 @@ const Inserter = struct {
                 if (kill.successor_offset != successor_offset) continue;
                 if (!edge_killed) {
                     edge_scratch.unsetAll();
-                    edge_scratch.setUnion(graph.nodes.items[successor].exposed);
+                    try edge_scratch.setUnion(graph.nodes.items[successor].exposed);
                     edge_killed = true;
                 }
-                edge_scratch.unset(kill.bit);
+                try edge_scratch.unset(kill.bit);
             }
-            scratch.setUnion(if (edge_killed) edge_scratch.* else graph.nodes.items[successor].exposed);
+            try scratch.setUnion(if (edge_killed) edge_scratch.* else graph.nodes.items[successor].exposed);
         }
         if (node.def) |local| {
-            if (self.rawLivenessBitOf(local)) |bit| scratch.unset(bit);
-            if (self.groupBitOf(local)) |bit| scratch.unset(bit);
-            if (self.valueUseBitOf(local)) |bit| scratch.unset(bit);
+            if (self.rawLivenessBitOf(local)) |bit| try scratch.unset(bit);
+            if (self.groupBitOf(local)) |bit| try scratch.unset(bit);
+            if (self.valueUseBitOf(local)) |bit| try scratch.unset(bit);
         }
-        scratch.setUnion(node.reads);
+        try scratch.setUnion(node.reads);
         if (node.exposed.eql(scratch.*)) return false;
         node.exposed.unsetAll();
-        node.exposed.setUnion(scratch.*);
+        try node.exposed.setUnion(scratch.*);
         return true;
     }
 
@@ -6542,7 +6541,7 @@ const Inserter = struct {
         if (!active.isSet(start_node)) arcInvariant("ARC loop liveness query was outside its explicit join regions");
 
         var keep_reads = try ExactBitSet.initEmpty(allocator, self.domain().livenessBitLen());
-        self.noteLivenessLoopKeep(&keep_reads, keep.set);
+        try self.noteLivenessLoopKeep(&keep_reads, keep.set);
         cache.consumed_keep_bits = keep_reads.count() != 0;
 
         const rows = try allocator.alloc(?ExactBitSet, node_count);
@@ -6552,7 +6551,7 @@ const Inserter = struct {
         for (graph.loop_edges) |loop_node| {
             if (!active.isSet(loop_node)) continue;
             var row = try graph.nodes.items[loop_node].exposed.clone(allocator);
-            row.setUnion(keep_reads);
+            try row.setUnion(keep_reads);
             rows[loop_node] = row;
             const pred_start = graph.predecessor_starts[loop_node];
             const pred_end = graph.predecessor_starts[loop_node + 1];
@@ -6577,24 +6576,24 @@ const Inserter = struct {
                     if (kill.successor_offset != successor_offset) continue;
                     if (!edge_killed) {
                         edge_scratch.unsetAll();
-                        edge_scratch.setUnion(successor_row.*);
+                        try edge_scratch.setUnion(successor_row.*);
                         edge_killed = true;
                     }
-                    edge_scratch.unset(kill.bit);
+                    try edge_scratch.unset(kill.bit);
                 }
-                scratch.setUnion(if (edge_killed) edge_scratch else successor_row.*);
+                try scratch.setUnion(if (edge_killed) edge_scratch else successor_row.*);
             }
             if (node.def) |local| {
-                if (self.rawLivenessBitOf(local)) |bit| scratch.unset(bit);
-                if (self.groupBitOf(local)) |bit| scratch.unset(bit);
-                if (self.valueUseBitOf(local)) |bit| scratch.unset(bit);
+                if (self.rawLivenessBitOf(local)) |bit| try scratch.unset(bit);
+                if (self.groupBitOf(local)) |bit| try scratch.unset(bit);
+                if (self.valueUseBitOf(local)) |bit| try scratch.unset(bit);
             }
-            scratch.setUnion(node.reads);
+            try scratch.setUnion(node.reads);
             const previous = if (rows[node_index]) |*row| row else &node.exposed;
             if (previous.eql(scratch)) continue;
             if (rows[node_index]) |*row| {
                 row.unsetAll();
-                row.setUnion(scratch);
+                try row.setUnion(scratch);
             } else {
                 rows[node_index] = try scratch.clone(allocator);
             }
@@ -6643,7 +6642,7 @@ const Inserter = struct {
 
         const allocator = self.emission_allocator;
         var new_keep_reads = try ExactBitSet.initEmpty(allocator, self.domain().livenessBitLen());
-        self.noteLivenessLoopKeep(&new_keep_reads, keep.set);
+        try self.noteLivenessLoopKeep(&new_keep_reads, keep.set);
         var new_iter = new_keep_reads.iterator(.{});
         while (new_iter.next()) |bit| {
             if (!old_keep_reads.isSet(bit)) arcInvariant("ARC loop boundary facts grew after their monotone keep-set shrank");
@@ -6663,12 +6662,12 @@ const Inserter = struct {
         for (graph.loop_edges) |loop_node| {
             if (!active.isSet(loop_node)) continue;
             scratch.unsetAll();
-            scratch.setUnion(graph.nodes.items[loop_node].exposed);
-            scratch.setUnion(new_keep_reads);
+            try scratch.setUnion(graph.nodes.items[loop_node].exposed);
+            try scratch.setUnion(new_keep_reads);
             const row = if (cache.rows[loop_node]) |*existing| existing else arcInvariant("ARC active loop edge lacked its cached row");
             if (row.eql(scratch)) continue;
             row.unsetAll();
-            row.setUnion(scratch);
+            try row.setUnion(scratch);
             const pred_start = graph.predecessor_starts[loop_node];
             const pred_end = graph.predecessor_starts[loop_node + 1];
             for (graph.predecessors[pred_start..pred_end]) |predecessor| {
@@ -6690,23 +6689,23 @@ const Inserter = struct {
                     if (kill.successor_offset != successor_offset) continue;
                     if (!edge_killed) {
                         edge_scratch.unsetAll();
-                        edge_scratch.setUnion(successor_row.*);
+                        try edge_scratch.setUnion(successor_row.*);
                         edge_killed = true;
                     }
-                    edge_scratch.unset(kill.bit);
+                    try edge_scratch.unset(kill.bit);
                 }
-                scratch.setUnion(if (edge_killed) edge_scratch else successor_row.*);
+                try scratch.setUnion(if (edge_killed) edge_scratch else successor_row.*);
             }
             if (node.def) |local| {
-                if (self.rawLivenessBitOf(local)) |bit| scratch.unset(bit);
-                if (self.groupBitOf(local)) |bit| scratch.unset(bit);
-                if (self.valueUseBitOf(local)) |bit| scratch.unset(bit);
+                if (self.rawLivenessBitOf(local)) |bit| try scratch.unset(bit);
+                if (self.groupBitOf(local)) |bit| try scratch.unset(bit);
+                if (self.valueUseBitOf(local)) |bit| try scratch.unset(bit);
             }
-            scratch.setUnion(node.reads);
+            try scratch.setUnion(node.reads);
             const row = if (cache.rows[node_index]) |*existing| existing else arcInvariant("ARC active loop node lacked its cached row");
             if (row.eql(scratch)) continue;
             row.unsetAll();
-            row.setUnion(scratch);
+            try row.setUnion(scratch);
             const pred_start = graph.predecessor_starts[node_index];
             const pred_end = graph.predecessor_starts[node_index + 1];
             for (graph.predecessors[pred_start..pred_end]) |predecessor| {
@@ -6717,7 +6716,7 @@ const Inserter = struct {
         }
 
         old_keep_reads.unsetAll();
-        old_keep_reads.setUnion(new_keep_reads);
+        try old_keep_reads.setUnion(new_keep_reads);
         cache.consumed_keep_bits = new_keep_reads.count() != 0;
         cache.dirty = false;
         if (builtin.mode == .Debug) try self.certifyLoopReadsBeforeRebind(cache);
@@ -6756,7 +6755,7 @@ const Inserter = struct {
         for (graph.loop_edges) |loop_node| {
             if (!active.isSet(loop_node)) continue;
             is_loop_edge.set(loop_node);
-            expected[loop_node].?.setUnion(keep_reads.*);
+            try expected[loop_node].?.setUnion(keep_reads.*);
         }
 
         var in_work = try active.clone(allocator);
@@ -6770,8 +6769,8 @@ const Inserter = struct {
             const node = graph.nodes.items[node_index];
             scratch.unsetAll();
             if (is_loop_edge.isSet(node_index)) {
-                scratch.setUnion(node.exposed);
-                scratch.setUnion(keep_reads.*);
+                try scratch.setUnion(node.exposed);
+                try scratch.setUnion(keep_reads.*);
             } else {
                 const successor_end = node.successor_start + @as(usize, node.successor_len);
                 for (graph.successors.items[node.successor_start..successor_end], 0..) |successor, successor_offset| {
@@ -6784,19 +6783,19 @@ const Inserter = struct {
                         if (kill.successor_offset != successor_offset) continue;
                         if (!edge_killed) {
                             edge_scratch.unsetAll();
-                            edge_scratch.setUnion(successor_row.*);
+                            try edge_scratch.setUnion(successor_row.*);
                             edge_killed = true;
                         }
-                        edge_scratch.unset(kill.bit);
+                        try edge_scratch.unset(kill.bit);
                     }
-                    scratch.setUnion(if (edge_killed) edge_scratch else successor_row.*);
+                    try scratch.setUnion(if (edge_killed) edge_scratch else successor_row.*);
                 }
                 if (node.def) |local| {
-                    if (self.rawLivenessBitOf(local)) |bit| scratch.unset(bit);
-                    if (self.groupBitOf(local)) |bit| scratch.unset(bit);
-                    if (self.valueUseBitOf(local)) |bit| scratch.unset(bit);
+                    if (self.rawLivenessBitOf(local)) |bit| try scratch.unset(bit);
+                    if (self.groupBitOf(local)) |bit| try scratch.unset(bit);
+                    if (self.valueUseBitOf(local)) |bit| try scratch.unset(bit);
                 }
-                scratch.setUnion(node.reads);
+                try scratch.setUnion(node.reads);
             }
             const row = if (expected[node_index]) |*entry|
                 entry
@@ -6804,7 +6803,7 @@ const Inserter = struct {
                 arcInvariant("ARC loop-liveness certifier omitted an active row");
             if (row.eql(scratch)) continue;
             row.unsetAll();
-            row.setUnion(scratch);
+            try row.setUnion(scratch);
             const pred_start = graph.predecessor_starts[node_index];
             const pred_end = graph.predecessor_starts[node_index + 1];
             for (graph.predecessors[pred_start..pred_end]) |predecessor| {
@@ -7177,84 +7176,71 @@ fn localSpanEql(a: LIR.LocalSpan, b: LIR.LocalSpan) bool {
     return a.start == b.start and a.len == b.len;
 }
 
+const OwnedEntry = struct {
+    present: bool = false,
+    residual_mask: u64 = 0,
+};
+
 const OwnedSet = struct {
-    allocator: std.mem.Allocator,
     domain: *const ProcArcDomain,
-    bits: ExactBitSet,
-    /// Exact committed aggregate field places still stored in each resource.
-    /// Ordinary resources have a zero full domain and ignore this row.
-    residual_masks: []u64,
+    /// Fresh sets update their one-owner tree in place until it is copied or
+    /// combined with another state.
+    unique: bool = true,
+    /// Logically one exact entry per resource. Absent resources consume no
+    /// tree storage, and control-flow forks share every unchanged subtree.
+    entries: ArcSnapshot(OwnedEntry, .{}),
 
     fn init(allocator: std.mem.Allocator, domain: *const ProcArcDomain) ResourceError!OwnedSet {
-        const bits = try ExactBitSet.initEmpty(allocator, domain.resource_locals.len);
-        const residual_masks = try allocator.alloc(u64, domain.resource_locals.len);
-        @memset(residual_masks, 0);
-        return .{ .allocator = allocator, .domain = domain, .bits = bits, .residual_masks = residual_masks };
+        return .{ .domain = domain, .entries = ArcSnapshot(OwnedEntry, .{}).init(allocator, domain.resource_locals.len) };
     }
 
-    fn deinit(self: *OwnedSet) void {
-        self.bits.deinit(self.allocator);
-        self.allocator.free(self.residual_masks);
-    }
+    /// Nodes have the surrounding proc arena's exact lifetime and may be
+    /// shared by any number of snapshots.
+    fn deinit(_: *OwnedSet) void {}
 
-    fn clone(self: *const OwnedSet) ResourceError!OwnedSet {
-        const bits = try self.bits.clone(self.allocator);
-        const residual_masks = try self.allocator.dupe(u64, self.residual_masks);
-        return .{ .allocator = self.allocator, .domain = self.domain, .bits = bits, .residual_masks = residual_masks };
-    }
-
-    fn set(self: *OwnedSet, local: LIR.LocalId) void {
+    fn set(self: *OwnedSet, local: LIR.LocalId) ResourceError!void {
         const bit = self.domain.requiredResourceBitOf(local);
-        self.bits.set(bit);
-        self.residual_masks[bit] = self.domain.fullResidualMaskAt(bit);
+        try self.putEntry(@intCast(bit), .{
+            .present = true,
+            .residual_mask = self.domain.fullResidualMaskAt(bit),
+        });
     }
 
-    fn unset(self: *OwnedSet, local: LIR.LocalId) void {
+    fn unset(self: *OwnedSet, local: LIR.LocalId) ResourceError!void {
         // Scalars are outside the ownership lattice, so removing one is the
         // same empty-set operation the former zeroed global bit performed.
-        if (self.domain.resourceBitOf(local)) |bit| {
-            self.bits.unset(bit);
-            self.residual_masks[bit] = 0;
-        }
+        if (self.domain.resourceBitOf(local)) |bit| try self.putEntry(@intCast(bit), .{});
     }
 
     fn contains(self: *const OwnedSet, local: LIR.LocalId) bool {
         const bit = self.domain.resourceBitOf(local) orelse return false;
-        return self.bits.isSet(bit);
+        return self.entryAt(bit).present;
     }
 
     fn eql(self: *const OwnedSet, other: *const OwnedSet) bool {
         self.requireSameDomain(other);
-        return self.bits.eql(other.bits) and std.mem.eql(u64, self.residual_masks, other.residual_masks);
+        return self.entries.eql(&other.entries);
     }
 
-    fn intersect(self: *OwnedSet, other: *const OwnedSet) void {
-        self.requireSameDomain(other);
-        self.bits.setIntersection(other.bits);
-        for (self.residual_masks, 0..) |*mask, bit| {
-            if (!self.bits.isSet(bit)) {
-                mask.* = 0;
-            } else {
-                mask.* &= other.residual_masks[bit];
-            }
-        }
+    fn meetEntry(_: void, lhs: OwnedEntry, rhs: OwnedEntry) OwnedEntry {
+        if (!lhs.present or !rhs.present) return .{};
+        return .{ .present = true, .residual_mask = lhs.residual_mask & rhs.residual_mask };
     }
 
     /// Places `local` carrying exactly `mask` of its committed field places,
     /// rather than the full ownership `set` grants. Used to copy a resource
     /// out of a meet that may have narrowed it.
-    fn setWithResidual(self: *OwnedSet, local: LIR.LocalId, mask: u64) void {
+    fn setWithResidual(self: *OwnedSet, local: LIR.LocalId, mask: u64) ResourceError!void {
         const bit = self.domain.requiredResourceBitOf(local);
         if ((mask & ~self.domain.fullResidualMaskAt(bit)) != 0) {
             arcInvariant("ARC residual placement exceeded the committed field places");
         }
-        self.bits.set(bit);
-        self.residual_masks[bit] = mask;
+        try self.putEntry(@intCast(bit), .{ .present = true, .residual_mask = mask });
     }
 
     fn residualMask(self: *const OwnedSet, local: LIR.LocalId) u64 {
         const bit = self.domain.resourceBitOf(local) orelse return 0;
-        return self.residual_masks[bit];
+        return self.entryAt(bit).residual_mask;
     }
 
     fn fullResidualMask(self: *const OwnedSet, local: LIR.LocalId) u64 {
@@ -7262,28 +7248,84 @@ const OwnedSet = struct {
         return self.domain.fullResidualMaskAt(bit);
     }
 
-    fn takeResidualField(self: *OwnedSet, local: LIR.LocalId, field_mask: u64) void {
+    fn takeResidualField(self: *OwnedSet, local: LIR.LocalId, field_mask: u64) ResourceError!void {
         const bit = self.domain.requiredResourceBitOf(local);
-        if (!self.bits.isSet(bit)) arcInvariant("ARC field take reached an absent aggregate resource");
-        if ((self.residual_masks[bit] & field_mask) != field_mask) arcInvariant("ARC field take consumed an absent committed field place");
-        self.residual_masks[bit] &= ~field_mask;
+        const entry = self.entryAt(bit);
+        if (!entry.present) arcInvariant("ARC field take reached an absent aggregate resource");
+        if ((entry.residual_mask & field_mask) != field_mask) arcInvariant("ARC field take consumed an absent committed field place");
+        try self.putEntry(@intCast(bit), .{ .present = true, .residual_mask = entry.residual_mask & ~field_mask });
     }
 
-    fn restoreResidualField(self: *OwnedSet, local: LIR.LocalId, field_mask: u64) void {
+    fn restoreResidualField(self: *OwnedSet, local: LIR.LocalId, field_mask: u64) ResourceError!void {
         const bit = self.domain.requiredResourceBitOf(local);
-        if (!self.bits.isSet(bit)) arcInvariant("ARC field restitution reached an absent aggregate resource");
+        const entry = self.entryAt(bit);
+        if (!entry.present) arcInvariant("ARC field restitution reached an absent aggregate resource");
         const full = self.domain.fullResidualMaskAt(bit);
         if ((field_mask & ~full) != 0) arcInvariant("ARC field restitution exceeded its committed aggregate field domain");
-        if ((self.residual_masks[bit] & field_mask) != 0) arcInvariant("ARC field restitution duplicated a live committed field place");
-        self.residual_masks[bit] |= field_mask;
+        if ((entry.residual_mask & field_mask) != 0) arcInvariant("ARC field restitution duplicated a live committed field place");
+        try self.putEntry(@intCast(bit), .{ .present = true, .residual_mask = entry.residual_mask | field_mask });
     }
 
-    fn copyResourceFrom(self: *OwnedSet, source: *const OwnedSet, local: LIR.LocalId) void {
+    fn copyResourceFrom(self: *OwnedSet, source: *const OwnedSet, local: LIR.LocalId) ResourceError!void {
         self.requireSameDomain(source);
         const bit = self.domain.requiredResourceBitOf(local);
-        if (!source.bits.isSet(bit)) arcInvariant("ARC copied an absent ownership resource");
-        self.bits.set(bit);
-        self.residual_masks[bit] = source.residual_masks[bit];
+        const entry = source.entryAt(bit);
+        if (!entry.present) arcInvariant("ARC copied an absent ownership resource");
+        try self.putEntry(@intCast(bit), entry);
+    }
+
+    fn putEntry(self: *OwnedSet, bit: u32, entry: OwnedEntry) ResourceError!void {
+        if (self.unique) {
+            try self.entries.putUnique(bit, entry);
+        } else {
+            try self.entries.put(bit, entry);
+        }
+    }
+
+    fn clear(self: *OwnedSet) void {
+        self.entries.clear();
+    }
+
+    fn entryAt(self: *const OwnedSet, bit: usize) OwnedEntry {
+        return self.entries.get(@intCast(bit));
+    }
+
+    fn Iterator(comptime options: std.bit_set.IteratorOptions) type {
+        if (options.kind != .set) @compileError("ARC ownership sets iterate only present resources");
+        return struct {
+            set: *const OwnedSet,
+            cursor: usize,
+
+            fn next(self: *@This()) ?usize {
+                return switch (options.direction) {
+                    .forward => {
+                        while (self.cursor < self.set.domain.resource_locals.len) {
+                            const bit = self.cursor;
+                            self.cursor += 1;
+                            if (self.set.entryAt(bit).present) return bit;
+                        }
+                        return null;
+                    },
+                    .reverse => {
+                        while (self.cursor > 0) {
+                            self.cursor -= 1;
+                            if (self.set.entryAt(self.cursor).present) return self.cursor;
+                        }
+                        return null;
+                    },
+                };
+            }
+        };
+    }
+
+    fn iterator(self: *const OwnedSet, comptime options: std.bit_set.IteratorOptions) Iterator(options) {
+        return .{
+            .set = self,
+            .cursor = switch (options.direction) {
+                .forward => 0,
+                .reverse => self.domain.resource_locals.len,
+            },
+        };
     }
 
     fn requireSameDomain(self: *const OwnedSet, other: *const OwnedSet) void {
@@ -7360,23 +7402,22 @@ fn fixtureTableIndex(comptime index: u32) u32 {
     return index;
 }
 
-test "exact ARC sets preserve operations at the inline boundary" {
+test "exact ARC sets preserve operations across persistent forks" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
     const word_bits = @bitSizeOf(usize);
     for ([_]usize{ word_bits, word_bits + 1 }) |bit_len| {
-        var left = try ExactBitSet.initEmpty(testing.allocator, bit_len);
-        defer left.deinit(testing.allocator);
-        var right = try ExactBitSet.initEmpty(testing.allocator, bit_len);
-        defer right.deinit(testing.allocator);
+        var left = try ExactBitSet.initEmpty(arena.allocator(), bit_len);
+        var right = try ExactBitSet.initEmpty(arena.allocator(), bit_len);
 
-        left.set(0);
-        left.set(bit_len - 1);
-        right.set(bit_len - 1);
-        left.setIntersection(right);
+        try left.set(0);
+        try left.set(bit_len - 1);
+        try right.set(bit_len - 1);
+        try left.setIntersection(right);
         try testing.expectEqual(@as(usize, 1), left.count());
         try testing.expect(left.isSet(bit_len - 1));
 
-        var cloned = try left.clone(testing.allocator);
-        defer cloned.deinit(testing.allocator);
+        var cloned = try left.clone(arena.allocator());
         try testing.expect(cloned.eql(left));
         var iter = cloned.iterator(.{ .direction = .reverse });
         try testing.expectEqual(bit_len - 1, iter.next().?);
@@ -8976,11 +9017,11 @@ test "ARC proc domain excludes scalar and other-proc locals" {
         try testing.expectEqual(@as(usize, 1), domain.livenessBitLen());
         try testing.expectEqual(resource, domain.resourceLocalAt(0));
 
-        var owned = try OwnedSet.init(testing.allocator, &domain);
+        var owned = try OwnedSet.init(arena.allocator(), &domain);
         defer owned.deinit();
         try testing.expect(!owned.contains(scalar));
-        owned.unset(scalar);
-        owned.set(resource);
+        try owned.unset(scalar);
+        try owned.set(resource);
         try testing.expect(owned.contains(resource));
     }
 

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -113,6 +113,7 @@ const rc_effect_rules = base.rc_effect_rules;
 const arc_sig = @import("arc_sig.zig");
 const arc_dismantle = @import("arc_dismantle.zig");
 const arc_solve = @import("arc_solve.zig");
+const ArcSnapshot = @import("arc_state.zig").Snapshot;
 const debug_print = @import("debug_print.zig");
 
 const LIR = core.LIR;
@@ -213,6 +214,7 @@ fn certifyStoreWithWorkStats(
         .rc_local = rc_local,
         .maybe_uninitialized = &maybe_uninitialized,
         .lender_arena = std.heap.ArenaAllocator.init(allocator),
+        .state_arena = std.heap.ArenaAllocator.init(allocator),
         .records = collections.DenseMap(LIR.JoinPointId, JoinRecord).init(allocator),
         .memo = std.AutoHashMap(MemoEntry, void).init(allocator),
         .repr_scratch = collections.DenseMap(ValueId, u32).init(allocator),
@@ -1226,49 +1228,39 @@ const ValueInfo = struct {
     call_restitution: []const RestitutionReceipt = &.{},
 };
 
-/// One forked ownership state along a control-flow path.
-/// Retired certifier states, kept so a fork can refill one instead of
-/// allocating a fresh set of buffers.
-///
-/// A state holds one array per refcounted local plus four indexed by value,
-/// and every branch clones the whole thing. On a wide derived codec that is
-/// tens of thousands of clone/free pairs of multi-kilobyte buffers, which in
-/// a Debug build means the same number of trips through the page allocator.
-/// Reusing them keeps the buffers hot and the allocator out of the loop.
-/// Entries are sized for one procedure, so the pool is drained between
-/// procedures.
-const StatePool = std.ArrayList(State);
-
+/// One exact ownership state along a control-flow path. Forks share all
+/// unchanged facts; a transfer allocates only bounded-depth paths to the facts
+/// it changes in the current procedure's state arena.
 const State = struct {
-    allocator: Allocator,
-    /// Where this state's buffers go when it dies, or null to free them.
-    pool: ?*StatePool = null,
+    /// True until the state first forks. Before that point its tree nodes have
+    /// one owner and construction can update them in place.
+    unique: bool = true,
     /// Dense proc-local position per store local, owned by the certifier and
     /// stable for the lifetime of every state for the current proc.
     local_dense: []const u32,
     /// Value bound to each reference-counted local used by this proc;
     /// `no_value` when unbound.
-    local_value: []ValueId,
+    local_value: ArcSnapshot(ValueId, no_value),
     /// Ownership units per value. Values created after a fork are absent in
     /// sibling states; absent means zero.
-    balance: std.ArrayList(i32),
+    balance: ArcSnapshot(i32, 0),
     /// Aggregate value currently holding a moved-in unit of this value, or
     /// `no_value`. Keeps consumed operands live until the holder dies.
-    holder: std.ArrayList(ValueId),
+    holder: ArcSnapshot(ValueId, no_value),
     /// Presence condition for a value that represents conditional ownership.
     /// `no_dense` means the value is ordinary. A conditional value carries a
     /// possible ownership unit: if the condition is true, the unit exists and
     /// must be released; if false, the payload was never initialized.
-    conditional_condition: std.ArrayList(u32),
-    conditional_condition_mask: std.ArrayList(u64),
+    conditional: ArcSnapshot(ConditionalEntry, .{}),
     /// Fields of a value whose stored units have been claimed by field
     /// takes. A claimed value's remaining unit covers only its unclaimed
     /// fields: it can no longer be released or consumed whole, and at a
     /// terminal it must be fully claimed and residual-released instead.
-    claims: std.AutoHashMapUnmanaged(ValueId, u64),
+    claims: ArcSnapshot(u64, 0),
     /// Scalar discriminant locals explicitly read from a direct call result
     /// carrying outcome-conditioned ownership.
-    outcome_discriminants: std.AutoHashMapUnmanaged(LIR.LocalId, ValueId),
+    outcome_discriminants: ArcSnapshot(ValueId, no_value),
+    outcome_discriminant_count: usize = 0,
     /// Statically known discriminant of the current proc's top-level result
     /// along this exact path. The initial restitution capability consumes it
     /// before a terminal jump/return, so it never crosses a join summary.
@@ -1278,236 +1270,60 @@ const State = struct {
     /// declaration is an exact LIR scope boundary: nested joins preserve its
     /// symbolic cells until a switch resolves them, while joins that precede
     /// or sit outside the declaration must not manufacture them.
-    maybe_uninitialized_unresolved: std.bit_set.DynamicBitSetUnmanaged,
+    maybe_uninitialized_unresolved: ArcSnapshot(bool, false),
     /// Payload cells that may already have been spent by a guarded release on
     /// one path. The bit is a may-fact: joins union it, a fresh payload write or
     /// producer-authored conditional join clears it, and another guarded read
     /// before either transition is a possible double release.
-    maybe_uninitialized_released: std.bit_set.DynamicBitSetUnmanaged,
+    maybe_uninitialized_released: ArcSnapshot(bool, false),
     /// Some value on this path has a negative balance: an aggregate move
     /// consumed a field read whose take has not settled yet.
     any_negative: bool = false,
 
+    const ConditionalEntry = struct {
+        condition: u32 = no_dense,
+        mask: u64 = 0,
+    };
+
     fn init(allocator: Allocator, local_dense: []const u32, proc_local_count: usize) Allocator.Error!State {
-        const local_value = try allocator.alloc(ValueId, proc_local_count);
-        errdefer allocator.free(local_value);
-        @memset(local_value, no_value);
-        var maybe_uninitialized_unresolved = try std.bit_set.DynamicBitSetUnmanaged.initEmpty(allocator, proc_local_count);
-        errdefer maybe_uninitialized_unresolved.deinit(allocator);
-        const maybe_uninitialized_released = try std.bit_set.DynamicBitSetUnmanaged.initEmpty(allocator, proc_local_count);
         return .{
-            .allocator = allocator,
             .local_dense = local_dense,
-            .local_value = local_value,
-            .balance = .empty,
-            .holder = .empty,
-            .conditional_condition = .empty,
-            .conditional_condition_mask = .empty,
-            .claims = .empty,
-            .outcome_discriminants = .empty,
+            .local_value = ArcSnapshot(ValueId, no_value).init(allocator, proc_local_count),
+            .balance = ArcSnapshot(i32, 0).init(allocator, proc_local_count),
+            .holder = ArcSnapshot(ValueId, no_value).init(allocator, proc_local_count),
+            .conditional = ArcSnapshot(ConditionalEntry, .{}).init(allocator, proc_local_count),
+            .claims = ArcSnapshot(u64, 0).init(allocator, proc_local_count),
+            .outcome_discriminants = ArcSnapshot(ValueId, no_value).init(allocator, local_dense.len),
             .result_discriminant = no_dense,
-            .maybe_uninitialized_unresolved = maybe_uninitialized_unresolved,
-            .maybe_uninitialized_released = maybe_uninitialized_released,
+            .maybe_uninitialized_unresolved = ArcSnapshot(bool, false).init(allocator, proc_local_count),
+            .maybe_uninitialized_released = ArcSnapshot(bool, false).init(allocator, proc_local_count),
             .any_negative = false,
         };
     }
 
-    fn deinit(self: *State) void {
-        if (self.pool) |pool| {
-            self.balance.clearRetainingCapacity();
-            self.holder.clearRetainingCapacity();
-            self.conditional_condition.clearRetainingCapacity();
-            self.conditional_condition_mask.clearRetainingCapacity();
-            self.claims.clearRetainingCapacity();
-            self.outcome_discriminants.clearRetainingCapacity();
-            // Recycling is an optimization; if the pool cannot grow, fall
-            // through and free the buffers as usual.
-            pool.append(self.allocator, self.*) catch {
-                self.freeBuffers();
-                return;
-            };
-            self.* = undefined;
-            return;
+    fn deinit(_: *State) void {}
+
+    fn clone(self: *State) Allocator.Error!State {
+        self.unique = false;
+        var cloned = self.*;
+        cloned.unique = false;
+        return cloned;
+    }
+
+    fn put(self: *State, snapshot: anytype, index: u32, value: anytype) Allocator.Error!void {
+        if (self.unique) {
+            try snapshot.putUnique(index, value);
+        } else {
+            try snapshot.put(index, value);
         }
-        self.freeBuffers();
-    }
-
-    fn freeBuffers(self: *State) void {
-        self.allocator.free(self.local_value);
-        self.balance.deinit(self.allocator);
-        self.holder.deinit(self.allocator);
-        self.conditional_condition.deinit(self.allocator);
-        self.conditional_condition_mask.deinit(self.allocator);
-        self.claims.deinit(self.allocator);
-        self.outcome_discriminants.deinit(self.allocator);
-        self.maybe_uninitialized_unresolved.deinit(self.allocator);
-        self.maybe_uninitialized_released.deinit(self.allocator);
-    }
-
-    fn clone(self: *const State) Allocator.Error!State {
-        if (self.pool) |pool| {
-            if (pool.pop()) |recycled| {
-                var reused = recycled;
-                errdefer reused.freeBuffers();
-                try reused.refillFrom(self);
-                return reused;
-            }
-        }
-
-        const local_value = try self.allocator.dupe(ValueId, self.local_value);
-        errdefer self.allocator.free(local_value);
-        var balance = try self.balance.clone(self.allocator);
-        errdefer balance.deinit(self.allocator);
-        var holder = try self.holder.clone(self.allocator);
-        errdefer holder.deinit(self.allocator);
-        var conditional_condition = try self.conditional_condition.clone(self.allocator);
-        errdefer conditional_condition.deinit(self.allocator);
-        var conditional_condition_mask = try self.conditional_condition_mask.clone(self.allocator);
-        errdefer conditional_condition_mask.deinit(self.allocator);
-        var claims = try self.claims.clone(self.allocator);
-        errdefer claims.deinit(self.allocator);
-        var outcome_discriminants = try self.outcome_discriminants.clone(self.allocator);
-        errdefer outcome_discriminants.deinit(self.allocator);
-        var maybe_uninitialized_unresolved = try self.maybe_uninitialized_unresolved.clone(self.allocator);
-        errdefer maybe_uninitialized_unresolved.deinit(self.allocator);
-        const maybe_uninitialized_released = try self.maybe_uninitialized_released.clone(self.allocator);
-        return .{
-            .allocator = self.allocator,
-            .pool = self.pool,
-            .local_dense = self.local_dense,
-            .local_value = local_value,
-            .balance = balance,
-            .holder = holder,
-            .conditional_condition = conditional_condition,
-            .conditional_condition_mask = conditional_condition_mask,
-            .claims = claims,
-            .outcome_discriminants = outcome_discriminants,
-            .result_discriminant = self.result_discriminant,
-            .maybe_uninitialized_unresolved = maybe_uninitialized_unresolved,
-            .maybe_uninitialized_released = maybe_uninitialized_released,
-            .any_negative = self.any_negative,
-        };
-    }
-
-    /// Overwrites a recycled state with `source`, keeping the buffers it
-    /// already owns. `refilled_fields` holds this to every field of `State`.
-    fn refillFrom(self: *State, source: *const State) Allocator.Error!void {
-        if (self.local_value.len != source.local_value.len) {
-            self.local_value = try self.allocator.realloc(self.local_value, source.local_value.len);
-        }
-        @memcpy(self.local_value, source.local_value);
-
-        try copyList(i32, &self.balance, &source.balance, self.allocator);
-        try copyList(ValueId, &self.holder, &source.holder, self.allocator);
-        try copyList(u32, &self.conditional_condition, &source.conditional_condition, self.allocator);
-        try copyList(u64, &self.conditional_condition_mask, &source.conditional_condition_mask, self.allocator);
-        try copyBitSet(&self.maybe_uninitialized_unresolved, &source.maybe_uninitialized_unresolved, self.allocator);
-        try copyBitSet(&self.maybe_uninitialized_released, &source.maybe_uninitialized_released, self.allocator);
-
-        self.claims.clearRetainingCapacity();
-        try self.claims.ensureTotalCapacity(self.allocator, source.claims.count());
-        var claim_it = source.claims.iterator();
-        while (claim_it.next()) |entry| self.claims.putAssumeCapacity(entry.key_ptr.*, entry.value_ptr.*);
-
-        self.outcome_discriminants.clearRetainingCapacity();
-        try self.outcome_discriminants.ensureTotalCapacity(self.allocator, source.outcome_discriminants.count());
-        var discriminant_it = source.outcome_discriminants.iterator();
-        while (discriminant_it.next()) |entry| {
-            self.outcome_discriminants.putAssumeCapacity(entry.key_ptr.*, entry.value_ptr.*);
-        }
-
-        try self.maybe_uninitialized_unresolved.resize(
-            self.allocator,
-            source.maybe_uninitialized_unresolved.capacity(),
-            false,
-        );
-        self.maybe_uninitialized_unresolved.unsetAll();
-        self.maybe_uninitialized_unresolved.setUnion(source.maybe_uninitialized_unresolved);
-
-        try self.maybe_uninitialized_released.resize(
-            self.allocator,
-            source.maybe_uninitialized_released.capacity(),
-            false,
-        );
-        self.maybe_uninitialized_released.unsetAll();
-        self.maybe_uninitialized_released.setUnion(source.maybe_uninitialized_released);
-
-        self.local_dense = source.local_dense;
-        self.pool = source.pool;
-        self.result_discriminant = source.result_discriminant;
-        self.any_negative = source.any_negative;
-    }
-
-    /// Every field `refillFrom` copies out of the source state.
-    const refilled_fields = [_][]const u8{
-        "local_value",
-        "balance",
-        "holder",
-        "conditional_condition",
-        "conditional_condition_mask",
-        "maybe_uninitialized_unresolved",
-        "maybe_uninitialized_released",
-        "claims",
-        "outcome_discriminants",
-        "local_dense",
-        "pool",
-        "result_discriminant",
-        "any_negative",
-    };
-
-    /// Fields a refill leaves as the recycled state already has them. Every
-    /// state in a pool is built with the certifier's allocator, so the one a
-    /// recycled state holds is already the source's.
-    const refill_exempt_fields = [_][]const u8{
-        "allocator",
-    };
-
-    // A recycled state keeps whatever the previous walk left in a field the
-    // refill skips, and a leftover fact reads as one this path established:
-    // the certifier then reports a finding against a path it never walked, or
-    // misses one it did. Neither shows up as a crash, so a field added to
-    // `State` fails to compile until it is accounted for above.
-    comptime {
-        for (@typeInfo(State).@"struct".fields) |field| {
-            var accounted = false;
-            for (refilled_fields) |name| {
-                if (std.mem.eql(u8, name, field.name)) accounted = true;
-            }
-            for (refill_exempt_fields) |name| {
-                if (std.mem.eql(u8, name, field.name)) accounted = true;
-            }
-            if (!accounted) @compileError(
-                "State." ++ field.name ++ " is neither copied by refillFrom nor listed as exempt",
-            );
-        }
-    }
-
-    fn copyList(
-        comptime T: type,
-        destination: *std.ArrayList(T),
-        source: *const std.ArrayList(T),
-        allocator: Allocator,
-    ) Allocator.Error!void {
-        destination.clearRetainingCapacity();
-        try destination.appendSlice(allocator, source.items);
-    }
-
-    fn copyBitSet(
-        destination: *std.bit_set.DynamicBitSetUnmanaged,
-        source: *const std.bit_set.DynamicBitSetUnmanaged,
-        allocator: Allocator,
-    ) Allocator.Error!void {
-        try destination.resize(allocator, source.capacity(), false);
-        destination.unsetAll();
-        destination.setUnion(source.*);
     }
 
     fn claimsOf(self: *const State, value: ValueId) u64 {
-        return self.claims.get(value) orelse 0;
+        return self.claims.get(value);
     }
 
     fn setClaims(self: *State, value: ValueId, mask: u64) Allocator.Error!void {
-        try self.claims.put(self.allocator, value, mask);
+        try self.put(&self.claims, value, mask);
     }
 
     fn denseIndex(self: *const State, local: LIR.LocalId) usize {
@@ -1519,105 +1335,114 @@ const State = struct {
     }
 
     fn valueOf(self: *const State, local: LIR.LocalId) ValueId {
-        return self.local_value[self.denseIndex(local)];
+        return self.valueAtDense(self.denseIndex(local));
     }
 
     fn valueAtDense(self: *const State, dense: usize) ValueId {
-        return self.local_value[dense];
+        return self.local_value.get(@intCast(dense));
     }
 
     fn maybeUninitializedIsUnresolved(self: *const State, dense: usize) bool {
-        return self.maybe_uninitialized_unresolved.isSet(dense);
+        return self.maybe_uninitialized_unresolved.get(@intCast(dense));
     }
 
     fn maybeUninitializedMayBeReleased(self: *const State, dense: usize) bool {
-        return self.maybe_uninitialized_released.isSet(dense);
+        return self.maybe_uninitialized_released.get(@intCast(dense));
     }
 
-    fn bindValue(self: *State, local: LIR.LocalId, value: ValueId) void {
-        self.local_value[self.denseIndex(local)] = value;
+    fn setMaybeUninitializedUnresolved(self: *State, dense: usize, value: bool) Allocator.Error!void {
+        try self.put(&self.maybe_uninitialized_unresolved, @intCast(dense), value);
+    }
+
+    fn setMaybeUninitializedReleased(self: *State, dense: usize, value: bool) Allocator.Error!void {
+        try self.put(&self.maybe_uninitialized_released, @intCast(dense), value);
+    }
+
+    fn bindValue(self: *State, local: LIR.LocalId, value: ValueId) Allocator.Error!void {
+        try self.put(&self.local_value, @intCast(self.denseIndex(local)), value);
     }
 
     fn balanceOf(self: *const State, value: ValueId) i32 {
-        if (value >= self.balance.items.len) return 0;
-        return self.balance.items[value];
+        return self.balance.get(value);
     }
 
     fn holderOf(self: *const State, value: ValueId) ValueId {
-        if (value >= self.holder.items.len) return no_value;
-        return self.holder.items[value];
+        return self.holder.get(value);
     }
 
     fn conditionalConditionOf(self: *const State, value: ValueId) ?PresenceCondition {
-        if (value >= self.conditional_condition.items.len) return null;
-        const condition = self.conditional_condition.items[value];
-        if (condition == no_dense) return null;
-        return .{ .local = @enumFromInt(condition), .mask = self.conditional_condition_mask.items[value] };
-    }
-
-    fn growToValue(self: *State, value: ValueId) Allocator.Error!void {
-        while (self.balance.items.len <= value) {
-            try self.balance.append(self.allocator, 0);
-        }
-        while (self.holder.items.len <= value) {
-            try self.holder.append(self.allocator, no_value);
-        }
-        while (self.conditional_condition.items.len <= value) {
-            try self.conditional_condition.append(self.allocator, no_dense);
-        }
-        while (self.conditional_condition_mask.items.len <= value) {
-            try self.conditional_condition_mask.append(self.allocator, 0);
-        }
+        const entry = self.conditional.get(value);
+        if (entry.condition == no_dense) return null;
+        return .{ .local = @enumFromInt(entry.condition), .mask = entry.mask };
     }
 
     fn addBalance(self: *State, value: ValueId, delta: i32) Allocator.Error!void {
-        try self.growToValue(value);
-        self.balance.items[value] += delta;
-        if (self.balance.items[value] < 0) self.any_negative = true;
+        const next = self.balanceOf(value) + delta;
+        try self.put(&self.balance, value, next);
+        if (next < 0) self.any_negative = true;
     }
 
     fn setHolder(self: *State, value: ValueId, holder_value: ValueId) Allocator.Error!void {
-        try self.growToValue(value);
-        self.holder.items[value] = holder_value;
+        try self.put(&self.holder, value, holder_value);
     }
 
     fn setConditional(self: *State, value: ValueId, condition: PresenceCondition) Allocator.Error!void {
-        try self.growToValue(value);
-        self.conditional_condition.items[value] = @intFromEnum(condition.local);
-        self.conditional_condition_mask.items[value] = condition.mask;
+        try self.put(&self.conditional, value, ConditionalEntry{ .condition = @intFromEnum(condition.local), .mask = condition.mask });
     }
 
-    fn markDefinitelyInitialized(self: *State, value: ValueId) void {
-        if (value >= self.conditional_condition.items.len) return;
-        self.conditional_condition.items[value] = no_dense;
-        self.conditional_condition_mask.items[value] = 0;
+    fn markDefinitelyInitialized(self: *State, value: ValueId) Allocator.Error!void {
+        try self.put(&self.conditional, value, ConditionalEntry{});
+    }
+
+    fn outcomeDiscriminantCount(self: *const State) usize {
+        return self.outcome_discriminant_count;
+    }
+
+    fn outcomeDiscriminant(self: *const State, local: LIR.LocalId) ?ValueId {
+        const value = self.outcome_discriminants.get(@intFromEnum(local));
+        return if (value == no_value) null else value;
+    }
+
+    fn hasOutcomeDiscriminant(self: *const State, local: LIR.LocalId) bool {
+        return self.outcomeDiscriminant(local) != null;
+    }
+
+    fn setOutcomeDiscriminant(self: *State, local: LIR.LocalId, value: ValueId) Allocator.Error!void {
+        const index = @intFromEnum(local);
+        if (self.outcome_discriminants.get(index) == no_value) self.outcome_discriminant_count += 1;
+        try self.put(&self.outcome_discriminants, index, value);
+    }
+
+    fn removeOutcomeDiscriminant(self: *State, local: LIR.LocalId) Allocator.Error!void {
+        const index = @intFromEnum(local);
+        if (self.outcome_discriminants.get(index) == no_value) return;
+        try self.put(&self.outcome_discriminants, index, no_value);
+        self.outcome_discriminant_count -= 1;
+    }
+
+    fn clearOutcomeDiscriminants(self: *State) void {
+        self.outcome_discriminants.clear();
+        self.outcome_discriminant_count = 0;
     }
 };
 
-test "recycled state copies maybe-uninitialized facts" {
-    var source = try State.init(testing.allocator, &.{}, 4);
-    defer source.deinit();
-    source.maybe_uninitialized_unresolved.set(1);
-    source.maybe_uninitialized_released.set(2);
+test "forked state shares unchanged maybe-uninitialized facts" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
 
-    var recycled = try State.init(testing.allocator, &.{}, 6);
-    defer recycled.deinit();
-    recycled.maybe_uninitialized_unresolved.set(0);
-    recycled.maybe_uninitialized_unresolved.set(3);
-    recycled.maybe_uninitialized_released.set(0);
-    recycled.maybe_uninitialized_released.set(3);
+    var source = try State.init(arena.allocator(), &.{}, 4);
+    try source.setMaybeUninitializedUnresolved(1, true);
+    try source.setMaybeUninitializedReleased(2, true);
 
-    try recycled.refillFrom(&source);
+    var forked = try source.clone();
+    try forked.setMaybeUninitializedUnresolved(0, true);
+    try forked.setMaybeUninitializedReleased(2, false);
 
-    try testing.expectEqual(@as(usize, 4), recycled.maybe_uninitialized_unresolved.capacity());
-    try testing.expect(!recycled.maybe_uninitialized_unresolved.isSet(0));
-    try testing.expect(recycled.maybe_uninitialized_unresolved.isSet(1));
-    try testing.expect(!recycled.maybe_uninitialized_unresolved.isSet(2));
-    try testing.expect(!recycled.maybe_uninitialized_unresolved.isSet(3));
-    try testing.expect(!recycled.maybe_uninitialized_released.isSet(0));
-    try testing.expect(!recycled.maybe_uninitialized_released.isSet(1));
-    try testing.expect(recycled.maybe_uninitialized_released.isSet(2));
-    try testing.expect(!recycled.maybe_uninitialized_released.isSet(3));
+    try testing.expect(!source.maybeUninitializedIsUnresolved(0));
+    try testing.expect(source.maybeUninitializedIsUnresolved(1));
+    try testing.expect(source.maybeUninitializedMayBeReleased(2));
+    try testing.expect(forked.maybeUninitializedIsUnresolved(0));
+    try testing.expect(!forked.maybeUninitializedMayBeReleased(2));
 }
 
 /// Sparse lifetime provenance for one alias-class representative. Ownership
@@ -1833,6 +1658,8 @@ const Certifier = struct {
     maybe_uninitialized: *const MaybeUninitializedConditions,
     values: std.ArrayList(ValueInfo) = .empty,
     lender_arena: std.heap.ArenaAllocator,
+    /// Persistent path-state nodes share this procedure-scoped lifetime.
+    state_arena: std.heap.ArenaAllocator,
     records: collections.DenseMap(LIR.JoinPointId, JoinRecord),
     memo: std.AutoHashMap(MemoEntry, void),
     /// Statements with more than one structural predecessor. Only these
@@ -1844,9 +1671,6 @@ const Certifier = struct {
     /// Hash-conses sparse descriptors within one proc so join comparisons
     /// usually reduce to pointer equality and repeated walks retain no copies.
     provenance_interner: SummaryProvenanceInterner = .empty,
-    /// Retired states for the procedure being certified. Sized per procedure,
-    /// so `certifyProc` drains it before moving on.
-    state_pool: StatePool = .empty,
     /// Reused while normalizing sparse provenance for one summary entry.
     provenance_value_scratch: std.ArrayList(ValueId) = .empty,
     provenance_lender_scratch: std.ArrayList(u32) = .empty,
@@ -1892,6 +1716,7 @@ const Certifier = struct {
     fn deinit(self: *Certifier) void {
         self.values.deinit(self.allocator);
         self.lender_arena.deinit();
+        self.state_arena.deinit();
         self.clearRecords();
         self.records.deinit();
         self.memo.deinit();
@@ -1899,8 +1724,6 @@ const Certifier = struct {
         self.summary_scratch.deinit(self.allocator);
         self.repr_scratch.deinit();
         self.provenance_interner.deinit(self.allocator);
-        self.drainStatePool();
-        self.state_pool.deinit(self.allocator);
         self.provenance_value_scratch.deinit(self.allocator);
         self.provenance_lender_scratch.deinit(self.allocator);
         self.provenance_holder_scratch.deinit(self.allocator);
@@ -1998,7 +1821,7 @@ const Certifier = struct {
     ) CertifyError!ValueId {
         const value = try self.newValue(local, lenders, always_live);
         try state.addBalance(value, units);
-        state.bindValue(local, value);
+        try state.bindValue(local, value);
         return value;
     }
 
@@ -2008,8 +1831,7 @@ const Certifier = struct {
         local: LIR.LocalId,
     ) CertifyError!ValueId {
         const value = try self.newValue(local, &.{}, true);
-        try state.growToValue(value);
-        state.bindValue(local, value);
+        try state.bindValue(local, value);
         return value;
     }
 
@@ -2354,12 +2176,12 @@ const Certifier = struct {
     /// rescues balances that were already failures before field takes.
     fn settleNegativeClaims(self: *Certifier, state: *State) Allocator.Error!void {
         var remaining = false;
-        for (0..state.balance.items.len) |value_index| {
-            while (state.balance.items[value_index] < 0) {
+        for (0..self.values.items.len) |value_index| {
+            while (state.balanceOf(@intCast(value_index)) < 0) {
                 if (!try self.tryClaim(state, @intCast(value_index))) break;
-                state.balance.items[value_index] += 1;
+                try state.addBalance(@intCast(value_index), 1);
             }
-            if (state.balance.items[value_index] < 0) remaining = true;
+            if (state.balanceOf(@intCast(value_index)) < 0) remaining = true;
         }
         state.any_negative = remaining;
     }
@@ -2367,7 +2189,8 @@ const Certifier = struct {
     fn checkLeaks(self: *Certifier, state: *State) CertifyError!void {
         try self.settleNegativeClaims(state);
 
-        for (state.balance.items, 0..) |units, value_index| {
+        for (0..self.values.items.len) |value_index| {
+            const units = state.balanceOf(@intCast(value_index));
             const claims = state.claimsOf(@intCast(value_index));
             if (claims != 0) {
                 // A dismantled value's own unit must still be in hand, and
@@ -2441,7 +2264,7 @@ const Certifier = struct {
             if (self.values.items[value].origin != param or
                 state.balanceOf(value) != 1 or
                 state.claimsOf(value) != 0 or
-                (value < state.holder.items.len and state.holder.items[value] != no_value))
+                state.holderOf(value) != no_value)
             {
                 return self.fail(
                     "outcome {d} did not preserve the exact entry unit of parameter {d}",
@@ -2862,27 +2685,16 @@ const Certifier = struct {
         return hasher.final();
     }
 
-    /// Frees every recycled state. Buffers are sized for one procedure's
-    /// local count, so they must not outlive it.
-    fn drainStatePool(self: *Certifier) void {
-        while (self.state_pool.pop()) |retired| {
-            var state = retired;
-            state.pool = null;
-            state.freeBuffers();
-        }
-    }
-
     /// Rebuilds a fresh state from an agreed join-entry summary. Alias sets
     /// share one fresh value; borrows are re-linked to the fresh values of the
     /// locals their liveness anchors on.
     fn stateFromSummary(self: *Certifier, summary: []const LocalSummary) CertifyError!State {
-        var state = try State.init(self.allocator, self.local_dense.items, self.proc_locals.items.len);
-        state.pool = &self.state_pool;
+        var state = try State.init(self.state_arena.allocator(), self.local_dense.items, self.proc_locals.items.len);
         errdefer state.deinit();
 
         for (summary, 0..) |entry, dense| {
-            if (entry.maybe_uninitialized_unresolved) state.maybe_uninitialized_unresolved.set(dense);
-            if (entry.maybe_uninitialized_released) state.maybe_uninitialized_released.set(dense);
+            if (entry.maybe_uninitialized_unresolved) try state.setMaybeUninitializedUnresolved(dense, true);
+            if (entry.maybe_uninitialized_released) try state.setMaybeUninitializedReleased(dense, true);
         }
 
         // Allocate every representative before attaching provenance. Lender,
@@ -2910,7 +2722,7 @@ const Certifier = struct {
             if (representative == no_value) {
                 return self.fail("join summary alias at dense local {d} had no representative", .{dense});
             }
-            state.bindValue(self.proc_locals.items[dense], representative);
+            try state.bindValue(self.proc_locals.items[dense], representative);
         }
 
         var dependency_values = std.ArrayList(ValueId).empty;
@@ -2951,7 +2763,6 @@ const Certifier = struct {
                 try state.setHolder(value, dependency_values.items[0]);
             } else if (dependency_values.items.len > 1) {
                 const synthetic_holder = try self.newValue(origin, dependency_values.items, false);
-                try state.growToValue(synthetic_holder);
                 try state.setHolder(value, synthetic_holder);
             }
 
@@ -4533,7 +4344,8 @@ const Certifier = struct {
         // a relevant local; anything else can never be released again. A
         // fully dismantled value is exempt: its unit is already spent by its
         // claims and owes no further release.
-        for (state.balance.items, 0..) |units, value_index| {
+        for (0..self.values.items.len) |value_index| {
+            const units = state.balanceOf(@intCast(value_index));
             if (units == 0) continue;
             if (self.claimsSpendUnit(state, @intCast(value_index))) continue;
             const origin = self.values.items[value_index].origin;
@@ -4582,8 +4394,7 @@ const Certifier = struct {
         self.current_proc = proc_id;
         self.current_sig = self.sigs.get(proc_id);
         self.current_proc_body = body;
-        // Recycled buffers are sized for this procedure's local count.
-        defer self.drainStatePool();
+        _ = self.state_arena.reset(.retain_capacity);
         self.current_return_local = null;
         self.values.clearRetainingCapacity();
         self.provenance_interner.clearRetainingCapacity();
@@ -4642,8 +4453,7 @@ const Certifier = struct {
         try self.collectMemoPoints(body);
         try self.relevant_scratch.resize(self.allocator, self.proc_locals.items.len, false);
 
-        var state = try State.init(self.allocator, self.local_dense.items, self.proc_locals.items.len);
-        state.pool = &self.state_pool;
+        var state = try State.init(self.state_arena.allocator(), self.local_dense.items, self.proc_locals.items.len);
         {
             errdefer state.deinit();
             const proc_args = self.store.getLocalSpan(proc.args);
@@ -4654,8 +4464,7 @@ const Certifier = struct {
                     .owned => _ = try self.bindFresh(&state, param, 1, &.{}),
                     .borrowed => {
                         const value = try self.newValue(param, &.{}, true);
-                        try state.growToValue(value);
-                        state.bindValue(param, value);
+                        try state.bindValue(param, value);
                     },
                 }
             }
@@ -4716,8 +4525,8 @@ const Certifier = struct {
         errdefer body_state.deinit();
         var declared = record.maybe_uninitialized.iterator(.{});
         while (declared.next()) |dense| {
-            body_state.maybe_uninitialized_unresolved.unset(dense);
-            body_state.maybe_uninitialized_released.unset(dense);
+            try body_state.setMaybeUninitializedUnresolved(dense, false);
+            try body_state.setMaybeUninitializedReleased(dense, false);
         }
         try work.append(self.allocator, .{ .segment = .{
             .cursor = record.body,
@@ -4764,9 +4573,9 @@ const Certifier = struct {
                     if (target == return_local) state.result_discriminant = no_dense;
                 }
             }
-            if (state.outcome_discriminants.count() != 0) {
+            if (state.outcomeDiscriminantCount() != 0) {
                 const consumes_refinement = stmt == .switch_stmt and
-                    state.outcome_discriminants.contains(stmt.switch_stmt.cond);
+                    state.hasOutcomeDiscriminant(stmt.switch_stmt.cond);
                 // ARC may insert explicit RC bookkeeping after the source
                 // discriminant read and before its immediately refining
                 // switch. Those statements cannot change the established
@@ -4779,7 +4588,7 @@ const Certifier = struct {
                     stmt_tag == .decref_if_initialized or
                     stmt_tag == .free;
                 if (!consumes_refinement and !preserves_refinement) {
-                    state.outcome_discriminants.clearRetainingCapacity();
+                    state.clearOutcomeDiscriminants();
                 }
             }
             switch (stmt) {
@@ -4793,11 +4602,11 @@ const Certifier = struct {
                         },
                         .discriminant => |op| {
                             const source_value = try self.requireLive(&state, op.source);
-                            _ = state.outcome_discriminants.remove(assign.target);
+                            try state.removeOutcomeDiscriminant(assign.target);
                             if (source_value != no_value and
                                 !self.values.items[source_value].call_outcomes.isEmpty())
                             {
-                                try state.outcome_discriminants.put(self.allocator, assign.target, source_value);
+                                try state.setOutcomeDiscriminant(assign.target, source_value);
                             }
                         },
                         .field => |op| try self.bindPayloadRead(
@@ -4831,11 +4640,11 @@ const Certifier = struct {
                 },
                 .init_uninitialized => |init| {
                     if (self.isRc(init.target)) {
-                        state.bindValue(init.target, no_value);
+                        try state.bindValue(init.target, no_value);
                         const dense = self.denseOf(init.target);
                         if (dense != no_dense) {
-                            state.maybe_uninitialized_unresolved.unset(dense);
-                            state.maybe_uninitialized_released.unset(dense);
+                            try state.setMaybeUninitializedUnresolved(dense, false);
+                            try state.setMaybeUninitializedReleased(dense, false);
                         }
                     }
                     cursor = init.next;
@@ -5041,15 +4850,15 @@ const Certifier = struct {
                     if (assign.target != assign.value) {
                         _ = try self.requireLive(&state, assign.value);
                         if (self.isRc(assign.target)) {
-                            state.bindValue(assign.target, state.valueOf(assign.value));
+                            try state.bindValue(assign.target, state.valueOf(assign.value));
                         }
                     }
                     if (assign.mode == .initialize_join_param and self.maybe_uninitialized.get(assign.target) != null) {
                         const dense = self.denseOf(assign.target);
-                        if (dense != no_dense) state.maybe_uninitialized_unresolved.set(dense);
+                        if (dense != no_dense) try state.setMaybeUninitializedUnresolved(dense, true);
                     }
                     const target_dense = self.denseOf(assign.target);
-                    if (target_dense != no_dense) state.maybe_uninitialized_released.unset(target_dense);
+                    if (target_dense != no_dense) try state.setMaybeUninitializedReleased(target_dense, false);
                     cursor = assign.next;
                 },
                 .debug => |debug_stmt| {
@@ -5089,10 +4898,10 @@ const Certifier = struct {
                     }
                     if (state.valueOf(rc.value) != no_value) {
                         try self.applyRelease(&state, rc.value);
-                        state.bindValue(rc.value, no_value);
-                        if (dense != no_dense) state.maybe_uninitialized_released.set(dense);
+                        try state.bindValue(rc.value, no_value);
+                        if (dense != no_dense) try state.setMaybeUninitializedReleased(dense, true);
                     }
-                    if (dense != no_dense) state.maybe_uninitialized_unresolved.unset(dense);
+                    if (dense != no_dense) try state.setMaybeUninitializedUnresolved(dense, false);
                     cursor = rc.next;
                 },
                 .free => |rc| {
@@ -5102,12 +4911,12 @@ const Certifier = struct {
                 .switch_stmt => |switch_stmt| {
                     _ = try self.requireLive(&state, switch_stmt.cond);
                     const branches = self.store.getCFSwitchBranches(switch_stmt.branches);
-                    const outcome_result = state.outcome_discriminants.get(switch_stmt.cond);
+                    const outcome_result = state.outcomeDiscriminant(switch_stmt.cond);
                     for (0..GuardedList.borrowLen(branches)) |branch_index| {
                         const branch = GuardedList.at(branches, branch_index);
                         var branch_state = try state.clone();
                         errdefer branch_state.deinit();
-                        branch_state.outcome_discriminants.clearRetainingCapacity();
+                        branch_state.clearOutcomeDiscriminants();
                         if (outcome_result) |result| {
                             if (self.callOutcomeMask(result, branch.value)) |mask| {
                                 try self.restoreCallOutcome(&branch_state, result, mask);
@@ -5117,7 +4926,7 @@ const Certifier = struct {
                     }
                     var default_state = try state.clone();
                     errdefer default_state.deinit();
-                    default_state.outcome_discriminants.clearRetainingCapacity();
+                    default_state.clearOutcomeDiscriminants();
                     if (outcome_result) |result| {
                         if (self.defaultCallOutcomeMask(result, branches)) |mask| {
                             try self.restoreCallOutcome(&default_state, result, mask);
@@ -5150,16 +4959,16 @@ const Certifier = struct {
 
                                 var initialized_state = try state.clone();
                                 errdefer initialized_state.deinit();
-                                initialized_state.markDefinitelyInitialized(payload_value);
-                                if (payload_dense != no_dense) initialized_state.maybe_uninitialized_unresolved.unset(payload_dense);
+                                try initialized_state.markDefinitelyInitialized(payload_value);
+                                if (payload_dense != no_dense) try initialized_state.setMaybeUninitializedUnresolved(payload_dense, false);
                                 try work.append(self.allocator, .{ .segment = .{ .cursor = switch_stmt.initialized_branch, .state = initialized_state, .origin_join = segment.origin_join } });
 
                                 var uninitialized_state = try state.clone();
                                 errdefer uninitialized_state.deinit();
                                 const units = uninitialized_state.balanceOf(payload_value);
                                 if (units > 0) try uninitialized_state.addBalance(payload_value, -units);
-                                uninitialized_state.bindValue(switch_stmt.payload, no_value);
-                                if (payload_dense != no_dense) uninitialized_state.maybe_uninitialized_unresolved.unset(payload_dense);
+                                try uninitialized_state.bindValue(switch_stmt.payload, no_value);
+                                if (payload_dense != no_dense) try uninitialized_state.setMaybeUninitializedUnresolved(payload_dense, false);
                                 try work.append(self.allocator, .{ .segment = .{ .cursor = switch_stmt.uninitialized_branch, .state = uninitialized_state, .origin_join = segment.origin_join } });
                                 return;
                             }
@@ -5172,7 +4981,7 @@ const Certifier = struct {
                             switch_stmt.uninitialized_branch;
                         var branch_state = try state.clone();
                         errdefer branch_state.deinit();
-                        if (payload_dense != no_dense) branch_state.maybe_uninitialized_unresolved.unset(payload_dense);
+                        if (payload_dense != no_dense) try branch_state.setMaybeUninitializedUnresolved(payload_dense, false);
                         try work.append(self.allocator, .{ .segment = .{ .cursor = target, .state = branch_state, .origin_join = segment.origin_join } });
                         return;
                     }
@@ -5194,7 +5003,7 @@ const Certifier = struct {
                         switch (step.capture) {
                             .discard => {},
                             .view => |local| if (self.isRc(local)) {
-                                match_state.bindValue(local, source_value);
+                                try match_state.bindValue(local, source_value);
                             },
                         }
                     }
@@ -5218,7 +5027,7 @@ const Certifier = struct {
                             switch (step.capture) {
                                 .discard => {},
                                 .view => |local| if (self.isRc(local)) {
-                                    match_state.bindValue(local, source_value);
+                                    try match_state.bindValue(local, source_value);
                                 },
                             }
                         }
@@ -5235,8 +5044,8 @@ const Certifier = struct {
                     for (0..GuardedList.borrowLen(maybe_uninitialized_params)) |index| {
                         const dense = self.denseOf(GuardedList.at(maybe_uninitialized_params, index));
                         if (dense != no_dense) {
-                            state.maybe_uninitialized_unresolved.set(dense);
-                            state.maybe_uninitialized_released.unset(dense);
+                            try state.setMaybeUninitializedUnresolved(dense, true);
+                            try state.setMaybeUninitializedReleased(dense, false);
                         }
                     }
                     const record = try self.records.getOrPut(join_stmt.id);
@@ -5490,7 +5299,7 @@ const Certifier = struct {
                 .{ @intFromEnum(target), @intFromEnum(source) },
             );
         }
-        state.bindValue(target, source_value);
+        try state.bindValue(target, source_value);
     }
 
     fn bindSameValue(self: *Certifier, state: *State, target: LIR.LocalId, source: LIR.LocalId) CertifyError!void {
@@ -5505,7 +5314,7 @@ const Certifier = struct {
                 .{ @intFromEnum(target), @intFromEnum(source) },
             );
         }
-        state.bindValue(target, source_value);
+        try state.bindValue(target, source_value);
     }
 
     fn applyRelease(self: *Certifier, state: *State, local: LIR.LocalId) CertifyError!void {
@@ -5700,8 +5509,7 @@ const Certifier = struct {
                     // The payload source is implicit (the executing frame's
                     // capture environment); it is live for the whole call.
                     target_value = try self.newValue(assign.target, &.{}, true);
-                    try state.growToValue(target_value);
-                    state.bindValue(assign.target, target_value);
+                    try state.bindValue(assign.target, target_value);
                 } else {
                     target_value = try self.bindFresh(state, assign.target, 0, lenders_buffer[0..lender_count]);
                 }
@@ -5843,18 +5651,20 @@ test "certifier state indexes explicit proc locals" {
     const first: LIR.LocalId = @enumFromInt(1);
     const second: LIR.LocalId = @enumFromInt(3);
     const local_dense = [_]u32{ no_dense, 0, no_dense, 1 };
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
 
-    var state = try State.init(testing.allocator, &local_dense, 2);
+    var state = try State.init(arena.allocator(), &local_dense, 2);
     defer state.deinit();
-    state.bindValue(first, 7);
-    state.bindValue(second, 11);
+    try state.bindValue(first, 7);
+    try state.bindValue(second, 11);
 
     try testing.expectEqual(@as(ValueId, 7), state.valueOf(first));
     try testing.expectEqual(@as(ValueId, 11), state.valueOf(second));
 
     var cloned = try state.clone();
     defer cloned.deinit();
-    cloned.bindValue(first, 13);
+    try cloned.bindValue(first, 13);
     try testing.expectEqual(@as(ValueId, 13), cloned.valueOf(first));
     try testing.expectEqual(@as(ValueId, 7), state.valueOf(first));
 }
@@ -8276,23 +8086,4 @@ test "certify rejects consuming Box.unbox after the ARC boundary" {
 
     try testing.expectError(error.Certification, f.certify());
     try testing.expect(std.mem.find(u8, f.diag.message(), "post-ARC LIR retained a consuming Box.unbox") != null);
-}
-
-test "reused certifier state copies maybe-uninitialized bits exactly" {
-    const local_dense = [_]u32{ 0, 1, 2, 3 };
-
-    var source = try State.init(testing.allocator, &local_dense, local_dense.len);
-    defer source.deinit();
-    source.maybe_uninitialized_unresolved.set(1);
-    source.maybe_uninitialized_released.set(2);
-
-    var reused = try State.init(testing.allocator, &local_dense, local_dense.len);
-    defer reused.deinit();
-    reused.maybe_uninitialized_unresolved.set(0);
-    reused.maybe_uninitialized_released.set(3);
-
-    try reused.refillFrom(&source);
-
-    try testing.expect(reused.maybe_uninitialized_unresolved.eql(source.maybe_uninitialized_unresolved));
-    try testing.expect(reused.maybe_uninitialized_released.eql(source.maybe_uninitialized_released));
 }

--- a/src/lir/arc_state.zig
+++ b/src/lir/arc_state.zig
@@ -1,0 +1,366 @@
+//! Persistent sparse snapshots for exact procedure-local ARC facts.
+
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+/// A bounded-depth radix tree whose absent entries have one caller-declared
+/// value. Copying a snapshot shares its root; changing one entry allocates
+/// only the nodes on that entry's path. Depth grows only as needed and is
+/// bounded for every `u32` index, so update cost does not depend on procedure
+/// width.
+pub fn Snapshot(comptime T: type, comptime empty: T) type {
+    return struct {
+        const Self = @This();
+        // Eight-way nodes balance lookup depth against copied null child
+        // pointers; wider nodes make sparse ARC path-state updates larger,
+        // while narrower nodes make every query need too many branches.
+        const radix_bits = 3;
+        const radix = 1 << radix_bits;
+        const radix_mask = radix - 1;
+        const leaf_bits = radix_bits;
+        const max_branch_depth = 10;
+
+        const Branch = struct {
+            children: [radix]?*const anyopaque,
+        };
+
+        const Leaf = struct {
+            values: [radix]T,
+        };
+
+        allocator: Allocator,
+        depth: u8,
+        root: ?*const anyopaque = null,
+
+        pub fn init(allocator: Allocator, entry_count: usize) Self {
+            const highest: u32 = if (entry_count == 0) 0 else @intCast(entry_count - 1);
+            const depth = depthFor(highest);
+            std.debug.assert(depth <= max_branch_depth);
+            return .{ .allocator = allocator, .depth = depth };
+        }
+
+        pub fn clone(self: *const Self) Self {
+            return self.*;
+        }
+
+        pub fn assignShared(self: *Self, source: *const Self) void {
+            std.debug.assert(self.depth == source.depth);
+            self.root = source.root;
+        }
+
+        pub fn clear(self: *Self) void {
+            self.root = null;
+        }
+
+        pub fn get(self: *const Self, index: u32) T {
+            if (depthFor(index) > self.depth) return empty;
+            var node = self.root orelse return empty;
+            var depth: usize = self.depth;
+            while (depth > 0) : (depth -= 1) {
+                const branch: *const Branch = @ptrCast(@alignCast(node));
+                const shift: u5 = @intCast(leaf_bits + (depth - 1) * radix_bits);
+                const slot: usize = @intCast((index >> shift) & radix_mask);
+                node = branch.children[slot] orelse return empty;
+            }
+            const leaf: *const Leaf = @ptrCast(@alignCast(node));
+            return leaf.values[index & radix_mask];
+        }
+
+        pub fn put(self: *Self, index: u32, value: T) Allocator.Error!void {
+            if (std.meta.eql(self.get(index), value)) return;
+            const required_depth = depthFor(index);
+            while (self.depth < required_depth) {
+                var children = [_]?*const anyopaque{null} ** radix;
+                children[0] = self.root;
+                const branch = try self.allocator.create(Branch);
+                branch.* = .{ .children = children };
+                self.root = branch;
+                self.depth += 1;
+            }
+            self.root = try self.putNode(self.root, self.depth, index, value);
+        }
+
+        /// Updates a snapshot whose entire tree is known to have exactly one
+        /// owner. This is for constructing a fresh path state before its first
+        /// control-flow fork; shared snapshots must use `put`.
+        pub fn putUnique(self: *Self, index: u32, value: T) Allocator.Error!void {
+            if (std.meta.eql(self.get(index), value)) return;
+            const required_depth = depthFor(index);
+            while (self.depth < required_depth) {
+                var children = [_]?*const anyopaque{null} ** radix;
+                children[0] = self.root;
+                const branch = try self.allocator.create(Branch);
+                branch.* = .{ .children = children };
+                self.root = branch;
+                self.depth += 1;
+            }
+            self.root = try self.putNodeUnique(self.root, self.depth, index, value);
+        }
+
+        pub fn eql(self: *const Self, other: *const Self) bool {
+            if (self.root == other.root) return true;
+            std.debug.assert(self.depth == other.depth);
+            return eqlNode(self.root, other.root, self.depth);
+        }
+
+        /// Pointwise meet over two snapshots. `meetFn` must be idempotent and
+        /// must return `empty` when either input is `empty`; those are the
+        /// lattice laws that permit pointer sharing and absent-subtree skips.
+        pub fn meetWith(
+            self: *Self,
+            other: *const Self,
+            context: anytype,
+            comptime meetFn: fn (@TypeOf(context), T, T) T,
+        ) Allocator.Error!bool {
+            if (self.root == other.root) return false;
+            std.debug.assert(self.depth == other.depth);
+            const old_root = self.root;
+            self.root = try self.meetNode(self.root, other.root, self.depth, context, meetFn);
+            return self.root != old_root;
+        }
+
+        /// Pointwise join over two snapshots. `joinFn` must be idempotent and
+        /// must return its nonempty input when the other input is `empty`.
+        pub fn joinWith(
+            self: *Self,
+            other: *const Self,
+            context: anytype,
+            comptime joinFn: fn (@TypeOf(context), T, T) T,
+        ) Allocator.Error!bool {
+            if (self.root == other.root or other.root == null) return false;
+            std.debug.assert(self.depth == other.depth);
+            const old_root = self.root;
+            self.root = try self.joinNode(self.root, other.root, self.depth, context, joinFn);
+            return self.root != old_root;
+        }
+
+        fn putNode(
+            self: *Self,
+            maybe_node: ?*const anyopaque,
+            depth: usize,
+            index: u32,
+            value: T,
+        ) Allocator.Error!?*const anyopaque {
+            if (depth == 0) {
+                var values = [_]T{empty} ** radix;
+                if (maybe_node) |node| {
+                    const leaf: *const Leaf = @ptrCast(@alignCast(node));
+                    values = leaf.values;
+                }
+                values[index & radix_mask] = value;
+                var all_empty = true;
+                for (values) |entry| {
+                    if (!std.meta.eql(entry, empty)) {
+                        all_empty = false;
+                        break;
+                    }
+                }
+                if (all_empty) return null;
+                const leaf = try self.allocator.create(Leaf);
+                leaf.* = .{ .values = values };
+                return leaf;
+            }
+
+            var children = [_]?*const anyopaque{null} ** radix;
+            if (maybe_node) |node| {
+                const branch: *const Branch = @ptrCast(@alignCast(node));
+                children = branch.children;
+            }
+            const shift: u5 = @intCast(leaf_bits + (depth - 1) * radix_bits);
+            const slot: usize = @intCast((index >> shift) & radix_mask);
+            children[slot] = try self.putNode(children[slot], depth - 1, index, value);
+            for (children) |child| {
+                if (child != null) {
+                    const branch = try self.allocator.create(Branch);
+                    branch.* = .{ .children = children };
+                    return branch;
+                }
+            }
+            return null;
+        }
+
+        fn putNodeUnique(
+            self: *Self,
+            maybe_node: ?*const anyopaque,
+            depth: usize,
+            index: u32,
+            value: T,
+        ) Allocator.Error!?*const anyopaque {
+            if (depth == 0) {
+                const leaf = if (maybe_node) |node|
+                    @as(*Leaf, @ptrCast(@alignCast(@constCast(node))))
+                else blk: {
+                    const fresh = try self.allocator.create(Leaf);
+                    fresh.* = .{ .values = [_]T{empty} ** radix };
+                    break :blk fresh;
+                };
+                leaf.values[index & radix_mask] = value;
+                for (leaf.values) |entry| {
+                    if (!std.meta.eql(entry, empty)) return leaf;
+                }
+                return null;
+            }
+
+            const branch = if (maybe_node) |node|
+                @as(*Branch, @ptrCast(@alignCast(@constCast(node))))
+            else blk: {
+                const fresh = try self.allocator.create(Branch);
+                fresh.* = .{ .children = [_]?*const anyopaque{null} ** radix };
+                break :blk fresh;
+            };
+            const shift: u5 = @intCast(leaf_bits + (depth - 1) * radix_bits);
+            const slot: usize = @intCast((index >> shift) & radix_mask);
+            branch.children[slot] = try self.putNodeUnique(branch.children[slot], depth - 1, index, value);
+            for (branch.children) |child| {
+                if (child != null) return branch;
+            }
+            return null;
+        }
+
+        fn meetNode(
+            self: *Self,
+            lhs: ?*const anyopaque,
+            rhs: ?*const anyopaque,
+            depth: usize,
+            context: anytype,
+            comptime meetFn: fn (@TypeOf(context), T, T) T,
+        ) Allocator.Error!?*const anyopaque {
+            if (lhs == rhs) return lhs;
+            if (lhs == null or rhs == null) return null;
+
+            if (depth == 0) {
+                const lhs_leaf: *const Leaf = @ptrCast(@alignCast(lhs.?));
+                const rhs_leaf: *const Leaf = @ptrCast(@alignCast(rhs.?));
+                var values: [radix]T = undefined;
+                var same_as_lhs = true;
+                var all_empty = true;
+                for (&values, lhs_leaf.values, rhs_leaf.values) |*result, left, right| {
+                    result.* = meetFn(context, left, right);
+                    if (!std.meta.eql(result.*, left)) same_as_lhs = false;
+                    if (!std.meta.eql(result.*, empty)) all_empty = false;
+                }
+                if (same_as_lhs) return lhs;
+                if (all_empty) return null;
+                const leaf = try self.allocator.create(Leaf);
+                leaf.* = .{ .values = values };
+                return leaf;
+            }
+
+            const lhs_branch: *const Branch = @ptrCast(@alignCast(lhs.?));
+            const rhs_branch: *const Branch = @ptrCast(@alignCast(rhs.?));
+            var children: [radix]?*const anyopaque = undefined;
+            var same_as_lhs = true;
+            var all_empty = true;
+            for (&children, lhs_branch.children, rhs_branch.children) |*result, left, right| {
+                result.* = try self.meetNode(left, right, depth - 1, context, meetFn);
+                if (result.* != left) same_as_lhs = false;
+                if (result.* != null) all_empty = false;
+            }
+            if (same_as_lhs) return lhs;
+            if (all_empty) return null;
+            const branch = try self.allocator.create(Branch);
+            branch.* = .{ .children = children };
+            return branch;
+        }
+
+        fn joinNode(
+            self: *Self,
+            lhs: ?*const anyopaque,
+            rhs: ?*const anyopaque,
+            depth: usize,
+            context: anytype,
+            comptime joinFn: fn (@TypeOf(context), T, T) T,
+        ) Allocator.Error!?*const anyopaque {
+            if (lhs == rhs or rhs == null) return lhs;
+            if (lhs == null) return rhs;
+
+            if (depth == 0) {
+                const lhs_leaf: *const Leaf = @ptrCast(@alignCast(lhs.?));
+                const rhs_leaf: *const Leaf = @ptrCast(@alignCast(rhs.?));
+                var values: [radix]T = undefined;
+                var same_as_lhs = true;
+                for (&values, lhs_leaf.values, rhs_leaf.values) |*result, left, right| {
+                    result.* = joinFn(context, left, right);
+                    if (!std.meta.eql(result.*, left)) same_as_lhs = false;
+                }
+                if (same_as_lhs) return lhs;
+                const leaf = try self.allocator.create(Leaf);
+                leaf.* = .{ .values = values };
+                return leaf;
+            }
+
+            const lhs_branch: *const Branch = @ptrCast(@alignCast(lhs.?));
+            const rhs_branch: *const Branch = @ptrCast(@alignCast(rhs.?));
+            var children: [radix]?*const anyopaque = undefined;
+            var same_as_lhs = true;
+            for (&children, lhs_branch.children, rhs_branch.children) |*result, left, right| {
+                result.* = try self.joinNode(left, right, depth - 1, context, joinFn);
+                if (result.* != left) same_as_lhs = false;
+            }
+            if (same_as_lhs) return lhs;
+            const branch = try self.allocator.create(Branch);
+            branch.* = .{ .children = children };
+            return branch;
+        }
+
+        fn eqlNode(lhs: ?*const anyopaque, rhs: ?*const anyopaque, depth: usize) bool {
+            if (lhs == rhs) return true;
+            if (lhs == null or rhs == null) return false;
+            if (depth == 0) {
+                const lhs_leaf: *const Leaf = @ptrCast(@alignCast(lhs.?));
+                const rhs_leaf: *const Leaf = @ptrCast(@alignCast(rhs.?));
+                for (lhs_leaf.values, rhs_leaf.values) |left, right| {
+                    if (!std.meta.eql(left, right)) return false;
+                }
+                return true;
+            }
+            const lhs_branch: *const Branch = @ptrCast(@alignCast(lhs.?));
+            const rhs_branch: *const Branch = @ptrCast(@alignCast(rhs.?));
+            for (lhs_branch.children, rhs_branch.children) |left, right| {
+                if (!eqlNode(left, right, depth - 1)) return false;
+            }
+            return true;
+        }
+
+        fn depthFor(index: u32) u8 {
+            var depth: u8 = 0;
+            var covered_bits: u8 = leaf_bits;
+            while (covered_bits < 32 and (index >> @intCast(covered_bits)) != 0) {
+                depth += 1;
+                covered_bits += radix_bits;
+            }
+            return depth;
+        }
+    };
+}
+
+test "persistent sparse snapshots share forks and meet exactly" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const Sparse = Snapshot(u32, 0);
+    var left = Sparse.init(arena.allocator(), 100_000);
+    try left.putUnique(4, 7);
+    try left.putUnique(70_000, 9);
+
+    var right = left.clone();
+    try right.put(4, 3);
+    try right.put(90_000, 11);
+
+    try std.testing.expectEqual(@as(u32, 7), left.get(4));
+    try std.testing.expectEqual(@as(u32, 0), left.get(90_000));
+    try std.testing.expectEqual(@as(u32, 3), right.get(4));
+
+    const meet = struct {
+        fn run(_: void, lhs: u32, rhs: u32) u32 {
+            if (lhs == 0 or rhs == 0) return 0;
+            return @min(lhs, rhs);
+        }
+    }.run;
+    try std.testing.expect(try left.meetWith(&right, {}, meet));
+    try std.testing.expectEqual(@as(u32, 3), left.get(4));
+    try std.testing.expectEqual(@as(u32, 9), left.get(70_000));
+    try std.testing.expectEqual(@as(u32, 0), left.get(90_000));
+    try std.testing.expect(left.eql(&left.clone()));
+}


### PR DESCRIPTION
Wide generated parsers made ARC and its debug certifier copy procedure-width ownership and liveness state at every control-flow fork, producing quadratic peak memory. This replaces those dense snapshots with exact persistent sparse radix trees, packs liveness bits into words, and updates fresh one-owner states in place until their first fork so unchanged paths are shared without weakening ARC or certification. Fixes #11100.