### PR TITLE
Stop ARC unit lookup at the nearest owned alias

### DIFF
--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -13669,6 +13669,77 @@ test "RC borrow survives the lender moving into an aggregate" {
     try testing.expect(f.countRc(payload, .incref) >= 1);
 }
 
+test "RC recursive tail carrier stops at an owned alias" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const param = try f.local(.str);
+    const original = try f.local(.str);
+    const owned_alias = try f.local(.str);
+    const borrowed_alias = try f.local(.str);
+    const stored = try f.local(f.pair_str);
+    const result = try f.local(.str);
+    const ignored = try f.local(.i64);
+    const proc = try f.addProcPendingBody(&.{param}, .str);
+    const tail = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = result,
+        .proc = proc,
+        .args = try f.span(&.{borrowed_alias}),
+        .next = try f.ret(result),
+    } });
+    // Storing the alias demands an owned binding. The later original use
+    // keeps its independent unit alive; the tail argument borrows the alias.
+    const use_original = try f.expectStmt(original, tail);
+    const borrow = try f.assignRefLocal(borrowed_alias, owned_alias, use_original);
+    const consume_stored = try f.assignCall(ignored, &.{stored}, borrow);
+    const store = try f.assignStruct(stored, &.{ owned_alias, owned_alias }, consume_stored);
+    const own = try f.assignRefLocal(owned_alias, original, store);
+    f.store.setProcSpecBody(proc, try f.assignStr(original, "still live", own));
+    const rc = [_]bool{ true, true, true, true, true, true, false };
+    var solution = try arc_solve.solve(testing.allocator, &f.store, &f.layouts, &rc, &.{}, &.{}, true);
+    defer solution.deinit();
+    try testing.expect(!solution.isBorrowed(owned_alias));
+    try testing.expect(solution.isBorrowed(borrowed_alias));
+    try testing.expectEqual(owned_alias, solution.tailCallAt(proc, tail).?.carrier(0).?);
+    try f.run();
+}
+
+test "RC borrowed alias transfers its nearest owned carrier" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const param = try f.local(.str);
+    const identity = try f.addProc(&.{param}, try f.ret(param), .str);
+    const original = try f.local(.str);
+    const owned_alias = try f.local(.str);
+    const borrowed_alias = try f.local(.str);
+    const stored = try f.local(f.pair_str);
+    const result = try f.local(.str);
+    const ignored = try f.local(.i64);
+
+    const ret = try f.ret(original);
+    const use_result = try f.expectStmt(result, ret);
+    const consume_stored = try f.assignCall(ignored, &.{stored}, use_result);
+    const call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = result,
+        .proc = identity,
+        .args = try f.span(&.{borrowed_alias}),
+        .next = consume_stored,
+    } });
+    // The aggregate gives owned_alias an owned binding, while the identity
+    // call's argument remains borrowed. The original is still returned later.
+    const borrow = try f.assignRefLocal(borrowed_alias, owned_alias, call);
+    const store = try f.assignStruct(stored, &.{ owned_alias, owned_alias }, borrow);
+    const own = try f.assignRefLocal(owned_alias, original, store);
+    const body = try f.assignStr(original, "still live", own);
+    _ = try f.addProc(&.{}, body, .str);
+    const rc = [_]bool{ true, true, true, true, true, true, false };
+    var solution = try arc_solve.solve(testing.allocator, &f.store, &f.layouts, &rc, &.{}, &.{}, true);
+    defer solution.deinit();
+    try testing.expect(!solution.isBorrowed(owned_alias));
+    try testing.expect(solution.isBorrowed(borrowed_alias));
+    try testing.expectEqual(owned_alias, solution.unitLocalOf(borrowed_alias));
+    try insert(&f.store, &f.layouts, .{ .specialize = true });
+}
+
 test "RC alias chain into a consuming call moves the unit through" {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -9697,6 +9697,32 @@ test "RC tag_payload_access: complete payload moves parent unit into return" {
     try testing.expectEqual(@as(usize, 0), f.countRc(extracted, .incref));
 }
 
+test "RC complete payload transfer with retained aliases" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const payload = try f.local(.str);
+    const root = try f.local(f.tag_str);
+    const owned_alias = try f.local(f.tag_str);
+    const borrowed_alias = try f.local(f.tag_str);
+    const first = try f.local(.str);
+    const second = try f.local(.str);
+    const pair = try f.local(f.pair_str);
+    const stored = try f.local(try f.layouts.insertList(f.tag_str));
+    const ignored = try f.local(.i64);
+    const ret = try f.ret(pair);
+    const consume = try f.assignCall(ignored, &.{stored}, ret);
+    const result = try f.assignStruct(pair, &.{ first, second }, consume);
+    const extract_second = try f.assignTagPayload(second, borrowed_alias, result);
+    const borrow = try f.assignRefLocal(borrowed_alias, owned_alias, extract_second);
+    const extract_first = try f.assignTagPayload(first, root, borrow);
+    const store = try f.assignList(stored, &.{owned_alias}, extract_first);
+    const own = try f.assignRefLocal(owned_alias, root, store);
+    const tag = try f.assignTag(root, 1, payload, own);
+    const body = try f.assignStr(payload, "extract", tag);
+    _ = try f.addProc(&.{}, body, f.pair_str);
+    try f.run();
+}
+
 test "RC tag_payload_access: complete payload retains when parent remains live" {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -2047,7 +2047,22 @@ const Certifier = struct {
             => return false,
         };
         const existing = state.claimsOf(container);
-        if (existing & bit != 0) return false;
+        if (existing & bit != 0) {
+            // Same-value aliases can own independent retained units. A
+            // complete projection may spend one intact surplus unit without
+            // claiming the already-dismantled unit's fields a second time.
+            // Partial projections still cannot repeat a field claim.
+            if (self.requiredClaimMask(container) != bit or
+                !self.hasIntactSurplusUnit(state, container)) return false;
+            const before = state.balanceOf(container);
+            try state.addBalance(container, -1);
+            if (mutations) |list| try list.append(self.allocator, .{ .balance = .{
+                .value = container,
+                .before = before,
+                .after = before - 1,
+            } });
+            return true;
+        }
         if (!try self.ensureClaimContainerUnit(state, container, seen, mutations)) return false;
         try state.setClaims(container, existing | bit);
         if (mutations) |list| try list.append(self.allocator, .{ .claims = .{
@@ -7839,6 +7854,54 @@ test "certify rejects a dismantled record moved whole without a retained surplus
 
     try testing.expectError(error.Certification, f.certify());
     try testing.expect(std.mem.find(u8, f.diag.message(), "partially dismantled") != null);
+}
+
+test "certify complete projections spend exactly the retained units" {
+    for ([_]bool{ false, true }) |tagged| {
+        for (0..3) |retains| {
+            var f = try CertifyTest.init(testing.allocator);
+            defer f.deinit();
+            const singleton = try f.layouts.putStructFields(&.{.{ .index = 0, .layout = .str }});
+            const container_layout = if (tagged)
+                try f.layouts.putTagUnion(&.{ try f.layouts.ensureZstLayout(), .str })
+            else
+                singleton;
+            const container = try f.local(container_layout);
+            const first = try f.local(.str);
+            const second = try f.local(.str);
+            const pair = try f.local(f.pair_str);
+            const ret = try f.ret(pair);
+            const join_id = f.freshJoinPointId();
+            const jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+            var body = try f.store.addCFStmt(.{ .assign_struct = .{
+                .target = pair,
+                .fields = try f.store.addLocalSpan(&.{ first, second }),
+                .next = jump,
+            } });
+            for ([_]LIR.LocalId{ second, first }) |target| {
+                const op: LIR.RefOp = if (tagged)
+                    .{ .tag_payload = .{ .source = container, .payload_idx = 0, .variant_index = 1, .tag_discriminant = 1 } }
+                else
+                    .{ .field = .{ .source = container, .field_idx = 0 } };
+                body = try f.store.addCFStmt(.{ .assign_ref = .{ .target = target, .op = op, .next = body } });
+            }
+            for (0..retains) |_| body = try f.increfStmt(container, container_layout, body);
+            const join = try f.store.addCFStmt(.{ .join = .{
+                .id = join_id,
+                .params = LIR.LocalSpan.empty(),
+                .body = ret,
+                .remainder = body,
+            } });
+            _ = try f.addProc(&.{container}, join, f.pair_str);
+            // Two complete projections need two units. One unit is a double
+            // consume; three units leave a leak. Neither may be accepted.
+            if (retains == 1) {
+                try f.certify();
+            } else {
+                try testing.expectError(error.Certification, f.certify());
+            }
+        }
+    }
 }
 
 test "certify accepts a fully dismantled record via field takes" {

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -310,10 +310,14 @@ pub const Solution = struct {
     /// aliases already have their own retained unit, and field/payload borrows
     /// are not the same value as their liveness leader.
     pub fn unitLocalOf(self: *const Solution, local: LIR.LocalId) LIR.LocalId {
-        if (!self.isBorrowed(local)) return local;
         var cursor = @intFromEnum(local);
         var steps: usize = 0;
-        while (cursor < self.alias_source.len and self.alias_source[cursor] != no_local) {
+        // Every owned binding has an independent unit, even when its value
+        // came from another local. Only borrowed links forward that unit.
+        while (cursor < self.alias_source.len and
+            self.isBorrowed(@enumFromInt(cursor)) and
+            self.alias_source[cursor] != no_local)
+        {
             cursor = self.alias_source[cursor];
             steps += 1;
             if (steps > self.alias_source.len) solveInvariant("ARC alias-source chain contained a cycle");
@@ -1807,7 +1811,7 @@ fn buildTailCallTable(
         for (0..@min(GuardedList.borrowLen(args), arc_sig.tracked_param_count)) |position| {
             const argument = solver.domain.indexOf(GuardedList.at(args, position)) orelse continue;
             if (!binding.borrowed.isSet(argument)) continue;
-            fact.carriers[position] = tailArgumentCarrier(solver, argument);
+            fact.carriers[position] = tailArgumentCarrier(solver, binding, argument);
             const leader = binding.leader[argument];
             if (!paramIsBorrowed(solver, leader)) continue;
             if (solver.param_proc[leader] != call.caller) continue;
@@ -1836,10 +1840,10 @@ fn tailCallLifetimeLessThan(_: void, left: TailCallLifetime, right: TailCallLife
 /// Mirrors `Solution.unitLocalOf` in the dense solver domain. Borrowed pure
 /// aliases transfer their source's unit; other borrowed definitions need an
 /// owned override on their own binding when a tail-call lifetime escapes.
-fn tailArgumentCarrier(solver: *const Solver, argument: u32) u32 {
+fn tailArgumentCarrier(solver: *const Solver, binding: *const BindingResult, argument: u32) u32 {
     var cursor = argument;
     var steps: usize = 0;
-    while (solver.alias_source[cursor] != no_local) {
+    while (binding.borrowed.isSet(cursor) and solver.alias_source[cursor] != no_local) {
         cursor = solver.alias_source[cursor];
         steps += 1;
         if (steps > solver.alias_source.len) solveInvariant("ARC tail-call carrier alias chain contained a cycle");


### PR DESCRIPTION
Fixes ARC consuming the wrong ownership unit through a borrowed alias of an owned alias. This caused roc-signals’ onboarding-wizard to fail certification with `use of dead refcounted local` under `--opt=dev`.

For `original -> owned_alias -> borrowed_alias`, the intermediate owned binding has its own unit. `Solution.unitLocalOf` checked only the starting local’s mode, then followed every alias edge back to `original`. Lifetime checks followed the immediate owner’s borrow group, while transfer cleared the original’s unit. A later original use could therefore retain a dead value. Stop at the first owned binding, including in recursive tail-call carrier lookup.

Correctly distinguishing those units also exposes valid complete payload transfers through independently retained aggregate aliases. The certifier merged their value identity but allowed only one complete claim. A subsequent complete projection can now spend an explicitly tracked intact surplus unit; it does not claim the dismantled unit’s fields twice. Partial-field claims and exact ownership accounting remain enforced.

Regression coverage:
- Ordinary and recursive-call carrier tests reject the old lookup and certify the fixed output.
- An end-to-end LIR test reproduces two complete transfers from retained aliases; before the certification fix it fails with `partially dismantled value ... balance 2`.
- Record and tag projection tests cross a join and accept exactly two units for two transfers. One unit is rejected as a double-consume; three are rejected as a leak.

Validation:
- Full LIR and RC conformance suites: 318/318 tests passed (315 LIR, 3 RC conformance). The final join-boundary test variant also passed the full LIR suite.
- `zig fmt --check` and `git diff --check` passed.

This PR is based directly on main and does not include the independent Wasm fix in #11124. With both fixes applied, the complete roc-signals CI command passed locally:

`python3 scripts/test.py zig browser roc-check roc-test wasm --native never --bundle never --roc-bin /path/to/combined/roc`

This includes all Zig checks, 145 browser contract tests, all Roc checks and tests, and **30/30 dev-mode Wasm builds and mounts**, including onboarding-wizard. The signals PR can be reverified against a nightly containing both fixes.
