### PR TITLE
Preserve module basenames on checked cache hits

### DIFF
--- a/design.md
+++ b/design.md
@@ -1754,6 +1754,14 @@ a function of source bytes alone—a type module's main type takes its name
 from the module's file name—so no key or identity derived from module
 content may be computed from source bytes without the module name.
 
+`ModuleEnv.module_name` is that source-visible final path segment, such as
+`Foo` for the normalized logical path `Folder/Foo`. The logical path belongs
+to module discovery and coordinator state; it must never replace the
+source-visible name when restoring a serialized `ModuleEnv`. Because the
+runtime slice itself is not serialized, a cache consumer supplies the exact
+source-visible name already produced by the current canonicalization, and a
+debug invariant checks it against the serialized `display_module_name_idx`.
+
 The cache id does not include target ABI, pointer width, layout ids, field offsets,
 alignment decisions, backend choice, object format, code-generation options,
 post-check lowering strategy, or post-check specialization state.

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -925,8 +925,10 @@ external_decls: CIR.ExternalDecl.SafeList,
 imports: CIR.Import.Store,
 /// Source-relative file imports read while canonicalizing this module.
 file_dependencies: FileDependency.SafeList,
-/// The module's name as a string
-/// This is needed for import resolution to match import names to modules
+/// The module's source-visible final path segment, such as `Foo` for the
+/// logical module path `Folder/Foo`.
+/// Used for type-module main types and associated-name construction; logical
+/// import paths remain in coordinator state.
 module_name: []const u8,
 /// The module's bare name as an interned identifier (e.g., "Color").
 /// Used for display, type module validation, and method name construction.
