### PR TITLE
Fix default app entrypoint publication

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -6536,6 +6536,12 @@ fn populateExports(self: *Self) std.mem.Allocator.Error!void {
     const scratch_exports_start = self.env.store.scratchDefTop();
 
     const defs_slice = self.env.store.sliceDefs(self.env.top_level_value_defs);
+    const file = self.parse_ir.store.getFile();
+    const header = self.parse_ir.store.getHeader(file.header);
+    const has_implicit_default_app_main = self.env.module_kind == .default_app and switch (header) {
+        .type_module, .default_app => true,
+        .app, .module, .package, .platform, .hosted, .malformed => false,
+    };
 
     // Check each definition to see if it corresponds to an exposed item.
     // We check exposed_idents which only contains items from the exposing clause,
@@ -6550,8 +6556,13 @@ fn populateExports(self: *Self) std.mem.Allocator.Error!void {
         const pattern = self.env.store.getPattern(def.pattern);
 
         if (pattern == .assign) {
-            // Check if this identifier was explicitly exposed in the module header
-            if (self.exposed_idents.contains(pattern.assign.ident)) {
+            // Headerless default apps have an implicit `provides [main!]`.
+            // Record it in the same exact export-definition inventory that
+            // explicit app headers produce, so checked root construction
+            // consumes this inventory instead of the broader exposed-item map.
+            const is_implicit_main = has_implicit_default_app_main and
+                pattern.assign.ident.eql(self.env.idents.main_bang);
+            if (self.exposed_idents.contains(pattern.assign.ident) or is_implicit_main) {
                 try self.env.store.addScratchDef(def_idx);
                 try self.env.setExposedValueNodeIndexById(pattern.assign.ident, @intFromEnum(def_idx));
             }

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -1055,21 +1055,20 @@ pub const RootRequestTable = struct {
             });
         }
 
-        if (validation == .checking) {
-            try appendPublishedEntrypointRoots(
-                &requests,
-                allocator,
-                module,
-                names,
-                checked_types,
-                provided_exports,
-                top_level_values,
-                top_level_procedure_bindings,
-                relation_substitutions,
-                platform_app_relation,
-                platform_required_declarations,
-            );
-        }
+        try appendPublishedEntrypointRoots(
+            &requests,
+            allocator,
+            module,
+            names,
+            checked_types,
+            provided_exports,
+            top_level_values,
+            top_level_procedure_bindings,
+            relation_substitutions,
+            platform_app_relation,
+            platform_required_declarations,
+            validation,
+        );
 
         for (platform_required_bindings.bindings, 0..) |binding, i| {
             switch (binding.value_use) {
@@ -2270,6 +2269,7 @@ fn appendPublishedEntrypointRoots(
     relation_substitutions: *const PlatformRelationTypeSubstitutions,
     platform_app_relation: ?PlatformAppRelationKey,
     platform_required_declarations: *const PlatformRequiredDeclarationTable,
+    validation: can.Can.Validation,
 ) Allocator.Error!void {
     const module_env = module.moduleEnvConst();
 
@@ -2303,14 +2303,16 @@ fn appendPublishedEntrypointRoots(
     }
 
     switch (module_env.module_kind) {
-        .default_app, .app => try appendExposedAppProcedureRoots(
-            requests,
-            allocator,
-            module,
-            checked_types,
-            top_level_values,
-            top_level_procedure_bindings,
-        ),
+        .default_app, .app => if (validation == .checking) {
+            try appendExposedAppProcedureRoots(
+                requests,
+                allocator,
+                module,
+                checked_types,
+                top_level_values,
+                top_level_procedure_bindings,
+            );
+        },
         .type_module,
         .package,
         .platform,

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -1022,6 +1022,7 @@ pub const RootRequestTable = struct {
         const_templates: *const ConstTemplateTable,
         template_root_evidence: []const artifact_serialize.Span,
         explicit_roots: []const ExplicitRootRequestInput,
+        validation: can.Can.Validation,
     ) Allocator.Error!RootRequestTable {
         var requests = std.ArrayList(RootRequest).empty;
         errdefer requests.deinit(allocator);
@@ -1054,20 +1055,21 @@ pub const RootRequestTable = struct {
             });
         }
 
-        try appendPublishedEntrypointRoots(
-            &requests,
-            allocator,
-            module,
-            names,
-            checked_types,
-            procedure_templates,
-            provided_exports,
-            top_level_values,
-            top_level_procedure_bindings,
-            relation_substitutions,
-            platform_app_relation,
-            platform_required_declarations,
-        );
+        if (validation == .checking) {
+            try appendPublishedEntrypointRoots(
+                &requests,
+                allocator,
+                module,
+                names,
+                checked_types,
+                provided_exports,
+                top_level_values,
+                top_level_procedure_bindings,
+                relation_substitutions,
+                platform_app_relation,
+                platform_required_declarations,
+            );
+        }
 
         for (platform_required_bindings.bindings, 0..) |binding, i| {
             switch (binding.value_use) {
@@ -1838,17 +1840,6 @@ fn checkedTagsAreConcreteCompileTimeRoots(
     return true;
 }
 
-fn checkedTypeContainsError(
-    allocator: Allocator,
-    checked_types: *const CheckedTypeStore,
-    root: CheckedTypeId,
-) Allocator.Error!bool {
-    var scan = CheckedTypeErrorScan{ .checked_types = checked_types };
-    var traversal = CheckedTypeErrorTraversal.init(allocator, &scan);
-    defer traversal.deinit();
-    return traversal.visit(root);
-}
-
 const CheckedTypeErrorTraversal = checked_traverse.BoolPredicateTraversal(CheckedTypeId, CheckedTypeErrorScan);
 
 const CheckedTypeErrorScan = struct {
@@ -2273,7 +2264,6 @@ fn appendPublishedEntrypointRoots(
     module: TypedCIR.Module,
     names: *const canonical.CanonicalNameStore,
     checked_types: *CheckedTypePublication,
-    procedure_templates: *const CheckedProcedureTemplateTable,
     provided_exports: *const ProvidedExportTable,
     top_level_values: *const TopLevelValueTable,
     top_level_procedure_bindings: *const TopLevelProcedureBindingTable,
@@ -2313,31 +2303,7 @@ fn appendPublishedEntrypointRoots(
     }
 
     switch (module_env.module_kind) {
-        .default_app => {
-            const main_ident = module_env.idents.main_bang;
-            const main_node_idx = module_env.getExposedValueNodeIndexById(main_ident) orelse {
-                if (builtin.mode == .Debug) {
-                    std.debug.panic(
-                        "checked artifact invariant violated: default app main! has no published root definition",
-                        .{},
-                    );
-                }
-                unreachable;
-            };
-            const main_def: CIR.Def.Idx = @enumFromInt(@as(u32, @intCast(main_node_idx)));
-            const checked_type = try checkedTypeIdForRootSource(allocator, module, checked_types, .{ .def = main_def });
-            if (try checkedTypeContainsError(allocator, &checked_types.store, checked_type)) return;
-            try appendRoot(requests, allocator, .{
-                .module_idx = module.moduleIndex(),
-                .kind = .runtime_entrypoint,
-                .source = .{ .def = main_def },
-                .checked_type = checked_type,
-                .abi = .roc,
-                .exposure = .exported,
-                .procedure_template = requiredProcedureTemplateForRootSource(procedure_templates, .{ .def = main_def }),
-            });
-        },
-        .app => try appendExposedAppProcedureRoots(
+        .default_app, .app => try appendExposedAppProcedureRoots(
             requests,
             allocator,
             module,
@@ -2418,18 +2384,6 @@ fn procedureTemplateForTopLevelBinding(
             .lifted => checkedArtifactInvariant("checked root binding referenced lifted procedure before post-check lowering", .{}),
         },
         .callable_eval_template => null,
-    };
-}
-
-fn requiredProcedureTemplateForRootSource(
-    procedure_templates: *const CheckedProcedureTemplateTable,
-    source: RootSource,
-) canonical.ProcedureTemplateRef {
-    return procedureTemplateForRootSource(procedure_templates, source) orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("checked artifact invariant violated: root procedure source has no checked procedure template", .{});
-        }
-        unreachable;
     };
 }
 
@@ -34117,6 +34071,7 @@ pub fn publishFromTypedModule(
         &const_templates,
         template_root_evidence,
         inputs.explicit_roots,
+        inputs.validation,
     );
     errdefer root_requests.deinit(allocator);
 
@@ -34816,6 +34771,7 @@ fn expectProvidedExportKind(
         &const_templates,
         template_root_evidence,
         &.{},
+        .checking,
     );
     defer root_requests.deinit(allocator);
 

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -148,6 +148,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10870_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10897_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10935_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10940_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10977_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10980_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11004_test.zig"));

--- a/src/compile/test/issue_10940_test.zig
+++ b/src/compile/test/issue_10940_test.zig
@@ -1,0 +1,126 @@
+//! Regression tests for issue #10940.
+//!
+//! A default app header may expose `main!` without defining it. Checking
+//! reports the missing definition, while explicit-root compilation does not
+//! require the app entrypoint. Neither mode treats it as a compiler invariant.
+
+const std = @import("std");
+const roc_target = @import("roc_target");
+
+const compile_build = @import("../compile_build.zig");
+const BuildEnv = compile_build.BuildEnv;
+
+test "issue 10940: a default app that never defines main! reports it as exposed but not defined" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\app [main!] {}
+        \\
+        ,
+    });
+
+    const cwd = try tmp_dir.dir.realPathFileAlloc(io, ".", gpa);
+    defer gpa.free(cwd);
+    const main_path = try tmp_dir.dir.realPathFileAlloc(io, "main.roc", gpa);
+    defer gpa.free(main_path);
+
+    var build_env = try BuildEnv.init(gpa, .single_threaded, 1, roc_target.RocTarget.detectNative(), cwd, io);
+    defer build_env.deinit();
+
+    try build_env.build(main_path);
+
+    const drained = try build_env.drainReports();
+    defer build_env.freeDrainedReports(drained);
+
+    var found_exposed_but_not_defined = false;
+    for (drained) |module_reports| {
+        for (module_reports.reports) |report| {
+            if (std.mem.eql(u8, report.title, "Exposed But Not Defined")) {
+                found_exposed_but_not_defined = true;
+            }
+        }
+    }
+    try std.testing.expect(found_exposed_but_not_defined);
+}
+
+test "issue 10940: explicit roots do not require a default app entrypoint" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\app [main!] {}
+        \\
+        ,
+    });
+
+    const cwd = try tmp_dir.dir.realPathFileAlloc(io, ".", gpa);
+    defer gpa.free(cwd);
+    const main_path = try tmp_dir.dir.realPathFileAlloc(io, "main.roc", gpa);
+    defer gpa.free(main_path);
+
+    var build_env = try BuildEnv.init(gpa, .single_threaded, 1, roc_target.RocTarget.detectNative(), cwd, io);
+    defer build_env.deinit();
+    build_env.setRootValidation(.explicit_roots);
+
+    try build_env.build(main_path);
+
+    const artifact = build_env.executableRootCheckedArtifact();
+    for (artifact.root_requests.runtime_requests) |root| {
+        try std.testing.expect(root.kind != .runtime_entrypoint);
+    }
+
+    const drained = try build_env.drainReports();
+    defer build_env.freeDrainedReports(drained);
+
+    for (drained) |module_reports| {
+        for (module_reports.reports) |report| {
+            try std.testing.expect(!std.mem.eql(u8, report.title, "Exposed But Not Defined"));
+        }
+    }
+}
+
+test "issue 10940: a headerless default app still publishes main!" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\main! = |_args| {}
+        \\
+        ,
+    });
+
+    const cwd = try tmp_dir.dir.realPathFileAlloc(io, ".", gpa);
+    defer gpa.free(cwd);
+    const main_path = try tmp_dir.dir.realPathFileAlloc(io, "main.roc", gpa);
+    defer gpa.free(main_path);
+
+    var build_env = try BuildEnv.init(gpa, .single_threaded, 1, roc_target.RocTarget.detectNative(), cwd, io);
+    defer build_env.deinit();
+
+    try build_env.build(main_path);
+
+    const artifact = build_env.executableRootCheckedArtifact();
+    var found_runtime_entrypoint = false;
+    for (artifact.root_requests.runtime_requests) |root| {
+        if (root.kind == .runtime_entrypoint) {
+            found_runtime_entrypoint = true;
+        }
+    }
+    try std.testing.expect(found_runtime_entrypoint);
+}

