### PR TITLE
Fix Wasm operand stack for unboxing zero-sized values

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4965,6 +4965,17 @@ pub fn build(b: *std.Build) void {
         build_wasm_rc_cleanup_model_list_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_rc_cleanup_model_list_app.step);
 
+        const build_wasm_box_zst_app = b.addRunArtifact(roc_exe);
+        build_wasm_box_zst_app.addArgs(&.{
+            "build",
+            "test/wasm/box_zst_static_lib_app.roc",
+            "--opt=dev",
+            "--target=wasm32",
+            "--output=test/wasm/box_zst_static_lib_app.wasm",
+        });
+        build_wasm_box_zst_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_box_zst_app.step);
+
         const build_wasm_boxed_model_update_app = b.addRunArtifact(roc_exe);
         build_wasm_boxed_model_update_app.addArgs(&.{
             "build",
@@ -5227,6 +5238,17 @@ pub fn build(b: *std.Build) void {
             });
             run_wasm_rc_cleanup_model_list_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_rc_cleanup_model_list_test.step);
+
+            const run_wasm_box_zst_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_box_zst_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/box_zst_static_lib_app.wasm",
+                "--expected",
+                "ok",
+                "--assert-alloc-balanced",
+            });
+            run_wasm_box_zst_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_box_zst_test.step);
 
             const run_wasm_boxed_model_update_test = b.addRunArtifact(wasm_test_exe);
             run_wasm_boxed_model_update_test.addArgs(&.{

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -14749,7 +14749,9 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             if (box_layout.tag == .box_of_zst or
                 (erased_box_ptr and try self.layoutByteSize(ll.ret_layout) == 0))
             {
-                _ = try self.emitProcLocal(box_expr);
+                // The input is an already-evaluated LIR local. A zero-sized
+                // payload needs no load; pushing its pointer here would leave
+                // an extra operand beneath the result. ARC owns its release.
                 const result_vt = try self.resolveValType(ll.ret_layout);
                 switch (result_vt) {
                     .i32 => {
@@ -14776,7 +14778,8 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 else
                     ls.builtinBoxAbi(box_layout_idx).elem_size;
                 if (elem_size == 0) {
-                    _ = try self.emitProcLocal(box_expr);
+                    // Only the result belongs on the operand stack for an
+                    // empty payload; the box local needs no dereference.
                     const result_vt = try self.resolveValType(ll.ret_layout);
                     switch (result_vt) {
                         .i32 => {

--- a/test/wasm/box_zst_static_lib_app.roc
+++ b/test/wasm/box_zst_static_lib_app.roc
@@ -1,0 +1,18 @@
+app [main!] { pf: platform "./static-lib-platform/main.roc" }
+
+unbox_unit : Box({}) -> {}
+unbox_unit = |boxed| Box.unbox(boxed)
+
+main! = |seed| {
+	boxed = if seed == 0 {
+		Box.box({})
+	} else {
+		Box.box({})
+	}
+	value = unbox_unit(boxed)
+	if value == {} {
+		"ok"
+	} else {
+		"bad"
+	}
+}


### PR DESCRIPTION
Unboxing a zero-sized value with `--target=wasm32 --opt=dev` can produce an invalid module. For example, selecting a `Box({})` through a runtime branch and unboxing it leaves an extra `i32` on the operand stack; validation fails at the end of the branch.

The zero-sized paths in `box_unbox_borrowed` emitted the box local before emitting the dummy result, without consuming the box operand. The input is already an evaluated LIR local and there is no payload to load. Remove those two unnecessary pushes and emit only the result. Evaluation and the explicit ARC statements remain unchanged.

Adds a runtime `Box({})` regression to the Wasm static-library suite, checking module validation, output, and allocation balance.

Validation:
- `zig build run-test-wasm-static-lib`: all 19 cases passed.
- The regression compiled before the fix fails the same runner with `ValidationTypeStackHeightMismatch`; the fixed output passes.
- `wasm-validate` rejects the pre-fix reduced program and roc-signals on-change-initial fixture, and accepts both with this fix.
- `zig fmt --check build.zig src/backend/wasm/WasmCodeGen.zig` and `git diff --check` passed.

Combined verification with the independent ARC fix in #11125 now passes the full roc-signals CI command, including **30/30 dev-mode Wasm builds and mounts**. #11125 resolves onboarding-wizard’s pre-codegen ARC failure and handles complete payload transfers from independently retained aggregate aliases. Both fixes are needed for the signals rollout; its nightly pin will be updated and reverified after they land.