@@ -4093,7 +4095,7 @@ pub const Serialized = extern struct {
         base_addr: usize,
         gpa: std.mem.Allocator,
         source: []const u8,
-        module_name: []const u8,
+        module_basename: []const u8,
     ) std.mem.Allocator.Error!*Self {
         // Allocate a fresh ModuleEnv on the heap
         const env = try gpa.create(Self);
@@ -4122,7 +4124,7 @@ pub const Serialized = extern struct {
             .external_decls = self.external_decls.deserializeInto(base_addr),
             .imports = try self.imports.deserializeInto(base_addr, gpa),
             .file_dependencies = self.file_dependencies.deserializeInto(base_addr),
-            .module_name = module_name,
+            .module_name = module_basename,
             .display_module_name_idx = @bitCast(self.display_module_name_idx_reserved),
             .qualified_module_ident = @bitCast(self.qualified_module_ident_reserved),
             .module_identities = self.module_identities.deserialize(base_addr),
@@ -4153,6 +4155,8 @@ pub const Serialized = extern struct {
             .record_omitted_defaults = self.record_omitted_defaults.deserializeInto(base_addr),
         };
 
+        env.debugAssertModuleBasename();
+
         return env;
     }
 
@@ -4164,13 +4168,13 @@ pub const Serialized = extern struct {
         base_addr: usize,
         gpa: std.mem.Allocator,
         source: []const u8,
-        module_name: []const u8,
+        module_basename: []const u8,
     ) error{CorruptSerializedModuleEnv}!Self {
         if (self.imports.imports.len != 0) return error.CorruptSerializedModuleEnv;
         if (self.imports.import_idents.len != 0) return error.CorruptSerializedModuleEnv;
         if (self.imports.resolved_modules.len != 0) return error.CorruptSerializedModuleEnv;
 
-        return Self{
+        const env = Self{
             .gpa = gpa,
             .common = self.common.deserializeInto(base_addr, source),
             .types = self.types.deserializeInto(base_addr, gpa),
@@ -4193,7 +4197,7 @@ pub const Serialized = extern struct {
             .external_decls = self.external_decls.deserializeInto(base_addr),
             .imports = CIR.Import.Store.init(),
             .file_dependencies = self.file_dependencies.deserializeInto(base_addr),
-            .module_name = module_name,
+            .module_name = module_basename,
             .display_module_name_idx = @bitCast(self.display_module_name_idx_reserved),
             .qualified_module_ident = @bitCast(self.qualified_module_ident_reserved),
             .module_identities = self.module_identities.deserialize(base_addr),
@@ -4223,6 +4227,9 @@ pub const Serialized = extern struct {
             .rejected_static_dispatches = self.rejected_static_dispatches.deserializeInto(base_addr),
             .record_omitted_defaults = self.record_omitted_defaults.deserializeInto(base_addr),
         };
+
+        env.debugAssertModuleBasename();
+        return env;
     }
 
     /// Deserialize with mutable type store and node store for cache modules.
@@ -4234,7 +4241,7 @@ pub const Serialized = extern struct {
         base_addr: usize,
         gpa: std.mem.Allocator,
         source: []const u8,
-        module_name: []const u8,
+        module_basename: []const u8,
     ) std.mem.Allocator.Error!*Self {
         // Allocate a fresh ModuleEnv on the heap
         const env = try gpa.create(Self);
@@ -4264,7 +4271,7 @@ pub const Serialized = extern struct {
             .external_decls = self.external_decls.deserializeInto(base_addr),
             .imports = try self.imports.deserializeInto(base_addr, gpa),
             .file_dependencies = self.file_dependencies.deserializeInto(base_addr),
-            .module_name = module_name,
+            .module_name = module_basename,
             .display_module_name_idx = @bitCast(self.display_module_name_idx_reserved),
             .qualified_module_ident = @bitCast(self.qualified_module_ident_reserved),
             .module_identities = self.module_identities.deserialize(base_addr),
@@ -4297,9 +4304,25 @@ pub const Serialized = extern struct {
             .record_omitted_defaults = try self.record_omitted_defaults.deserializeWithCopy(base_addr, gpa),
         };
 
+        env.debugAssertModuleBasename();
+
         return env;
     }
 };
+
+/// Assert that the runtime-only module basename agrees with its serialized
+/// identifier. The basename is supplied by the cache consumer because its
+/// slice is not relocatable; it must never be replaced with a logical path.
+fn debugAssertModuleBasename(self: *const Self) void {
+    if (comptime builtin.mode == .Debug) {
+        std.debug.assert(!self.display_module_name_idx.isNone());
+        std.debug.assert(std.mem.eql(
+            u8,
+            self.module_name,
+            self.getIdent(self.display_module_name_idx),
+        ));
+    }
+}
 
 /// Convert a type into a node index
 pub fn nodeIdxFrom(idx: anytype) Node.Idx {

--- a/src/compile/cache_module.zig
+++ b/src/compile/cache_module.zig
@@ -178,8 +178,10 @@ pub const CacheModule = struct {
     }
 
     /// Restore ModuleEnv from the cached data
-    /// IMPORTANT: This expects source to remain valid for the lifetime of the restored ModuleEnv.
-    pub fn restore(self: *const CacheModule, allocator: Allocator, module_name: []const u8, source: []const u8) (Allocator.Error || error{ BufferTooSmall, CorruptSerializedModuleEnv })!*ModuleEnv {
+    /// `module_basename` is the source-visible final path segment, not the
+    /// logical import path. Both it and `source` must remain valid for the
+    /// lifetime of the restored ModuleEnv.
+    pub fn restore(self: *const CacheModule, allocator: Allocator, module_basename: []const u8, source: []const u8) (Allocator.Error || error{ BufferTooSmall, CorruptSerializedModuleEnv })!*ModuleEnv {
         // The entire data section contains the serialized ModuleEnv
         const serialized_data = self.data;
 
@@ -197,7 +199,7 @@ pub const CacheModule = struct {
         const base_addr = @intFromPtr(serialized_data.ptr);
 
         // Deserialize the ModuleEnv with mutable types so it can be type-checked further
-        const module_env_ptr: *ModuleEnv = try deserialized_ptr.deserializeWithMutableTypes(base_addr, allocator, source, module_name);
+        const module_env_ptr: *ModuleEnv = try deserialized_ptr.deserializeWithMutableTypes(base_addr, allocator, source, module_basename);
 
         return module_env_ptr;
     }

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -3306,7 +3306,7 @@ pub const Coordinator = struct {
             @intFromPtr(buffer.ptr),
             module_alloc,
             source,
-            mod.name,
+            current_env.module_name,
         ) catch {
             manager.stats.recordInvalidation();
             return false;

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -146,6 +146,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10849_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10865_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10870_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10897_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10935_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10977_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10980_test.zig"));

--- a/src/compile/test/issue_10897_test.zig
+++ b/src/compile/test/issue_10897_test.zig
@@ -1,0 +1,162 @@
+//! Regression test for issue #10897.
+//!
+//! repro for https://github.com/roc-lang/roc/issues/10897
+//!
+//! `import Folder/Foo exposing [log!]` must resolve the same way whether
+//! `Folder/Foo` was compiled from source or restored from the checked-module
+//! cache. Expected: both compiles report no user errors. Actual: the second
+//! compile (the one that hits the cache) reports `Value Not Exposed` for `log!`
+//! plus `Name Not In Scope` at the call site.
+
+const std = @import("std");
+const build_options = @import("build_options");
+const collections = @import("collections");
+const eval = @import("eval");
+const roc_target = @import("roc_target");
+
+const CacheManager = @import("../cache_manager.zig").CacheManager;
+const Coordinator = @import("../coordinator.zig").Coordinator;
+const CoreCtx = @import("ctx").CoreCtx;
+
+const CompileResult = struct {
+    has_user_errors: bool,
+    cache_hits: u32,
+};
+
+fn compileWithCache(
+    gpa: std.mem.Allocator,
+    cache_dir: []const u8,
+    app_path: []const u8,
+    label: []const u8,
+) !CompileResult {
+    const roc_ctx = CoreCtx.os(gpa, gpa, std.testing.io);
+
+    var cache_manager = CacheManager.init(gpa, .{
+        .enabled = true,
+        .cache_dir = cache_dir,
+    }, roc_ctx);
+
+    var builtin_modules = try eval.BuiltinModules.init(gpa);
+    defer builtin_modules.deinit();
+
+    var coord = try Coordinator.init(
+        gpa,
+        .single_threaded,
+        1,
+        roc_target.RocTarget.detectNative(),
+        &builtin_modules,
+        build_options.compiler_version,
+        &cache_manager,
+        roc_ctx,
+    );
+    defer coord.deinit();
+    coord.enable_hosted_transform = true;
+
+    var arena_impl = collections.SingleThreadArena.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    try coord.start();
+    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+    try coord.coordinatorLoop();
+
+    var reports = coord.iterReports();
+    while (reports.next()) |entry| {
+        switch (entry.report.severity) {
+            .warning => {},
+            .runtime_error, .fatal => std.debug.print(
+                "{s} compile reported {s}: {s}\n",
+                .{ label, @tagName(entry.report.severity), entry.report.title },
+            ),
+        }
+    }
+
+    return .{
+        .has_user_errors = coord.hasUserErrors(),
+        .cache_hits = coord.getBuildStats().cache_hits,
+    };
+}
+
+test "issue 10897: a value exposed from a directory-qualified module still resolves on a cache hit" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "cache");
+    try tmp_dir.dir.createDirPath(io, "app/.roc_test_platform");
+    try tmp_dir.dir.createDirPath(io, "app/Folder");
+
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "app/main.roc",
+        .data =
+        \\app [main!] { pf: platform "./.roc_test_platform/main.roc" }
+        \\
+        \\import Folder/Foo exposing [log!]
+        \\
+        \\main! = |_args| {
+        \\    log!("Hello World!")
+        \\    Ok({})
+        \\}
+        ,
+    });
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "app/Folder/Foo.roc",
+        .data =
+        \\import pf.Stdout
+        \\
+        \\Foo := {}.{
+        \\    log! = |message| Stdout.line!(message)
+        \\}
+        ,
+    });
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "app/.roc_test_platform/main.roc",
+        .data =
+        \\platform ""
+        \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
+        \\    exposes [Stdout]
+        \\    packages {}
+        \\    provides { "roc_main": main_for_host! }
+        \\    hosted {
+        \\        "roc_stdout_line": Stdout.line!,
+        \\    }
+        \\
+        \\import Stdout
+        \\
+        \\main_for_host! : List(Str) => I8
+        \\main_for_host! = |args|
+        \\    match main!(args) {
+        \\        Ok({}) => 0
+        \\        Err(Exit(code)) => code
+        \\        Err(_) => 1
+        \\    }
+        ,
+    });
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "app/.roc_test_platform/Stdout.roc",
+        .data =
+        \\Stdout := [].{
+        \\    line! : Str => {}
+        \\}
+        ,
+    });
+
+    const cache_dir = try tmp_dir.dir.realPathFileAlloc(io, "cache", gpa);
+    defer gpa.free(cache_dir);
+    const app_path = try tmp_dir.dir.realPathFileAlloc(io, "app/main.roc", gpa);
+    defer gpa.free(app_path);
+
+    const first = try compileWithCache(gpa, cache_dir, app_path, "first");
+    try std.testing.expect(!first.has_user_errors);
+
+    const second = try compileWithCache(gpa, cache_dir, app_path, "second");
+    // The second compile must actually exercise the cache, otherwise it would
+    // just repeat the first compile and prove nothing.
+    if (second.cache_hits == 0) {
+        std.debug.print("second compile hit no cached modules\n", .{});
+        return error.CheckedModuleCacheNotExercised;
+    }
+    try std.testing.expect(!second.has_user_errors);
+}

--- a/src/compile/test/issue_10897_test.zig
+++ b/src/compile/test/issue_10897_test.zig
@@ -23,12 +23,18 @@ const CompileResult = struct {
     cache_hits: u32,
 };
 
+const CompileError = eval.BuiltinModules.InitError || std.Thread.SpawnError || Coordinator.AppDiscoveryError || error{
+    UnsupportedBuiltinAnnotationOnly,
+    BuiltinLowLevelAnnotationMustBeFunction,
+    LowLevelOperationsNotFound,
+};
+
 fn compileWithCache(
     gpa: std.mem.Allocator,
     cache_dir: []const u8,
     app_path: []const u8,
     label: []const u8,
-) !CompileResult {
+) CompileError!CompileResult {
     const roc_ctx = CoreCtx.os(gpa, gpa, std.testing.io);
 
     var cache_manager = CacheManager.init(gpa, .{


### PR DESCRIPTION
Checked-module cache restoration now preserves a module's source-visible basename instead of substituting its directory-qualified logical import path. This keeps associated exposed values identical on cold and warm compiles, while a debug invariant prevents the two identities from drifting again.

Fixes #10897.