### PR TITLE
Fix generated codec nominal subject identity

### DIFF
--- a/design.md
+++ b/design.md
@@ -3217,6 +3217,19 @@ evidence still distinguish genuinely different targets. The grounding call
 index remains only activation and debug metadata. These audits and their
 consumption bits are absent from release compiler builds.
 
+Backed named applications keep independent main union-find classes so each
+request retains its own representation witness. An explicit checked/request or
+deferred-template relation therefore also records the matching applications in
+a sparse nominal-identity union-find. Independently allocated wrappers for the
+same application join that identity through their exact permanent backing
+witness; the nominal-backing cache keys that witness by the complete
+declaration and all type arguments, including phantom arguments. Generated
+codec call selection consumes this producer-written identity directly. It does
+not recursively compare type arguments, open a backing to reconstruct nominal
+identity, or merge the representation-owning main classes. Nominal subject
+comparison is therefore constant-time amortized while preserving both exact
+source identity and backing ownership.
+
 If a format does not support a shape, checking reports the missing method as a
 static-dispatch error. Unsupported shapes are not represented as runtime parse
 or encode failures. Runtime failures are reserved for input/output conditions

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -1068,6 +1068,74 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "\"xnull\"" },
     },
     .{
+        // https://github.com/roc-lang/roc/issues/11094
+        //
+        // The custom codec delegates through `a.parser_for`. Its `Bool`
+        // instantiation must select Bool's scalar parser instead of opening
+        // Bool's tag-union runtime representation under the outer contract.
+        .name = "issue 11094: custom codec delegating to Bool's parser through its type parameter decodes",
+        .source_kind = .module,
+        .source =
+        \\Wrap(a) := [W(a)].{
+        \\    parser_for : encoding -> (state -> Try({ value : Wrap(a), rest : state }, [InvalidJson(Str), MissingRequiredField(Str), ..]))
+        \\        where [
+        \\            a.parser_for : encoding -> (state -> Try({ value : a, rest : state }, [InvalidJson(Str), MissingRequiredField(Str)])),
+        \\        ]
+        \\    parser_for = |encoding| {
+        \\        Elem : a
+        \\        parse_elem = Elem.parser_for(encoding)
+        \\        |state|
+        \\            match parse_elem(state) {
+        \\                Ok(parsed) => Ok({ value: W(parsed.value), rest: parsed.rest })
+        \\                Err(InvalidJson(e)) => Err(InvalidJson(e))
+        \\                Err(MissingRequiredField(f)) => Err(MissingRequiredField(f))
+        \\            }
+        \\    }
+        \\}
+        \\
+        \\main : Str
+        \\main = {
+        \\    parsed : Try({ r : Wrap(Bool) }, _)
+        \\    parsed = Json.parse("{\"r\":true}")
+        \\    match parsed {
+        \\        Ok({ r: W(value) }) => if value "yes" else "no"
+        \\        Err(_) => "failed"
+        \\    }
+        \\}
+        ,
+        .expected = .{ .inspect_str = "\"yes\"" },
+    },
+    .{
+        // https://github.com/roc-lang/roc/issues/11094
+        //
+        // The encoder path has the same nominal-subject identity requirement
+        // as the parser path above. Delegating through `a.encoder_for` must use
+        // Bool's scalar encoder instead of its tag-union representation.
+        .name = "issue 11094: custom codec delegating to Bool's encoder through its type parameter encodes",
+        .source_kind = .module,
+        .source =
+        \\Wrap(a) := [W(a)].{
+        \\    encoder_for : encoding -> (Wrap(a), state -> Try(state, err))
+        \\        where [
+        \\            a.encoder_for : encoding -> (a, state -> Try(state, err)),
+        \\        ]
+        \\    encoder_for = |encoding| {
+        \\        Elem : a
+        \\        encode_elem = Elem.encoder_for(encoding)
+        \\        |W(value), state| encode_elem(value, state)
+        \\    }
+        \\}
+        \\
+        \\main : Str
+        \\main = {
+        \\    wrapped : Wrap(Bool)
+        \\    wrapped = W(Bool.True)
+        \\    Json.to_str({ r: wrapped })
+        \\}
+        ,
+        .expected = .{ .inspect_str = "\"{\\\"r\\\":true}\"" },
+    },
+    .{
         // https://github.com/roc-lang/roc/issues/11064
         .name = "issue 11064: unannotated imported field reader runs from every match arm calling it",
         .source_kind = .module,

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -1110,10 +1110,7 @@ fn relateMatchingRequestContainers(
         },
         .named => |left_named| switch (right_content) {
             .named => |right_named| {
-                if (!sameTypeDef(left_named.def, right_named.def) or
-                    left_named.kind != right_named.kind or
-                    left_named.args.len != right_named.args.len)
-                {
+                if (!sameNamedValueDefinition(left_named, right_named)) {
                     return false;
                 }
                 for (left_named.args, right_named.args) |left_arg, right_arg| {
@@ -1125,6 +1122,7 @@ fn relateMatchingRequestContainers(
                 } else if (right_named.backing != null) {
                     return false;
                 }
+                try graph.relateNamedInstances(left_node, right_node);
                 return true;
             },
             .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => {},
@@ -1215,9 +1213,7 @@ fn constrainDeferredTemplateTypeArgumentsAt(
         },
         .named => |checked_named| switch (request_content) {
             .named => |request_named| {
-                if (!sameTypeDef(checked_named.def, request_named.def) or
-                    checked_named.args.len != request_named.args.len)
-                {
+                if (!sameNamedValueDefinition(checked_named, request_named)) {
                     if (transparentAliasBacking(graph, checked_content)) |backing| {
                         return constrainDeferredTemplateTypeArgumentsAt(graph, backing, request_root, seen);
                     }
@@ -1229,6 +1225,7 @@ fn constrainDeferredTemplateTypeArgumentsAt(
                 for (checked_named.args, request_named.args) |checked_arg, request_arg| {
                     try constrainDeferredTemplateArgument(graph, checked_arg, request_arg, seen);
                 }
+                try graph.relateNamedInstances(checked_root, request_root);
             },
             .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return,
         },
@@ -1584,6 +1581,7 @@ fn relateCheckedMonoRequestNodeAt(
                         row_width,
                         seen,
                     );
+                    try graph.relateNamedInstances(checked_root, request_root);
                     return;
                 }
             },
@@ -44448,7 +44446,6 @@ const BodyContext = struct {
     }
 
     fn sameCodecSubject(self: *BodyContext, checked_subject: NodeId, requested_subject: NodeId) bool {
-        if (self.graph.sameClass(checked_subject, requested_subject)) return true;
         // A declaration-backed nominal opens its backing in a declaration
         // scope, independently from the checked codec contract's snapshot.
         // Closed primitives and named applications still have exact constant-
@@ -44461,21 +44458,9 @@ const BodyContext = struct {
                 .primitive => |requested_primitive| checked_primitive == requested_primitive,
                 .redirect, .unresolved, .named, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => false,
             },
-            .redirect, .unresolved, .named, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => {},
+            .named => return self.graph.sameRelatedNamedInstance(checked_subject, requested_subject),
+            .redirect, .unresolved, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return self.graph.sameClass(checked_subject, requested_subject),
         }
-        const checked_named = switch (checked_content) {
-            .named => |named| named,
-            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return false,
-        };
-        const requested_named = switch (requested_content) {
-            .named => |named| named,
-            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return false,
-        };
-        if (!sameNamedValueDefinition(checked_named, requested_named)) return false;
-        for (checked_named.args, requested_named.args) |checked_arg, requested_arg| {
-            if (!self.graph.sameClass(checked_arg, requested_arg)) return false;
-        }
-        return true;
     }
 
     fn debugVerifyGeneratedCodecContractConsumed(
@@ -44512,28 +44497,16 @@ const BodyContext = struct {
             .encoder => "encoder_for",
         };
         const active = self.active_codec_contract orelse return null;
-        const request_named = switch (self.graph.content(shape_node)) {
-            .named => |named| named,
-            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return null,
-        };
+        if (self.graph.content(shape_node) != .named) return null;
         var selected: ?InstantiatedGeneratedCodecCall = null;
         for (self.instantiated_codec_calls.items[active.calls_start..][0..active.calls_len]) |*candidate| {
             if (!std.mem.eql(u8, candidate.view.names.methodNameText(candidate.checked.method), method_name)) continue;
             const candidate_subject = candidate.subject_node orelse
                 Common.invariant("checked generated codec boundary call had no nominal subject");
-            const candidate_named = switch (self.graph.content(candidate_subject)) {
-                .named => |named| named,
-                .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => Common.invariant("checked generated codec boundary subject was not nominal"),
-            };
-            if (!sameNamedValueDefinition(candidate_named, request_named)) continue;
-            var args_match = true;
-            for (candidate_named.args, request_named.args) |candidate_arg, request_arg| {
-                if (!self.graph.sameClass(candidate_arg, request_arg)) {
-                    args_match = false;
-                    break;
-                }
+            if (self.graph.content(candidate_subject) != .named) {
+                Common.invariant("checked generated codec boundary subject was not nominal");
             }
-            if (!args_match) continue;
+            if (!self.sameCodecSubject(candidate_subject, shape_node)) continue;
             if (selected) |previous| {
                 if (!self.graph.sameFunctionInterface(previous.callable_node, candidate.callable_node) or
                     !std.meta.eql(previous.checked.resolution, candidate.checked.resolution))

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -177,6 +177,13 @@ const InstNamed = struct {
     declared_order: []const InstDeclaredField = &.{},
 };
 
+/// Union-find node for nominal applications that an explicit relation proved
+/// equivalent without joining their representation-owning type classes.
+const RelatedNamedInstance = struct {
+    parent: NodeId,
+    rank: u8 = 0,
+};
+
 /// Graph-owned data for a private iterator representation before sealing.
 pub const InstGeneratedIterator = struct {
     callable_evidence: ?names.TypeDigest,
@@ -509,6 +516,16 @@ pub const InstGraph = struct {
     class_member_head: std.ArrayList(NodeId),
     class_member_tail: std.ArrayList(NodeId),
     processed_relations: std.AutoHashMap(RelationStamp, void),
+    /// Explicit equivalence classes for matching nominal applications whose
+    /// backing nodes must remain independently owned. This is deliberately
+    /// separate from the main type union-find: consumers can use the proven
+    /// nominal identity without collapsing declaration and request storage.
+    related_named_instances: collections.DenseMap(NodeId, RelatedNamedInstance),
+    /// One related wrapper for each exact declaration-backing witness. The
+    /// nominal backing cache includes every type argument in its key, so a
+    /// shared permanent backing id proves two independently allocated wrappers
+    /// denote the same application without inspecting their shape.
+    related_named_backings: collections.DenseMap(NodeId, NodeId),
     /// Immutable Type-shaped snapshots by permanent node id. Old snapshots
     /// retain their original provenance while `find` resolves that node to its
     /// current class root; unions therefore never move or reindex snapshots.
@@ -624,6 +641,8 @@ pub const InstGraph = struct {
             .class_member_head = .empty,
             .class_member_tail = .empty,
             .processed_relations = std.AutoHashMap(RelationStamp, void).init(allocator),
+            .related_named_instances = collections.DenseMap(NodeId, RelatedNamedInstance).init(allocator),
+            .related_named_backings = collections.DenseMap(NodeId, NodeId).init(allocator),
             .node_snapshots = collections.DenseMap(NodeId, std.ArrayList(Type.TypeId)).init(allocator),
             .current_snapshots = collections.DenseMap(NodeId, Type.TypeId).init(allocator),
             .current_snapshots_dirty = false,
@@ -711,6 +730,8 @@ pub const InstGraph = struct {
         self.active_snapshot_nodes.deinit();
         self.imported_type_nodes.deinit();
         self.provisional_view_shareable.deinit();
+        self.related_named_backings.deinit();
+        self.related_named_instances.deinit();
         self.processed_relations.deinit();
         self.class_member_tail.deinit(allocator);
         self.class_member_head.deinit(allocator);
@@ -2009,6 +2030,133 @@ pub const InstGraph = struct {
     /// Whether two live cells already belong to the same union-find class.
     pub fn sameClass(self: *InstGraph, left: NodeId, right: NodeId) bool {
         return self.find(left) == self.find(right);
+    }
+
+    fn relatedNamedInstanceRoot(self: *InstGraph, node: NodeId) NodeId {
+        var root = node;
+        while (self.related_named_instances.get(root)) |entry| {
+            if (entry.parent == root) break;
+            root = entry.parent;
+        }
+
+        var current = node;
+        while (current != root) {
+            const entry = self.related_named_instances.getPtr(current) orelse break;
+            const next = entry.parent;
+            entry.parent = root;
+            current = next;
+        }
+        return root;
+    }
+
+    fn ensureRelatedNamedInstanceNode(self: *InstGraph, node: NodeId) Allocator.Error!void {
+        const entry = try self.related_named_instances.getOrPut(node);
+        if (!entry.found_existing) entry.value_ptr.* = .{ .parent = node };
+    }
+
+    fn unionRelatedNamedInstanceNodes(self: *InstGraph, left_node: NodeId, right_node: NodeId) void {
+        var left_root = self.relatedNamedInstanceRoot(left_node);
+        var right_root = self.relatedNamedInstanceRoot(right_node);
+        if (left_root == right_root) return;
+        if (self.related_named_instances.get(left_root).?.rank <
+            self.related_named_instances.get(right_root).?.rank)
+        {
+            const temp = left_root;
+            left_root = right_root;
+            right_root = temp;
+        }
+        self.related_named_instances.getPtr(right_root).?.parent = left_root;
+        const left_rank = self.related_named_instances.get(left_root).?.rank;
+        if (left_rank == self.related_named_instances.get(right_root).?.rank) {
+            self.related_named_instances.getPtr(left_root).?.rank = left_rank + 1;
+        }
+    }
+
+    fn bindRelatedNamedBacking(
+        self: *InstGraph,
+        named_node: NodeId,
+        named: InstNamed,
+    ) Allocator.Error!void {
+        const backing = named.backing orelse return;
+        const entry = try self.related_named_backings.getOrPut(backing.node);
+        if (entry.found_existing) {
+            self.unionRelatedNamedInstanceNodes(named_node, entry.value_ptr.*);
+        } else {
+            entry.value_ptr.* = named_node;
+        }
+    }
+
+    /// Record an exact nominal identity proved by a graph relation. Backed
+    /// named applications intentionally keep distinct main type classes so
+    /// each request retains its own representation witness; this parallel
+    /// union-find exposes the proven source-level identity to later consumers.
+    pub fn relateNamedInstances(
+        self: *InstGraph,
+        raw_left: NodeId,
+        raw_right: NodeId,
+    ) Allocator.Error!void {
+        self.requireRelationProduction();
+        const left_node = self.find(raw_left);
+        const right_node = self.find(raw_right);
+        const left = switch (self.content(left_node)) {
+            .named => |named| named,
+            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => Common.invariant("named-instance relation received a non-named left node"),
+        };
+        const right = switch (self.content(right_node)) {
+            .named => |named| named,
+            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => Common.invariant("named-instance relation received a non-named right node"),
+        };
+        if (left.kind != right.kind or
+            !sameTypeDef(left.def, right.def) or
+            left.builtin_owner != right.builtin_owner or
+            left.args.len != right.args.len)
+        {
+            Common.invariant("named-instance relation received different declarations");
+        }
+
+        try self.ensureRelatedNamedInstanceNode(left_node);
+        try self.ensureRelatedNamedInstanceNode(right_node);
+        try self.bindRelatedNamedBacking(left_node, left);
+        try self.bindRelatedNamedBacking(right_node, right);
+        self.unionRelatedNamedInstanceNodes(left_node, right_node);
+    }
+
+    /// Whether the main type relation or a backed-nominal relation proved
+    /// that two named application cells have the same source-level identity.
+    pub fn sameRelatedNamedInstance(self: *InstGraph, left: NodeId, right: NodeId) bool {
+        const left_named = switch (self.content(left)) {
+            .named => |named| named,
+            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return false,
+        };
+        const right_named = switch (self.content(right)) {
+            .named => |named| named,
+            .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .record, .empty_tag_union, .empty_record, .erased, .zst => return false,
+        };
+        if (left_named.kind != right_named.kind or
+            !sameTypeDef(left_named.def, right_named.def) or
+            left_named.builtin_owner != right_named.builtin_owner or
+            left_named.args.len != right_named.args.len) return false;
+        if (self.sameClass(left, right)) return true;
+
+        const left_related = if (self.related_named_instances.contains(left))
+            self.relatedNamedInstanceRoot(left)
+        else if (left_named.backing) |backing|
+            if (self.related_named_backings.get(backing.node)) |representative|
+                self.relatedNamedInstanceRoot(representative)
+            else
+                return false
+        else
+            return false;
+        const right_related = if (self.related_named_instances.contains(right))
+            self.relatedNamedInstanceRoot(right)
+        else if (right_named.backing) |backing|
+            if (self.related_named_backings.get(backing.node)) |representative|
+                self.relatedNamedInstanceRoot(representative)
+            else
+                return false
+        else
+            return false;
+        return left_related == right_related;
     }
 
     pub const ClassMemberIterator = struct {
@@ -8962,6 +9110,80 @@ test "nominal backing index rekeys root tuples and merges collisions" {
     }
     try std.testing.expectEqual(@as(usize, 3), active_instances);
     try std.testing.expectEqual(@as(u32, 3), graph.nominal_backing_index.count());
+}
+
+test "related named instances reuse exact backing witnesses" {
+    const gpa = std.testing.allocator;
+
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+
+    const module_identity = try name_store.internModuleIdentity(&([_]u8{0xAC} ** 32));
+    const type_name = try name_store.internTypeName("Wrap");
+    const other_type_name = try name_store.internTypeName("Other");
+    const named_type: Type.NamedType = .{ .module = .{}, .ty = testCheckedTypeId(1) };
+    const def: Type.TypeDef = .{ .module = module_identity, .type_name = type_name };
+    const other_def: Type.TypeDef = .{ .module = module_identity, .type_name = other_type_name };
+
+    const request_arg = try graph.newNode(.{ .primitive = .bool });
+    const checked_arg = try graph.newNode(.{ .primitive = .bool });
+    try graph.unify(request_arg, checked_arg);
+    const request_backing = try graph.newNode(.empty_tag_union);
+    const checked_backing = try graph.newNode(.empty_tag_union);
+    const unrelated_backing = try graph.newNode(.empty_tag_union);
+
+    const request = try graph.newNode(.{ .named = .{
+        .named_type = named_type,
+        .def = def,
+        .kind = .nominal,
+        .builtin_owner = null,
+        .args = try graph.arena().dupe(NodeId, &.{request_arg}),
+        .backing = .{ .node = request_backing, .use = .inspectable },
+    } });
+    const same_request = try graph.newNode(.{ .named = .{
+        .named_type = named_type,
+        .def = def,
+        .kind = .nominal,
+        .builtin_owner = null,
+        .args = try graph.arena().dupe(NodeId, &.{request_arg}),
+        .backing = .{ .node = request_backing, .use = .inspectable },
+    } });
+    const checked_node = try graph.newNode(.{ .named = .{
+        .named_type = named_type,
+        .def = def,
+        .kind = .nominal,
+        .builtin_owner = null,
+        .args = try graph.arena().dupe(NodeId, &.{checked_arg}),
+        .backing = .{ .node = checked_backing, .use = .inspectable },
+    } });
+    const unrelated = try graph.newNode(.{ .named = .{
+        .named_type = named_type,
+        .def = def,
+        .kind = .nominal,
+        .builtin_owner = null,
+        .args = try graph.arena().dupe(NodeId, &.{request_arg}),
+        .backing = .{ .node = unrelated_backing, .use = .inspectable },
+    } });
+    const other_definition = try graph.newNode(.{ .named = .{
+        .named_type = named_type,
+        .def = other_def,
+        .kind = .nominal,
+        .builtin_owner = null,
+        .args = try graph.arena().dupe(NodeId, &.{request_arg}),
+        .backing = .{ .node = request_backing, .use = .inspectable },
+    } });
+
+    try graph.relateNamedInstances(request, checked_node);
+
+    try std.testing.expect(!graph.sameClass(request, checked_node));
+    try std.testing.expect(graph.sameRelatedNamedInstance(request, checked_node));
+    try std.testing.expect(graph.sameRelatedNamedInstance(same_request, checked_node));
+    try std.testing.expect(!graph.sameRelatedNamedInstance(unrelated, checked_node));
+    try std.testing.expect(!graph.sameRelatedNamedInstance(other_definition, checked_node));
 }
 
 test "issue 9647: same nominal backing wrapper resolves to structural backing once" {


### PR DESCRIPTION
Generated codec lowering could lose the checked nominal subject identity when generic specialization allocated a second backed wrapper, causing custom Bool codecs to fall through to structural tag-union handling. This records explicit nominal-instance relations through exact backing witnesses, preserving representation ownership while making codec subject selection exact and amortized constant-time.

Fixes #11094.