### PR TITLE
Align Wasm REPL with compile-time evaluation

### DIFF
--- a/src/repl_wasm/README.md
+++ b/src/repl_wasm/README.md
@@ -51,7 +51,7 @@ For example:
 
 | Operation | Contract |
 | --- | --- |
-| `capabilities` | Reports protocol operations, ownership boundaries, and the one-way effect interface. |
+| `capabilities` | Reports protocol operations, ownership boundaries, and supported features. |
 | `eval` | Parser-backed multiline/batch input; evaluates left to right and stops at the first failed snippet. Earlier successful definitions remain committed. |
 | `analyze` | Reports whether input is complete, incomplete, or invalid without changing the session. |
 | `complete` | Filters session definitions by the identifier prefix ending at `params.cursor` and returns insertion text plus an explicit replacement range. |
@@ -70,42 +70,21 @@ Revisions are unsigned 32-bit counters scoped to one WASM instance, so they are
 exact JavaScript numbers. Hosts must not compare revisions across instances.
 
 Expression values, checked types, definition metadata, diagnostics, and ordered
-runtime events are separate fields. Diagnostics have a stable `code`,
-`severity`, human-readable `message`, and nullable `region`. Runtime crashes are
-language-level results and do not poison the next request.
+`dbg` events are separate fields. Diagnostics have a stable `code`, `severity`,
+human-readable `message`, and nullable `region`. A failed compile-time `expect`
+or user-written `crash` is a checking diagnostic and does not poison the next
+request.
 
 Version 1 enumerates blocking diagnostics only; non-blocking compiler warnings
 are not part of the current contract. This is reported by the capabilities
 response rather than being left implicit.
 
-## One-way host effects
+## Compile-time evaluation
 
-The reserved, built-in `Repl` module provides one generic function:
-
-```roc
-import Repl
-
-Repl.emit!({ name: "log", payload: "hello" })
-```
-
-`emit!` accepts `{ name : Str, payload : Str }` and returns `{}`. Each call adds
-an ordered `{ "kind": "effect", "name": ..., "payload": ... }` event to the
-evaluated snippet. Names and payloads are caller-defined UTF-8 strings; the
-module does not parse them, run an effect, or wait for a response. Hosts choose
-an allowlist and encoding for their own handlers. Unknown names must remain
-observable so a caller can report or ignore them deliberately.
-
-Effects emitted before a crash remain in the ordered event trace because they
-were observed during execution. A host decides whether to act on events from a
-failed snippet. The bundled demo deliberately marks them as suppressed and
-runs handlers only when the snippet status is `ok`.
-
-`Repl` is reserved and cannot be replaced through `set_modules`. The evaluator
-receives its hosted-call dispatcher as an explicit dependency; other inspected
-execution rejects hosted calls. The internal hosted symbol and runtime
-signature are validated before an event is recorded. The dispatcher copies the
-event payload and then releases the refcounted arguments whose ownership LIR
-ARC transferred at the hosted-call boundary.
+REPL expressions are explicit compile-time roots. Pure expressions produce an
+inspected value, and `dbg` observations become ordered structured events.
+Effectful expressions are rejected with an `Effectful Compile Time Expression`
+diagnostic; the WebAssembly module does not expose a platform-effect boundary.
 
 ## Text offsets and completion
 
@@ -130,12 +109,10 @@ typed commands to `executeCommandWithConfig`; they are not recognized by the
 WASM protocol. The browser demo renders only structured fields and never parses
 compiler display text.
 
-The module has no filesystem, network, package resolver, stdin, or history
-store. Apart from the explicit one-way `Repl.emit!` event boundary, it has no
-platform capabilities. Hosts own persistence, effect handling, and
-cancellation. The demo uses a Web Worker; Stop terminates the worker, creates a
-new module instance, and replays the exact structured `definition_source`
-returned by `get_state`.
+The module has no filesystem, network, package resolver, stdin, history store,
+or platform effects. Hosts own persistence and cancellation. The demo uses a
+Web Worker; Stop terminates the worker, creates a new module instance, and
+replays the exact structured `definition_source` returned by `get_state`.
 
 The demo keeps the complete editable notebook source in one textarea. A line
 containing only `#%%` separates cells; Ctrl/Command-Enter evaluates the active

