### PR TITLE
Harden LSP protocol validation and failure handling

### DIFF
--- a/src/lsp/build_session.zig
+++ b/src/lsp/build_session.zig
@@ -67,6 +67,9 @@ pub const BuildSession = struct {
             override = .{ .path = absolute_path, .content = text, .base = env.filesystem };
             env.filesystem = override.io();
         }
+        errdefer if (override_text != null) {
+            env.filesystem = saved_io;
+        };
 
         const preferred_main = try preferredMainFromWorkspace(allocator, env.filesystem, workspace_root);
         defer if (preferred_main) |main_path| allocator.free(main_path);

--- a/src/lsp/handlers/did_change.zig
+++ b/src/lsp/handlers/did_change.zig
@@ -7,7 +7,7 @@ const DocumentStore = @import("../document_store.zig").DocumentStore;
 /// Handler for `textDocument/didChange` notifications (supports incremental edits).
 pub fn handler(comptime ServerType: type) type {
     return struct {
-        pub fn call(self: *ServerType, params_value: ?std.json.Value) Allocator.Error!void {
+        pub fn call(self: *ServerType, params_value: ?std.json.Value) (Allocator.Error || error{WriteFailed})!void {
             const params = params_value orelse return;
             if (std.meta.activeTag(params) != .object) return;
             const obj = params.object;
@@ -81,7 +81,7 @@ pub fn handler(comptime ServerType: type) type {
                 };
             }
 
-            self.onDocumentChanged(uri);
+            try self.onDocumentChanged(uri);
         }
 
         fn parseRange(value: std.json.Value) error{InvalidRange}!DocumentStore.Range {

--- a/src/lsp/handlers/did_open.zig
+++ b/src/lsp/handlers/did_open.zig
@@ -6,7 +6,7 @@ const Allocator = std.mem.Allocator;
 /// Handler for `textDocument/didOpen` notifications.
 pub fn handler(comptime ServerType: type) type {
     return struct {
-        pub fn call(self: *ServerType, params_value: ?std.json.Value) Allocator.Error!void {
+        pub fn call(self: *ServerType, params_value: ?std.json.Value) (Allocator.Error || error{WriteFailed})!void {
             const params = params_value orelse return;
             if (std.meta.activeTag(params) != .object) return;
             const obj = params.object;
@@ -33,7 +33,7 @@ pub fn handler(comptime ServerType: type) type {
 
             try self.doc_store.upsert(uri, version, text);
 
-            self.onDocumentChanged(uri);
+            try self.onDocumentChanged(uri);
         }
     };
 }

--- a/src/lsp/handlers/initialize.zig
+++ b/src/lsp/handlers/initialize.zig
@@ -8,7 +8,7 @@ const capabilities = @import("../capabilities.zig");
 /// Returns the `initialize` method handler for the LSP.
 pub fn handler(comptime ServerType: type) type {
     return struct {
-        pub fn call(self: *ServerType, id: *protocol.JsonId, maybe_params: ?std.json.Value) (Allocator.Error || error{ InvalidParams, WriteFailed })!void {
+        pub fn call(self: *ServerType, id: *protocol.JsonId, maybe_params: ?std.json.Value) (Allocator.Error || error{WriteFailed})!void {
             if (self.state != .waiting_for_initialize) {
                 try ServerType.sendError(self, id, .invalid_request, "server was already initialized");
                 return;
@@ -16,12 +16,14 @@ pub fn handler(comptime ServerType: type) type {
 
             const params_value = maybe_params orelse return try ServerType.sendError(self, id, .invalid_params, "initialize requires params");
 
-            var params = try protocol.InitializeParams.fromJson(self.allocator, params_value);
+            var params = protocol.InitializeParams.fromJson(self.allocator, params_value) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.InvalidParams => {
+                    try ServerType.sendError(self, id, .invalid_params, "invalid initialize params");
+                    return;
+                },
+            };
             defer params.deinit(self.allocator);
-
-            self.client.deinit(self.allocator);
-            params.moveInto(&self.client);
-            self.state = .waiting_for_initialized;
 
             const response = protocol.InitializeResult{
                 .capabilities = capabilities.buildCapabilities(),
@@ -32,6 +34,10 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             try ServerType.sendResponse(self, id, response);
+
+            self.client.deinit(self.allocator);
+            params.moveInto(&self.client);
+            self.state = .waiting_for_initialized;
         }
     };
 }

--- a/src/lsp/protocol.zig
+++ b/src/lsp/protocol.zig
@@ -11,7 +11,7 @@ pub const ErrorCode = enum(i32) {
     invalid_params = -32602,
     internal_error = -32603,
     server_not_initialized = -32002,
-    request_failed = -32003,
+    request_failed = -32803,
     server_cancelled = -32802,
     content_modified = -32801,
     request_cancelled = -32800,
@@ -34,7 +34,10 @@ pub const JsonId = union(enum) {
     string: []u8,
 
     pub fn fromJsonValue(allocator: std.mem.Allocator, value: std.json.Value) (Allocator.Error || error{InvalidIdType})!JsonId {
-        if (std.meta.activeTag(value) == .integer) return .{ .integer = value.integer };
+        if (std.meta.activeTag(value) == .integer) {
+            if (std.math.cast(i32, value.integer) == null) return error.InvalidIdType;
+            return .{ .integer = value.integer };
+        }
         if (std.meta.activeTag(value) == .string) return .{ .string = try copyString(allocator, value.string) };
         return error.InvalidIdType;
     }
@@ -47,7 +50,10 @@ pub const JsonId = union(enum) {
     }
 
     pub fn deinit(self: *JsonId, allocator: std.mem.Allocator) void {
-        if (std.meta.activeTag(self.*) == .string) allocator.free(self.string);
+        switch (self.*) {
+            .integer => {},
+            .string => |text| allocator.free(text),
+        }
         self.* = undefined;
     }
 
@@ -89,55 +95,64 @@ pub const InitializeParams = struct {
         if (std.meta.activeTag(value) != .object) return error.InvalidParams;
         const obj = value.object;
 
-        var params = InitializeParams{};
-
-        if (obj.get("processId")) |pid_node| {
-            if (std.meta.activeTag(pid_node) == .integer) {
-                params.process_id = pid_node.integer;
-            } else if (std.meta.activeTag(pid_node) != .null) {
-                return error.InvalidParams;
-            }
-        }
-
-        if (obj.get("rootUri")) |uri_node| {
-            const uri_text: ?[]const u8 = if (std.meta.activeTag(uri_node) == .string)
-                uri_node.string
-            else if (std.meta.activeTag(uri_node) == .null)
-                null
+        const process_id_value = obj.get("processId") orelse return error.InvalidParams;
+        const process_id: ?i64 = if (std.meta.activeTag(process_id_value) == .integer)
+            if (std.math.cast(i32, process_id_value.integer) != null)
+                process_id_value.integer
             else
-                return error.InvalidParams;
-            if (uri_text) |text| {
-                params.root_uri = try copyString(allocator, text);
-            }
-        }
+                return error.InvalidParams
+        else if (std.meta.activeTag(process_id_value) == .null)
+            null
+        else
+            return error.InvalidParams;
 
+        const root_uri_value = obj.get("rootUri") orelse return error.InvalidParams;
+        const root_uri_text: ?[]const u8 = if (std.meta.activeTag(root_uri_value) == .string)
+            root_uri_value.string
+        else if (std.meta.activeTag(root_uri_value) == .null)
+            null
+        else
+            return error.InvalidParams;
+
+        const capabilities_value = obj.get("capabilities") orelse return error.InvalidParams;
+        if (std.meta.activeTag(capabilities_value) != .object) return error.InvalidParams;
+
+        var client_name: ?[]const u8 = null;
+        var client_version: ?[]const u8 = null;
         if (obj.get("clientInfo")) |client_node| {
             if (std.meta.activeTag(client_node) != .object) return error.InvalidParams;
             const client_obj = client_node.object;
             const name_value = client_obj.get("name") orelse return error.InvalidParams;
             if (std.meta.activeTag(name_value) != .string) return error.InvalidParams;
-            const name_string = name_value.string;
+            client_name = name_value.string;
 
+            if (client_obj.get("version")) |version_value| {
+                if (std.meta.activeTag(version_value) != .string) return error.InvalidParams;
+                client_version = version_value.string;
+            }
+        }
+
+        var params = InitializeParams{ .process_id = process_id };
+        errdefer params.deinit(allocator);
+
+        if (root_uri_text) |text| {
+            params.root_uri = try copyString(allocator, text);
+        }
+
+        if (client_name) |name| {
             var info = ClientInfo{
-                .name = try copyString(allocator, name_string),
+                .name = try copyString(allocator, name),
             };
+            errdefer info.deinit(allocator);
 
-            if (client_obj.get("version")) |ver_node| {
-                const ver_text: ?[]u8 = if (std.meta.activeTag(ver_node) == .string)
-                    try copyString(allocator, ver_node.string)
-                else if (std.meta.activeTag(ver_node) == .null)
-                    null
-                else
-                    return error.InvalidParams;
-                info.version = ver_text;
+            if (client_version) |version| {
+                info.version = try copyString(allocator, version);
             }
 
             params.client_info = info;
         }
 
-        if (obj.get("capabilities")) |caps_node| {
-            params.capabilities_json = try stringifyValue(allocator, caps_node);
-        }
+        params.capabilities_json = try stringifyValue(allocator, capabilities_value);
 
         return params;
     }

--- a/src/lsp/server.zig
+++ b/src/lsp/server.zig
@@ -45,6 +45,7 @@ pub const RunWithStdIoError = CreateLogFileError || std.Io.File.Reader.Error || 
     InvalidHeader,
     MissingContentLength,
     PayloadTooLarge,
+    WriteFailed,
 };
 
 /// Factory for the Roc LSP server. Handles the state and request handlers.
@@ -58,9 +59,11 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
     return struct {
         const Self = @This();
         const TransportType = makeTransport(ReaderType, WriterType);
-        const HandlerError = Allocator.Error || error{ InvalidParams, WriteFailed };
-        const NotificationError = Allocator.Error;
-        const PayloadError = Allocator.Error || std.json.ParseError(std.json.Scanner) || HandlerError || NotificationError || error{InvalidIdType};
+        const HandlerError = Allocator.Error || error{WriteFailed};
+        const NotificationError = Allocator.Error || error{WriteFailed};
+        const PayloadError = HandlerError || NotificationError;
+        /// Errors that terminate the server because input or output can no longer be processed reliably.
+        pub const RunError = TransportType.ReadMessageError || PayloadError;
         const RunSyntaxCheckError = SyntaxDriverType.CheckError || Allocator.Error || error{WriteFailed};
         const HandlerFn = fn (*Self, *protocol.JsonId, ?std.json.Value) HandlerError!void;
         const HandlerPtr = *const HandlerFn;
@@ -158,11 +161,11 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
             self.syntax_checker.deinit();
         }
 
-        pub fn run(self: *Self) TransportType.ReadMessageError!void {
+        pub fn run(self: *Self) RunError!void {
             while (try self.processNextMessage()) {}
         }
 
-        fn processNextMessage(self: *Self) TransportType.ReadMessageError!bool {
+        fn processNextMessage(self: *Self) RunError!bool {
             if (self.state == .exit_success or self.state == .exit_failure) {
                 return false;
             }
@@ -178,39 +181,93 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
             };
             defer self.allocator.free(payload);
 
-            self.handlePayload(payload) catch |err| {
-                log.err("failed to process message: {s}", .{@errorName(err)});
-            };
+            try self.handlePayload(payload);
 
             return self.state != .exit_success and self.state != .exit_failure;
         }
 
         fn handlePayload(self: *Self, payload: []u8) PayloadError!void {
-            var parsed = try std.json.parseFromSlice(std.json.Value, self.allocator, payload, .{});
+            var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, payload, .{}) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    try self.sendError(null, .parse_error, "parse error");
+                    return;
+                },
+            };
             defer parsed.deinit();
 
             const root = parsed.value;
             if (std.meta.activeTag(root) != .object) {
-                log.err("received non-object JSON-RPC message", .{});
+                try self.sendError(null, .invalid_request, "invalid request");
                 return;
             }
             const obj = root.object;
 
-            const method_value = obj.get("method") orelse return;
-            if (std.meta.activeTag(method_value) != .string) return;
+            var maybe_id: ?protocol.JsonId = if (obj.get("id")) |id_node|
+                protocol.JsonId.fromJsonValue(self.allocator, id_node) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.InvalidIdType => {
+                        try self.sendError(null, .invalid_request, "invalid request");
+                        return;
+                    },
+                }
+            else
+                null;
+            defer if (maybe_id) |*id| id.deinit(self.allocator);
+
+            const jsonrpc_value = obj.get("jsonrpc") orelse {
+                try self.sendInvalidRequest(if (maybe_id) |*id| id else null);
+                return;
+            };
+            if (std.meta.activeTag(jsonrpc_value) != .string or !std.mem.eql(u8, jsonrpc_value.string, "2.0")) {
+                try self.sendInvalidRequest(if (maybe_id) |*id| id else null);
+                return;
+            }
+
+            const method_value = obj.get("method") orelse {
+                try self.sendInvalidRequest(if (maybe_id) |*id| id else null);
+                return;
+            };
+            if (std.meta.activeTag(method_value) != .string) {
+                try self.sendInvalidRequest(if (maybe_id) |*id| id else null);
+                return;
+            }
             const method = method_value.string;
 
-            if (obj.get("id")) |id_node| {
-                var id = try protocol.JsonId.fromJsonValue(self.allocator, id_node);
-                defer id.deinit(self.allocator);
+            if (obj.get("params")) |params| {
+                switch (std.meta.activeTag(params)) {
+                    .object, .array => {},
+                    .null, .bool, .integer, .float, .number_string, .string => {
+                        try self.sendInvalidRequest(if (maybe_id) |*id| id else null);
+                        return;
+                    },
+                }
+            }
 
-                try self.handleRequest(method, &id, obj.get("params"));
+            if (maybe_id) |*id| {
+                try self.handleRequest(method, id, obj.get("params"));
             } else {
                 try self.handleNotification(method, obj.get("params"));
             }
         }
 
         fn handleRequest(self: *Self, method: []const u8, id: *protocol.JsonId, maybe_params: ?std.json.Value) HandlerError!void {
+            switch (self.state) {
+                .waiting_for_initialize => if (!std.mem.eql(u8, method, "initialize")) {
+                    try self.sendError(id, .server_not_initialized, "server not initialized");
+                    return;
+                },
+                .waiting_for_initialized => if (!std.mem.eql(u8, method, "initialize")) {
+                    try self.sendError(id, .server_not_initialized, "server not initialized");
+                    return;
+                },
+                .running => {},
+                .shutdown, .exit_success, .exit_failure => {
+                    try self.sendError(id, .invalid_request, "server is shutting down");
+                    return;
+                },
+            }
+
             if (request_handlers.get(method)) |handler| {
                 try handler(self, id, maybe_params);
                 return;
@@ -219,23 +276,31 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
             try self.sendError(id, .method_not_found, "method not implemented");
         }
 
-        fn handleNotification(self: *Self, method: []const u8, params: ?std.json.Value) Allocator.Error!void {
-            if (std.mem.eql(u8, method, "initialized")) {
-                if (self.state == .waiting_for_initialized) {
-                    self.state = .running;
-                }
-                return;
-            }
+        fn sendInvalidRequest(self: *Self, maybe_id: ?*protocol.JsonId) (Allocator.Error || error{WriteFailed})!void {
+            try self.sendError(maybe_id, .invalid_request, "invalid request");
+        }
 
+        fn handleNotification(self: *Self, method: []const u8, params: ?std.json.Value) NotificationError!void {
             if (std.mem.eql(u8, method, "exit")) {
                 self.state = if (self.state == .shutdown) .exit_success else .exit_failure;
                 return;
             }
 
+            switch (self.state) {
+                .waiting_for_initialized => {
+                    if (std.mem.eql(u8, method, "initialized")) {
+                        self.state = .running;
+                    }
+                    return;
+                },
+                .running => {},
+                .waiting_for_initialize, .shutdown, .exit_success, .exit_failure => return,
+            }
+
+            if (std.mem.eql(u8, method, "initialized")) return;
+
             if (notification_handlers.get(method)) |handler| {
-                handler(self, params) catch |err| {
-                    log.err("notification handler {s} failed: {s}", .{ method, @errorName(err) });
-                };
+                try handler(self, params);
                 return;
             }
 
@@ -255,15 +320,15 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
             });
         }
 
-        pub fn sendError(self: *Self, id: *protocol.JsonId, code: protocol.ErrorCode, message: []const u8) (Allocator.Error || error{WriteFailed})!void {
+        pub fn sendError(self: *Self, id: ?*protocol.JsonId, code: protocol.ErrorCode, message: []const u8) (Allocator.Error || error{WriteFailed})!void {
             const Response = struct {
                 jsonrpc: []const u8 = "2.0",
-                id: protocol.JsonId,
+                id: ?protocol.JsonId,
                 @"error": protocol.ResponseError,
             };
 
             try self.transport.sendJson(Response{
-                .id = id.*,
+                .id = if (id) |value| value.* else null,
                 .@"error" = .{ .code = code, .message = message },
             });
         }
@@ -281,9 +346,13 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
             });
         }
 
-        pub fn onDocumentChanged(self: *Self, uri: []const u8) void {
+        pub fn onDocumentChanged(self: *Self, uri: []const u8) (Allocator.Error || error{WriteFailed})!void {
             self.runSyntaxCheck(uri) catch |err| {
-                log.err("syntax check failed for {s}: {s}", .{ uri, @errorName(err) });
+                switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.WriteFailed => return error.WriteFailed,
+                    else => log.err("syntax check failed for {s}: {s}", .{ uri, @errorName(err) }),
+                }
             };
         }
 

--- a/src/lsp/test/handler_integration_tests.zig
+++ b/src/lsp/test/handler_integration_tests.zig
@@ -285,7 +285,7 @@ fn runSessionResponses(
     var bodies: std.ArrayList([]const u8) = .empty;
     defer bodies.deinit(allocator);
     try bodies.append(allocator,
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     );
     try bodies.append(allocator,
         \\{"jsonrpc":"2.0","method":"initialized","params":{}}
@@ -400,7 +400,7 @@ pub fn documentSymbolHandlerExtractsFunctionDeclarations() integration_spec.Spec
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "symbols.roc", .data = roc_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -500,7 +500,7 @@ pub fn documentHighlightHandlerFindsVariableOccurrences() integration_spec.SpecE
     defer allocator.free(file_uri);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -609,7 +609,7 @@ pub fn documentHighlightHandlerResolvesFromReferenceSite() integration_spec.Spec
     defer allocator.free(escaped_source);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -720,7 +720,7 @@ pub fn documentHighlightHandlerIncludesAnnotationName() integration_spec.SpecErr
     defer allocator.free(escaped_source);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -1686,7 +1686,7 @@ pub fn definitionHandlerFindsLocalVariableDefinition() integration_spec.SpecErro
     defer allocator.free(escaped_source);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -1773,7 +1773,7 @@ pub fn definitionHandlerReturnsNullForUndefinedSymbol() integration_spec.SpecErr
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -1862,7 +1862,7 @@ pub fn hoverHandlerReturnsTypeInfoForTypeAnnotation() integration_spec.SpecError
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -1959,7 +1959,7 @@ pub fn definitionHandlerNavigatesToBuiltinTypeFromTypeAnnotation() integration_s
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2057,7 +2057,7 @@ pub fn documentSymbolsWorksAfterGotoDefinitionRegressionTest() integration_spec.
     defer allocator.free(escaped_source);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2172,7 +2172,7 @@ pub fn multipleGotoDefinitionCallsDontBreakDocumentSymbols() integration_spec.Sp
     defer allocator.free(escaped_source);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2304,7 +2304,7 @@ pub fn documentSymbolHandlerReturnsSymbolsWithCorrectNames() integration_spec.Sp
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "outline.roc", .data = roc_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2419,7 +2419,7 @@ pub fn documentSymbolHandlerWorksIndependentlyOfCheck() integration_spec.SpecErr
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "independent.roc", .data = roc_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2520,7 +2520,7 @@ pub fn completionHandlerReturnsModuleDefinitions() integration_spec.SpecError!vo
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2609,7 +2609,7 @@ pub fn completionHandlerReturnsModuleMembersAfterDot() integration_spec.SpecErro
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2697,7 +2697,7 @@ pub fn completionHandlerReturnsModuleNamesInExpressionContext() integration_spec
     defer allocator.free(file_uri);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2787,7 +2787,7 @@ pub fn completionHandlerReturnsTypesAfterColon() integration_spec.SpecError!void
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2876,7 +2876,7 @@ pub fn completionHandlerReturnsListModuleMembersAfterListDot() integration_spec.
     const platform_path = try platformPath(allocator);
     defer allocator.free(platform_path);
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -2971,7 +2971,7 @@ pub fn completionHandlerReturnsLocalVariablesInBlockScope() integration_spec.Spe
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3064,7 +3064,7 @@ pub fn completionHandlerReturnsLambdaParameters() integration_spec.SpecError!voi
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3153,7 +3153,7 @@ pub fn completionHandlerReturnsTopLevelDefinitions() integration_spec.SpecError!
     defer allocator.free(file_uri);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3243,7 +3243,7 @@ pub fn completionHandlerReturnsRecordFieldsAfterDot() integration_spec.SpecError
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3348,7 +3348,7 @@ pub fn definitionHandlerNavigatesToBuiltinDeclarations() integration_spec.SpecEr
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3478,7 +3478,7 @@ pub fn workspaceDocumentEndingInBuiltinRocBuildsAndProducesDiagnostics() integra
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3578,7 +3578,7 @@ pub fn openingBuiltinRocDoesNotPanic() integration_spec.SpecError!void {
     defer allocator.free(builtin_uri);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3664,7 +3664,7 @@ pub fn definitionHandlerNavigatesToExternalModuleMembers() integration_spec.Spec
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "ComputeHelper.roc", .data = helper_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3798,7 +3798,7 @@ pub fn definitionHandlerNavigatesToExposedImportMemberInImportStatement() integr
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "Helpers.roc", .data = helper_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -3907,7 +3907,7 @@ pub fn definitionHandlerNavigatesToUnqualifiedExposedImportFunctionCall() integr
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "Helpers.roc", .data = helper_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4001,7 +4001,7 @@ pub fn definitionHandlerNavigatesToTagDeclarationInPatternMatch() integration_sp
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4105,7 +4105,7 @@ pub fn definitionHandlerNavigatesToExposedTypeAliasInTypeAnnotation() integratio
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "Helpers.roc", .data = helper_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4202,7 +4202,7 @@ pub fn semanticTokensHandlerHandlesFileImportsWithoutCrashing() integration_spec
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "input.txt", .data = "hello roc" });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4295,7 +4295,7 @@ pub fn definitionHandlerNavigatesToFileImportPath() integration_spec.SpecError!v
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "input.txt", .data = "hello roc" });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4417,7 +4417,7 @@ pub fn definitionHandlerNavigatesToEchoPlatformDefinition() integration_spec.Spe
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4527,7 +4527,7 @@ pub fn definitionHandlerResolvesPackageShorthandQualifiedImport() integration_sp
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "main.roc", .data = main_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4664,7 +4664,7 @@ pub fn definitionHandlerDisambiguatesSameNamedModuleAcrossPackages() integration
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "main.roc", .data = main_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4856,7 +4856,7 @@ pub fn definitionHandlerResolvesShorthandInImportingPackageContext() integration
     try tmp.dir.writeFile(test_env.io, .{ .sub_path = "main.roc", .data = main_source });
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -4986,7 +4986,7 @@ pub fn definitionHandlerNavigatesToTagDeclarationInPackageQualifiedImport() inte
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -5086,7 +5086,7 @@ pub fn definitionHandlerDisambiguatesSameNamedTagAcrossImportedModules() integra
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -5185,7 +5185,7 @@ pub fn definitionHandlerBranchValueOpenTagDoesNotNavigateToMatchConditionType() 
     defer allocator.free(platform_path);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);

--- a/src/lsp/test/handler_unit_tests.zig
+++ b/src/lsp/test/handler_unit_tests.zig
@@ -23,6 +23,7 @@ const UnitTestError = std.mem.Allocator.Error ||
         MissingContentLength,
         MissingResponse,
         PayloadTooLarge,
+        WriteFailed,
     };
 
 fn TestServer(comptime ReaderType: type, comptime WriterType: type) type {
@@ -51,7 +52,7 @@ fn requestInput(
     request_body: []const u8,
 ) std.mem.Allocator.Error![]u8 {
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const initialized_body =
         \\{"jsonrpc":"2.0","method":"initialized","params":{}}

--- a/src/lsp/test/protocol_test.zig
+++ b/src/lsp/test/protocol_test.zig
@@ -19,6 +19,50 @@ test "JsonId round-trips" {
     try std.testing.expectEqualStrings("abc", clone.string);
 }
 
+test "JsonId enforces the LSP integer range" {
+    const allocator = std.testing.allocator;
+
+    var minimum = try protocol.JsonId.fromJsonValue(allocator, .{ .integer = std.math.minInt(i32) });
+    defer minimum.deinit(allocator);
+    var maximum = try protocol.JsonId.fromJsonValue(allocator, .{ .integer = std.math.maxInt(i32) });
+    defer maximum.deinit(allocator);
+
+    try std.testing.expectError(
+        error.InvalidIdType,
+        protocol.JsonId.fromJsonValue(allocator, .{ .integer = @as(i64, std.math.minInt(i32)) - 1 }),
+    );
+    try std.testing.expectError(
+        error.InvalidIdType,
+        protocol.JsonId.fromJsonValue(allocator, .{ .integer = @as(i64, std.math.maxInt(i32)) + 1 }),
+    );
+}
+
+test "ErrorCode serializes the LSP protocol values" {
+    const Case = struct {
+        code: protocol.ErrorCode,
+        expected: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .code = .parse_error, .expected = "-32700" },
+        .{ .code = .invalid_request, .expected = "-32600" },
+        .{ .code = .method_not_found, .expected = "-32601" },
+        .{ .code = .invalid_params, .expected = "-32602" },
+        .{ .code = .internal_error, .expected = "-32603" },
+        .{ .code = .server_not_initialized, .expected = "-32002" },
+        .{ .code = .request_failed, .expected = "-32803" },
+        .{ .code = .server_cancelled, .expected = "-32802" },
+        .{ .code = .content_modified, .expected = "-32801" },
+        .{ .code = .request_cancelled, .expected = "-32800" },
+    };
+
+    for (cases) |case| {
+        var writer: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer writer.deinit();
+        try std.json.Stringify.value(case.code, .{}, &writer.writer);
+        try std.testing.expectEqualStrings(case.expected, writer.written());
+    }
+}
+
 test "InitializeParams parses fields" {
     const allocator = std.testing.allocator;
     const payload =
@@ -46,6 +90,49 @@ test "InitializeParams parses fields" {
 
     try std.testing.expect(params.capabilities_json != null);
     try std.testing.expect(std.mem.find(u8, params.capabilities_json.?, "textDocumentSync") != null);
+}
+
+test "InitializeParams rejects missing and malformed required fields" {
+    const allocator = std.testing.allocator;
+    const invalid_payloads = [_][]const u8{
+        \\{"rootUri":null,"capabilities":{}}
+        ,
+        \\{"processId":null,"capabilities":{}}
+        ,
+        \\{"processId":null,"rootUri":null}
+        ,
+        \\{"processId":2147483648,"rootUri":null,"capabilities":{}}
+        ,
+        \\{"processId":-2147483649,"rootUri":null,"capabilities":{}}
+        ,
+        \\{"processId":null,"rootUri":42,"capabilities":{}}
+        ,
+        \\{"processId":null,"rootUri":null,"capabilities":[]}
+        ,
+        \\{"processId":null,"rootUri":null,"capabilities":{},"clientInfo":{"name":"test","version":null}}
+        ,
+    };
+
+    for (invalid_payloads) |payload| {
+        var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+        defer parsed.deinit();
+        try std.testing.expectError(error.InvalidParams, protocol.InitializeParams.fromJson(allocator, parsed.value));
+    }
+}
+
+test "InitializeParams cleans up partial allocations after OOM" {
+    const allocator = std.testing.allocator;
+    const payload =
+        \\{"processId":1,"rootUri":"file:///tmp","capabilities":{},"clientInfo":{"name":"test"}}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+    defer parsed.deinit();
+
+    var failing_allocator = std.testing.FailingAllocator.init(allocator, .{ .fail_index = 1 });
+    try std.testing.expectError(
+        error.OutOfMemory,
+        protocol.InitializeParams.fromJson(failing_allocator.allocator(), parsed.value),
+    );
 }
 
 test "SemanticTokensParams parses textDocument.uri" {

--- a/src/lsp/test/server_test.zig
+++ b/src/lsp/test/server_test.zig
@@ -10,17 +10,96 @@ const frame = helpers.frame;
 const collectResponses = helpers.collectResponses;
 const uriFromPath = helpers.uriFromPath;
 
+const ExpectSingleErrorResponseError = helpers.HelperError || std.json.ParseError(std.json.Scanner) || error{
+    MissingCode,
+    MissingError,
+    MissingId,
+    MissingMessage,
+    TestExpectedEqual,
+    TestUnexpectedResult,
+    WriteFailed,
+};
+
+const InitialServerState = enum {
+    waiting_for_initialize,
+    running,
+    shutdown,
+};
+
+const FailingWriter = struct {
+    pub fn write(_: *@This(), _: []const u8) error{InjectedFailure}!usize {
+        return error.InjectedFailure;
+    }
+};
+
 fn TestServer(comptime ReaderType: type, comptime WriterType: type) type {
     return server_module.ServerWithSyntaxDriver(ReaderType, WriterType, TestSyntaxDriver);
 }
 
+fn expectSingleErrorResponse(
+    allocator: std.mem.Allocator,
+    request_body: []const u8,
+    expected_id: ?i64,
+    expected_code: protocol.ErrorCode,
+    expected_message: []const u8,
+    initial_state: InitialServerState,
+) ExpectSingleErrorResponseError!void {
+    const input = try frame(allocator, request_body);
+    defer allocator.free(input);
+
+    const reader_stream: std.Io.Reader = .fixed(input);
+    var writer_buffer: [4096]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    var server = try TestServer(std.Io.Reader, std.Io.Writer).init(allocator, std.testing.io, reader_stream, writer_stream, null, .{});
+    defer server.deinit();
+    server.state = switch (initial_state) {
+        .waiting_for_initialize => .waiting_for_initialize,
+        .running => .running,
+        .shutdown => .shutdown,
+    };
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), responses.len);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, responses[0], .{});
+    defer parsed.deinit();
+    const response = parsed.value.object;
+
+    const id = response.get("id") orelse return error.MissingId;
+    if (expected_id) |integer| {
+        try std.testing.expect(id == .integer);
+        try std.testing.expectEqual(integer, id.integer);
+    } else {
+        try std.testing.expect(id == .null);
+    }
+
+    const response_error = response.get("error") orelse return error.MissingError;
+    const code = response_error.object.get("code") orelse return error.MissingCode;
+    try std.testing.expectEqual(@as(i64, @intFromEnum(expected_code)), code.integer);
+    const message = response_error.object.get("message") orelse return error.MissingMessage;
+    try std.testing.expectEqualStrings(expected_message, message.string);
+}
+
 fn lifecycleInput(allocator: std.mem.Allocator) std.mem.Allocator.Error![]u8 {
     const messages = [_][]const u8{
+        \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///tmp/before.roc","version":1,"text":"before"}}}
+        ,
         \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":7,"rootUri":"file:///tmp","clientInfo":{"name":"test-client","version":"1.0.0"},"capabilities":{}}}
         ,
         \\{"jsonrpc":"2.0","method":"initialized","params":{}}
         ,
         \\{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+        ,
+        \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///tmp/after.roc","version":1,"text":"after"}}}
+        ,
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
         ,
         \\{"jsonrpc":"2.0","method":"exit"}
         ,
@@ -55,6 +134,9 @@ test "server handles initialize/shutdown/exit handshake" {
     defer server.deinit();
 
     try server.run();
+    try std.testing.expectEqual(@as(usize, 0), server.syntax_checker.check_calls);
+    try std.testing.expect(server.getDocumentForTesting("file:///tmp/before.roc") == null);
+    try std.testing.expect(server.getDocumentForTesting("file:///tmp/after.roc") == null);
 
     const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
     defer {
@@ -62,7 +144,7 @@ test "server handles initialize/shutdown/exit handshake" {
         allocator.free(responses);
     }
 
-    try std.testing.expectEqual(@as(usize, 2), responses.len);
+    try std.testing.expectEqual(@as(usize, 3), responses.len);
 
     {
         var parsed = try std.json.parseFromSlice(std.json.Value, allocator, responses[0], .{});
@@ -79,15 +161,23 @@ test "server handles initialize/shutdown/exit handshake" {
         const result = parsed.value.object.get("result") orelse return error.MissingResult;
         try std.testing.expect(result == .null);
     }
+
+    {
+        var parsed = try std.json.parseFromSlice(std.json.Value, allocator, responses[2], .{});
+        defer parsed.deinit();
+        const response_error = parsed.value.object.get("error") orelse return error.MissingError;
+        const code = response_error.object.get("code") orelse return error.MissingCode;
+        try std.testing.expectEqual(@as(i64, @intFromEnum(protocol.ErrorCode.invalid_request)), code.integer);
+    }
 }
 
 test "server rejects re-initialization requests" {
     const allocator = std.testing.allocator;
     const init =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const reinit =
-        \\{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const shutdown =
         \\{"jsonrpc":"2.0","id":2,"method":"shutdown"}
@@ -132,6 +222,132 @@ test "server rejects re-initialization requests" {
     try std.testing.expect(error_obj.object.get("code").?.integer == @intFromEnum(protocol.ErrorCode.invalid_request));
 }
 
+test "server reports definition parameter errors exactly once" {
+    const request =
+        \\{"jsonrpc":"2.0","id":7,"method":"textDocument/definition","params":{"textDocument":{"uri":"file:///tmp/main.roc"}}}
+    ;
+
+    try expectSingleErrorResponse(
+        std.testing.allocator,
+        request,
+        7,
+        .invalid_params,
+        "missing position",
+        .running,
+    );
+}
+
+test "server reports invalid initialize params as InvalidParams" {
+    const request =
+        \\{"jsonrpc":"2.0","id":8,"method":"initialize","params":{"processId":"not-an-integer"}}
+    ;
+
+    try expectSingleErrorResponse(
+        std.testing.allocator,
+        request,
+        8,
+        .invalid_params,
+        "invalid initialize params",
+        .waiting_for_initialize,
+    );
+}
+
+test "server keeps malformed params envelopes as InvalidRequest" {
+    const request =
+        \\{"jsonrpc":"2.0","id":9,"method":"shutdown","params":7}
+    ;
+
+    try expectSingleErrorResponse(
+        std.testing.allocator,
+        request,
+        9,
+        .invalid_request,
+        "invalid request",
+        .running,
+    );
+}
+
+test "server uses a null response ID for malformed payloads without IDs" {
+    try expectSingleErrorResponse(
+        std.testing.allocator,
+        "[]",
+        null,
+        .invalid_request,
+        "invalid request",
+        .running,
+    );
+}
+
+test "server enforces request lifecycle state before dispatch" {
+    const request =
+        \\{"jsonrpc":"2.0","id":10,"method":"textDocument/definition","params":{"textDocument":{"uri":"file:///tmp/main.roc"},"position":{"line":0,"character":0}}}
+    ;
+
+    try expectSingleErrorResponse(
+        std.testing.allocator,
+        request,
+        10,
+        .server_not_initialized,
+        "server not initialized",
+        .waiting_for_initialize,
+    );
+    try expectSingleErrorResponse(
+        std.testing.allocator,
+        request,
+        10,
+        .invalid_request,
+        "server is shutting down",
+        .shutdown,
+    );
+}
+
+test "server propagates response write failures without committing initialization" {
+    const allocator = std.testing.allocator;
+    const request =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"capabilities":{}}}
+    ;
+    const input = try frame(allocator, request);
+    defer allocator.free(input);
+
+    const reader: std.Io.Reader = .fixed(input);
+    var server = try TestServer(std.Io.Reader, FailingWriter).init(
+        allocator,
+        std.testing.io,
+        reader,
+        .{},
+        null,
+        .{},
+    );
+    defer server.deinit();
+
+    try std.testing.expectError(error.WriteFailed, server.run());
+    try std.testing.expectEqual(.waiting_for_initialize, server.state);
+    try std.testing.expectEqual(@as(?i64, null), server.client.process_id);
+}
+
+test "server propagates payload allocation failures" {
+    const request = "[]";
+    const input = try frame(std.testing.allocator, request);
+    defer std.testing.allocator.free(input);
+
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+    const allocator = failing_allocator.allocator();
+    const reader: std.Io.Reader = .fixed(input);
+    var writer_buffer: [4096]u8 = undefined;
+    const writer: std.Io.Writer = .fixed(&writer_buffer);
+    var server = try TestServer(std.Io.Reader, std.Io.Writer).init(
+        allocator,
+        std.testing.io,
+        reader,
+        writer,
+        null,
+        .{},
+    );
+    defer server.deinit();
+
+    try std.testing.expectError(error.OutOfMemory, server.run());
+}
+
 test "server tracks documents on didOpen/didChange" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -172,6 +388,7 @@ test "server tracks documents on didOpen/didChange" {
     const WriterType = std.Io.Writer;
     var server = try TestServer(ReaderType, WriterType).init(allocator, std.testing.io, reader_stream, writer_stream, null, .{});
     defer server.deinit();
+    server.state = .running;
     try server.run();
     try std.testing.expectEqual(@as(usize, 2), server.syntax_checker.check_calls);
 
@@ -226,6 +443,7 @@ test "server applies sequential incremental changes in a single didChange" {
     const WriterType = std.Io.Writer;
     var server = try TestServer(ReaderType, WriterType).init(allocator, std.testing.io, reader_stream, writer_stream, null, .{});
     defer server.deinit();
+    server.state = .running;
     try server.run();
     try std.testing.expectEqual(@as(usize, 2), server.syntax_checker.check_calls);
 
@@ -303,6 +521,7 @@ test "server handles burst of incremental didChange messages" {
     const WriterType = std.Io.Writer;
     var server = try TestServer(ReaderType, WriterType).init(allocator, std.testing.io, reader_stream, writer_stream, null, .{});
     defer server.deinit();
+    server.state = .running;
     try server.run();
     try std.testing.expectEqual(@as(usize, 4), server.syntax_checker.check_calls);
 
@@ -326,7 +545,7 @@ test "server responds to semantic tokens request" {
 
     // Full lifecycle: init -> initialized -> didOpen -> semanticTokens -> shutdown -> exit
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -419,7 +638,7 @@ test "server returns error for semantic tokens on unknown document" {
     const allocator = std.testing.allocator;
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);
@@ -504,7 +723,7 @@ test "server returns empty tokens for empty document" {
     defer allocator.free(file_uri);
 
     const init_body =
-        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"rootUri":null,"clientInfo":{"name":"test"},"capabilities":{}}}
     ;
     const init_msg = try frame(allocator, init_body);
     defer allocator.free(init_msg);


### PR DESCRIPTION
LSP requests now enforce protocol-required initialize fields and the JSON-RPC integer ID range, serialize the correct `RequestFailed` error code, and avoid committing initialized state when writing the initialize response fails. Partial parser allocations and temporary build-session filesystem overrides are also cleaned up on failure, with server-level regression coverage for malformed requests and state transitions.