--- a/src/compile/test/issue_10940_test.zig
+++ b/src/compile/test/issue_10940_test.zig
@@ -124,3 +124,35 @@ test "issue 10940: a headerless default app still publishes main!" {
     }
     try std.testing.expect(found_runtime_entrypoint);
 }
+
+test "issue 10940: explicit roots do not automatically publish a defined main!" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\main! = |_args| {}
+        \\
+        ,
+    });
+
+    const cwd = try tmp_dir.dir.realPathFileAlloc(io, ".", gpa);
+    defer gpa.free(cwd);
+    const main_path = try tmp_dir.dir.realPathFileAlloc(io, "main.roc", gpa);
+    defer gpa.free(main_path);
+
+    var build_env = try BuildEnv.init(gpa, .single_threaded, 1, roc_target.RocTarget.detectNative(), cwd, io);
+    defer build_env.deinit();
+    build_env.setRootValidation(.explicit_roots);
+
+    try build_env.build(main_path);
+
+    const artifact = build_env.executableRootCheckedArtifact();
+    for (artifact.root_requests.runtime_requests) |root| {
+        try std.testing.expect(root.kind != .runtime_entrypoint);
+    }
+}


### PR DESCRIPTION
Default apps with a declared but undefined main! reached checked-artifact publication, which assumed every default app had a concrete root and panicked before diagnostics could be emitted. This records the implicit headerless main! in canonicalization’s exact export inventory and makes publication consume that inventory only when the app entrypoint contract is active, preserving explicit-root behavior and platform roots. Fixes #10940.