--- a/src/repl_wasm/main.zig
+++ b/src/repl_wasm/main.zig
@@ -52,32 +52,9 @@ const Region = struct {
     end: u32,
 };
 
-const Event = union(enum) {
-    runtime: struct { kind: []const u8, message: []const u8 },
-    effect: struct { name: []const u8, payload: []const u8 },
-
-    /// Emit the tagged event shape the protocol documents: a `kind` plus either
-    /// a `message` or an effect's `name`/`payload`.
-    pub fn jsonStringify(self: Event, json: anytype) error{WriteFailed}!void {
-        try json.beginObject();
-        switch (self) {
-            .runtime => |event| {
-                try json.objectField("kind");
-                try json.write(event.kind);
-                try json.objectField("message");
-                try json.write(event.message);
-            },
-            .effect => |event| {
-                try json.objectField("kind");
-                try json.write("effect");
-                try json.objectField("name");
-                try json.write(event.name);
-                try json.objectField("payload");
-                try json.write(event.payload);
-            },
-        }
-        try json.endObject();
-    }
+const Event = struct {
+    kind: []const u8,
+    message: []const u8,
 };
 
 const Crash = struct {
@@ -197,13 +174,10 @@ fn copyEvents(arena: Allocator, session: *ReplSession) Allocator.Error![]const E
     const events = try arena.alloc(Event, host_events.len);
     for (host_events, 0..) |event, index| {
         events[index] = switch (event) {
-            .dbg => |message| .{ .runtime = .{ .kind = "dbg", .message = try arenaDupe(arena, message) } },
-            .expect_failed => |message| .{ .runtime = .{ .kind = "expect_failed", .message = try arenaDupe(arena, message) } },
-            .crashed => |message| .{ .runtime = .{ .kind = "crashed", .message = try arenaDupe(arena, message) } },
-            .effect => |effect| .{ .effect = .{
-                .name = try arenaDupe(arena, effect.name),
-                .payload = try arenaDupe(arena, effect.payload),
-            } },
+            .dbg => |message| .{ .kind = "dbg", .message = try arenaDupe(arena, message) },
+            .expect_failed => |message| .{ .kind = "expect_failed", .message = try arenaDupe(arena, message) },
+            .crashed => |message| .{ .kind = "crashed", .message = try arenaDupe(arena, message) },
+            .effect => unreachable,
         };
     }
     return events;
@@ -602,11 +576,7 @@ fn capabilities(request: Request) Allocator.Error![]u8 {
             .presentation_strings = false,
             .filesystem = false,
             .network = false,
-            .platform_effects = "one_way_events",
-            .effect_module = eval.InspectedRun.repl_effect_module_name,
-            .effect_function = "emit!",
-            .effect_payload_encoding = "caller_defined_utf8",
-            .effect_responses = false,
+            .platform_effects = false,
             .host_managed_history = true,
             .host_managed_cancellation = true,
         },

--- a/src/repl_wasm/protocol.d.ts
+++ b/src/repl_wasm/protocol.d.ts
@@ -22,10 +22,7 @@ export interface Diagnostic {
   region: Region | null;
 }
 
-export type RuntimeEvent =
-  | { kind: "dbg" | "expect_failed" | "crashed"; message: string }
-  /** A one-way request emitted by `Repl.emit!`; the host owns interpretation. */
-  | { kind: "effect"; name: string; payload: string };
+export type RuntimeEvent = { kind: "dbg" | "expect_failed" | "crashed"; message: string };
 
 export interface SnippetResult {
   source: string;
@@ -128,11 +125,7 @@ export interface CapabilitiesResult {
   revision_bits: 32;
   completion_scope: "session_definitions";
   features: Record<string, boolean | string> & {
-    platform_effects: "one_way_events";
-    effect_module: "Repl";
-    effect_function: "emit!";
-    effect_payload_encoding: "caller_defined_utf8";
-    effect_responses: false;
+    platform_effects: false;
   };
 }
 

--- a/src/repl_wasm/www/app.js
+++ b/src/repl_wasm/www/app.js
@@ -19,7 +19,6 @@ const editorStatus = document.querySelector("#editor-status");
 const completion = document.querySelector("#completion");
 const definitions = document.querySelector("#definitions");
 const modules = document.querySelector("#modules");
-const toasts = document.querySelector("#toasts");
 
 let worker;
 let ready = false;
@@ -103,31 +102,8 @@ function definitionSummary(snippet) {
   }
 }
 
-function showToast(payload) {
-  const toast = makeElement("div", "toast", payload);
-  toasts.append(toast);
-  setTimeout(() => toast.remove(), 4000);
-}
-
-const effectHandlers = new Map([
-  ["log", (payload) => console.log(`[Roc REPL] ${payload}`)],
-  ["toast", showToast],
-]);
-
-function renderEvent(event, runEffects) {
-  if (event.kind !== "effect") {
-    return makeElement("div", "event", `${event.kind}: ${event.message}`);
-  }
-
-  const handler = effectHandlers.get(event.name);
-  let disposition = "unhandled";
-  if (!runEffects) {
-    disposition = "suppressed";
-  } else if (handler) {
-    handler(event.payload);
-    disposition = "handled";
-  }
-  return makeElement("div", `event effect ${disposition}`, `effect ${event.name}: ${event.payload} (${disposition})`);
+function renderEvent(event) {
+  return makeElement("div", "event", `${event.kind}: ${event.message}`);
 }
 
 function renderSnippet(snippet) {
@@ -144,7 +120,7 @@ function renderSnippet(snippet) {
   }
   for (const event of snippet.events || []) {
     if (event.kind === "crashed") continue;
-    node.append(renderEvent(event, snippet.status === "ok"));
+    node.append(renderEvent(event));
   }
   if (snippet.status === "crashed") {
     node.append(makeElement(

--- a/src/repl_wasm/www/index.html
+++ b/src/repl_wasm/www/index.html
@@ -53,7 +53,6 @@
     .diagnostic { color: var(--danger); white-space: pre-wrap; font: 13px/1.45 ui-monospace, monospace; }
     .request-failure { padding: .8rem; }
     .event { color: var(--event); white-space: pre-wrap; font: 13px/1.45 ui-monospace, monospace; }
-    .effect.unhandled, .effect.suppressed { color: var(--muted); }
     .notice { padding: .6rem .8rem; color: var(--muted); font-size: .82rem; }
     aside { padding: 1rem; }
     aside section + section { margin-top: 1.5rem; }
@@ -64,8 +63,6 @@
     #transcript > .empty { padding: 1rem; }
     kbd { border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 5px; padding: .08rem .3rem; background: Canvas; font: 11px ui-monospace, monospace; }
     .shortcuts { display: grid; grid-template-columns: auto 1fr; gap: .45rem .6rem; margin-top: .7rem; color: var(--muted); font-size: .82rem; }
-    .toasts { position: fixed; z-index: 4; right: 1rem; bottom: 1rem; display: grid; gap: .5rem; max-width: min(360px, calc(100vw - 2rem)); }
-    .toast { border: 1px solid var(--accent); border-radius: 10px; padding: .75rem 1rem; background: Canvas; box-shadow: 0 10px 30px #0004; }
     @media (max-width: 1100px) { .workspace.details-open { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); } .workspace.details-open aside { grid-column: 1 / -1; } }
     @media (max-width: 760px) { .workspace, .workspace.details-open { grid-template-columns: 1fr; } .workspace.details-open aside { grid-column: auto; } header { align-items: start; flex-direction: column; } .toolbar .status { width: 100%; margin-left: 0; } textarea, #transcript { min-height: 45vh; } }
   </style>
@@ -97,11 +94,7 @@ bar = "${foo}: bar"
 #%%
 bar
 #%%
-import Repl
-#%%
-Repl.emit!({ name: "log", payload: "Hello from Roc" })
-#%%
-Repl.emit!({ name: "toast", payload: "The caller handled this effect" })</textarea>
+dbg bar</textarea>
         <div id="completion" class="completion" role="listbox" aria-label="Completions" hidden></div>
       </div>
     </main>
@@ -138,7 +131,6 @@ Repl.emit!({ name: "toast", payload: "The caller handled this effect" })</textar
     </aside>
   </div>
 
-  <div id="toasts" class="toasts" aria-live="polite"></div>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/test/repl-wasm-test/main.zig
+++ b/test/repl-wasm-test/main.zig
@@ -64,17 +64,6 @@ fn requireContains(response: []const u8, expected: []const u8) anyerror!void {
     return error.UnexpectedResponse;
 }
 
-fn requireInOrder(response: []const u8, expected: []const []const u8) anyerror!void {
-    var offset: usize = 0;
-    for (expected) |fragment| {
-        const relative = std.mem.find(u8, response[offset..], fragment) orelse {
-            std.debug.print("Expected ordered fragment:\n{s}\nAfter offset {d} in response:\n{s}\n", .{ fragment, offset, response });
-            return error.UnexpectedResponse;
-        };
-        offset += relative + fragment.len;
-    }
-}
-
 fn sendAndRequire(interface: Interface, allocator: std.mem.Allocator, request: []const u8, expected: []const []const u8) anyerror!void {
     const response = try invoke(interface, allocator, request);
     defer allocator.free(response);
@@ -127,9 +116,9 @@ pub fn main(init: std.process.Init) anyerror!void {
         .free_response = try instance.getFunctionHandle("roc_repl_free_response"),
     };
 
-    try sendAndRequire(interface, gpa,
+    try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":1,"op":"capabilities"}
-    , &.{ "\"ok\":true", "one_session_per_wasm_instance", "\"revision_bits\":32", "\"presentation_strings\":false", "\"diagnostic_scope\":\"blocking_only\"", "\"completion_scope\":\"session_definitions\"", "\"filesystem\":false", "\"platform_effects\":\"one_way_events\"", "\"effect_module\":\"Repl\"", "\"effect_function\":\"emit!\"", "\"effect_payload_encoding\":\"caller_defined_utf8\"", "\"effect_responses\":false" });
+    , &.{ "\"ok\":true", "one_session_per_wasm_instance", "\"revision_bits\":32", "\"presentation_strings\":false", "\"diagnostic_scope\":\"blocking_only\"", "\"completion_scope\":\"session_definitions\"", "\"filesystem\":false", "\"platform_effects\":false" }, &.{ "one_way_events", "\"effect_module\"", "\"effect_function\"", "\"effect_payload_encoding\"", "\"effect_responses\"" });
 
     try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":2,"op":"eval","params":{"source":"x = 41"}}
@@ -175,43 +164,29 @@ pub fn main(init: std.process.Init) anyerror!void {
         \\{"protocol":1,"id":11,"op":"eval","params":{"source":"dbg \"hello\""}}
     , &.{ "\"kind\":\"dbg\"", "hello" });
 
-    try sendAndRequire(interface, gpa,
+    try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":111,"op":"eval","params":{"source":"{ expect 1 == 0\n42 }"}}
-    , &.{ "\"kind\":\"expect_failed\"", "expect failed", "\"value\":\"42.0\"" });
+    , &.{ "\"status\":\"diagnostic\"", "\"code\":\"compile_error\"", "Compile Time Expect Failed", "expect failed", "\"events\":[]", "\"completed\":false", "\"stop_reason\":\"diagnostic\"", "\"committed_count\":0" }, &.{ "\"kind\":\"expect_failed\"", "\"value\":\"42.0\"" });
 
-    try sendAndRequire(interface, gpa,
+    try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":12,"op":"eval","params":{"source":"crash \"boom\""}}
-    , &.{ "\"status\":\"crashed\"", "\"crash\":{\"message\":\"boom\"}", "\"kind\":\"crashed\"" });
+    , &.{ "\"status\":\"diagnostic\"", "\"code\":\"compile_error\"", "Compile Time Crash", "boom", "\"events\":[]", "\"completed\":false", "\"stop_reason\":\"diagnostic\"", "\"committed_count\":0" }, &.{ "\"status\":\"crashed\"", "\"crash\":{\"message\":\"boom\"}", "\"kind\":\"crashed\"" });
 
     try sendAndRequire(interface, gpa,
         \\{"protocol":1,"id":13,"op":"eval","params":{"source":"1 + 1"}}
     , &.{ "\"status\":\"ok\"", "\"value\":\"2.0\"" });
 
-    const effect_response = try invoke(interface, gpa,
+    try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":130,"op":"eval","params":{"source":"import Repl\n{\n    Repl.emit!({ name: \"log\", payload: \"héllo\" })\n    dbg \"middle\"\n    Repl.emit!({ name: \"toast\", payload: \"done\" })\n}"}}
-    );
-    defer gpa.free(effect_response);
-    try requireInOrder(effect_response, &.{
-        "\"definition_kind\":\"import\"",
-        "\"kind\":\"effect\",\"name\":\"log\",\"payload\":\"héllo\"",
-        "\"kind\":\"dbg\"",
-        "\"kind\":\"effect\",\"name\":\"toast\",\"payload\":\"done\"",
-    });
-    try requireContains(effect_response, "\"type\":\"{}\"");
+    , &.{ "\"definition_kind\":\"import\"", "\"status\":\"diagnostic\"", "\"code\":\"compile_error\"", "Effectful Compile Time Expression", "\"events\":[]", "\"completed\":false", "\"stop_reason\":\"diagnostic\"", "\"committed_count\":1" }, &.{ "\"kind\":\"effect\"", "\"kind\":\"dbg\"", "\"type\":\"{}\"" });
 
     try sendAndRequire(interface, gpa,
         \\{"protocol":1,"id":1300,"op":"inspect","params":{"source":"Repl.emit!({ name: \"log\", payload: \"inspection does not run\" })"}}
     , &.{ "\"status\":\"ok\"", "\"type\":\"{}\"" });
 
-    const crashed_effect_response = try invoke(interface, gpa,
+    try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":1301,"op":"eval","params":{"source":"{\n    Repl.emit!({ name: \"log\", payload: \"before crash\" })\n    crash \"effect boom\"\n}"}}
-    );
-    defer gpa.free(crashed_effect_response);
-    try requireContains(crashed_effect_response, "\"crash\":{\"message\":\"effect boom\"}");
-    try requireInOrder(crashed_effect_response, &.{
-        "\"kind\":\"effect\",\"name\":\"log\",\"payload\":\"before crash\"",
-        "\"kind\":\"crashed\"",
-    });
+    , &.{ "\"status\":\"diagnostic\"", "\"code\":\"compile_error\"", "Effectful Compile Time Expression", "\"events\":[]", "\"completed\":false", "\"stop_reason\":\"diagnostic\"", "\"committed_count\":0" }, &.{ "\"kind\":\"effect\"", "\"crash\":{\"message\":\"effect boom\"}", "\"kind\":\"crashed\"" });
 
     try sendAndRequire(interface, gpa,
         \\{"protocol":1,"id":131,"op":"eval","params":{"source":"pending : Str"}}
@@ -285,7 +260,7 @@ pub fn main(init: std.process.Init) anyerror!void {
         \\{"protocol":1,"id":19,"op":"set_modules","params":{"modules":[{"name":"Other","source":"Other := [].{\n    emit! : { name : Str, payload : Str } => {}\n}"}]}}
     , &.{ "\"ok\":true", "\"module_names\":[\"Other\"]" });
 
-    try sendAndRequire(interface, gpa,
+    try sendAndCheck(interface, gpa,
         \\{"protocol":1,"id":20,"op":"eval","params":{"source":"import Other\nOther.emit!({ name: \"log\", payload: \"not Repl\" })"}}
-    , &.{ "\"status\":\"diagnostic\"", "This REPL only supports the hosted function Repl.emit!." });
+    , &.{ "\"status\":\"diagnostic\"", "\"code\":\"compile_error\"", "Effectful Compile Time Expression", "\"events\":[]", "\"completed\":false", "\"stop_reason\":\"diagnostic\"", "\"committed_count\":1" }, &.{ "This REPL only supports the hosted function Repl.emit!.", "\"kind\":\"effect\"" });
 }


### PR DESCRIPTION
REPL expressions became compile-time roots in #11031, which makes failed expects, crashes, and effects checking diagnostics, but the WebAssembly protocol surfaces and nightly coverage still described the old runtime behavior. This aligns the protocol, capabilities, docs, demo, and regression assertions with compile-time evaluation while preserving structured dbg events.