### PR TITLE
Avoid quadratic work when lowering record updates

### DIFF
--- a/design.md
+++ b/design.md
@@ -9724,8 +9724,8 @@ The direct solved-to-LIR builder keeps by-value record bindings as persistent
 field-value trees while lowering a lexical block. Leaves are fresh LIR locals
 whose expressions execute at the original binding, including fields later
 overwritten or unused. This preserves effects, failure, divergence, and
-snapshot order. Record versions share unchanged components; an update copies
-only the paths to changed fields, and projections select those evaluated locals.
+snapshot order. Record versions share unchanged component-tree nodes; an update
+copies only the tree paths to changed fields, and field reads select those evaluated locals.
 Field names map to committed field indices once per type in the procedure.
 A whole-value use requests one materialization at the original binding; it does
 not rebuild the record at each consumer. Boxed representations remain explicit
@@ -9734,8 +9734,8 @@ Their depth is logarithmic in field count, independent of update-chain length.
 The existing unique erased-result component demand follows these bindings back
 to the evaluated field producer, using the same ambiguity and repeatable-region
 rules as ordinary local return forwarding. Layout padding is excluded through
-its explicit committed padding marker, not by comparing physical and logical
-field counts.
+its explicit committed padding marker, not by comparing layout and type field
+counts.
 
 ### Join-Parameter Scalarization
 
@@ -9762,7 +9762,7 @@ matching descriptor parameter for every resulting field local.
 
 Alias transparency is solved along explicit source dependencies. Every opaque
 alias contributes a whole-value use before propagation starts, each transparent
-alias can be demoted once, and canonical roots share already resolved paths.
+alias can be demoted once, and equivalent alias roots share already resolved paths.
 Reverse alias edges are intrusive links in the alias-definition table, so
 closure queries visit their own members without allocating a list per alias.
 Independent ordinary constructor eliminations share one analysis and edge

--- a/design.md
+++ b/design.md
@@ -9718,6 +9718,25 @@ Each explicit RC statement carries the concrete RC helper selected by ARC.
 Backends, the interpreter, and LirImage builders follow those statements
 mechanically. The ARC algorithm is specified in ARC Borrow Inference below.
 
+### Record Component Bindings
+
+The direct solved-to-LIR builder keeps by-value record bindings as persistent
+field-value trees while lowering a lexical block. Leaves are fresh LIR locals
+whose expressions execute at the original binding, including fields later
+overwritten or unused. This preserves effects, failure, divergence, and
+snapshot order. Record versions share unchanged components; an update copies
+only the paths to changed fields, and projections select those evaluated locals.
+Field names map to committed field indices once per type in the procedure.
+A whole-value use requests one materialization at the original binding; it does
+not rebuild the record at each consumer. Boxed representations remain explicit
+materialized values. Component trees are builder scratch, not another stored IR.
+Their depth is logarithmic in field count, independent of update-chain length.
+The existing unique erased-result component demand follows these bindings back
+to the evaluated field producer, using the same ambiguity and repeatable-region
+rules as ordinary local return forwarding. Layout padding is excluded through
+its explicit committed padding marker, not by comparing physical and logical
+field counts.
+
 ### Join-Parameter Scalarization
 
 Between direct LIR lowering and ARC insertion, one normalization splits
@@ -9740,6 +9759,15 @@ iterates so nested wrappers dissolve. A struct parameter carrying a Boxy
 descriptor also remains unsplit: scalarization may not replace its `assign_ref`
 field reads with local aliases unless it also introduces and initializes a
 matching descriptor parameter for every resulting field local.
+
+Alias transparency is solved along explicit source dependencies. Every opaque
+alias contributes a whole-value use before propagation starts, each transparent
+alias can be demoted once, and canonical roots share already resolved paths.
+Reverse alias edges are intrusive links in the alias-definition table, so
+closure queries visit their own members without allocating a list per alias.
+Independent ordinary constructor eliminations share one analysis and edge
+patching traversal. Their dependencies used as constructor operands remain
+whole-value uses until the next analysis; join ABI changes require fresh data.
 
 ## Integer Arithmetic Operations
 

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -832,10 +832,16 @@ const all_syntax_expected_stderr =
     \\
 ;
 
+const issue_11130_expected_stdout = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n";
+const issue_11130_speed_expected_stdout = if (builtin.os.tag == .windows)
+    "first\r\nsecond\r\nold:0\r\nnew:0\r\nold\r\nold\r\nunused\r\n"
+else
+    issue_11130_expected_stdout;
+
 const echo_cases = [_]CliCase{
-    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{ "--opt=interpreter", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (dev)", .backend = .dev, .body = .{ .command = .{ .args = &.{ "--opt=dev", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (speed)", .backend = .speed, .body = .{ .command = .{ .args = &.{ "--opt=speed", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n" } } },
+    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{ "--opt=interpreter", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = issue_11130_expected_stdout } } },
+    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (dev)", .backend = .dev, .body = .{ .command = .{ .args = &.{ "--opt=dev", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = issue_11130_expected_stdout } } },
+    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (speed)", .backend = .speed, .body = .{ .command = .{ .args = &.{ "--opt=speed", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = issue_11130_speed_expected_stdout } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: hello (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: hello (dev backend)", .backend = .dev, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: consecutive raw writes (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/multi.roc", .stdout_exact = "Hello, World!" } } },

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -833,6 +833,9 @@ const all_syntax_expected_stderr =
 ;
 
 const echo_cases = [_]CliCase{
+    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{ "--opt=interpreter", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n" } } },
+    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (dev)", .backend = .dev, .body = .{ .command = .{ .args = &.{ "--opt=dev", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n" } } },
+    .{ .id = 0, .suite = .echo, .name = "issue 11130: record versions and eager effects (speed)", .backend = .speed, .body = .{ .command = .{ .args = &.{ "--opt=speed", "--no-cache" }, .roc_file = "test/echo/issue_11130_record_versions.roc", .stdout_exact = "first\nsecond\nold:0\nnew:0\nold\nold\nunused\n" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: hello (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: hello (dev backend)", .backend = .dev, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: consecutive raw writes (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/multi.roc", .stdout_exact = "Hello, World!" } } },

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -155,6 +155,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11103_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11062_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11098_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11130_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11130_test.zig
+++ b/src/compile/test/issue_11130_test.zig
@@ -1,0 +1,95 @@
+//! Regression tests for record update normalization (issue #11130).
+const std = @import("std");
+const lir = @import("lir");
+const harness = @import("lower_to_lir_harness.zig");
+
+fn updateChain(allocator: std.mem.Allocator, fields: usize, updates: usize) std.mem.Allocator.Error![]u8 {
+    var source: std.ArrayList(u8) = .empty;
+    errdefer source.deinit(allocator);
+    try source.appendSlice(allocator, "Big : {\n");
+    for (0..fields) |i| try source.print(allocator, "f{d}: Try(Str, [Null]),\n", .{i});
+    try source.appendSlice(allocator, "}\nmk : Str -> Big\nmk = |s| {\n");
+    for (0..fields) |i| try source.print(allocator, "f{d}: Ok(s),\n", .{i});
+    try source.appendSlice(allocator, "}\nbig : Str -> Str\nbig = |s| {\na0 = mk(s)\n");
+    for (1..updates + 1) |i| try source.print(allocator, "a{d} = {{ ..a{d}, f{d}: Ok(\"{d}\") }}\n", .{ i, i - 1, i % fields, i });
+    try source.print(allocator,
+        \\match a{d}.f0 {{ Ok(x) => x, Err(Null) => "" }}
+        \\}}
+        \\main! = |args| {{
+        \\echo!(big(args.len().to_str()))
+        \\Ok({{}})
+        \\}}
+    , .{updates});
+    return source.toOwnedSlice(allocator);
+}
+
+fn lirPassNs(fields: usize, updates: usize) harness.LowerToLirHarnessError!u64 {
+    const source = try updateChain(std.testing.allocator, fields, updates);
+    defer std.testing.allocator.free(source);
+    var timing: lir.CheckedPipeline.TimingSnapshot = .{};
+    try harness.expectLowersToLirWithOptions(source, .{ .timing_out = &timing });
+    return timing.lir_passes_ns;
+}
+
+test "issue 11130: chained record updates cost LIR pass time proportional to the chain" {
+    const at_30 = try lirPassNs(10, 30);
+    const at_60 = try lirPassNs(10, 60);
+    const at_120 = try lirPassNs(10, 120);
+    if (at_120 > at_30 *| 6) {
+        std.debug.print("LIR passes took {d}us, {d}us and {d}us at 30, 60 and 120 updates\n", .{ at_30 / 1000, at_60 / 1000, at_120 / 1000 });
+        return error.LirPassTimeGrewSuperlinearly;
+    }
+}
+
+test "issue 11130: record versions survive whole uses and branching projections" {
+    try harness.expectLowersToLir(
+        \\main! = |args| {
+        \\a = { x: args, y: ["before"] }
+        \\b = { ..a, y: ["after"] }
+        \\echo!(Str.inspect(a))
+        \\echo!(Str.inspect(b))
+        \\echo!(Str.inspect(if args.is_empty() { a.y } else { b.y }))
+        \\Ok({})
+        \\}
+    );
+}
+
+test "issue 11130: overwritten record fields still evaluate effects" {
+    try harness.expectLowersToLir(
+        \\main! = |args| {
+        \\a = { x: args, y: {
+        \\echo!("first")
+        \\"old"
+        \\} }
+        \\b = { ..a, y: {
+        \\echo!("second")
+        \\"new"
+        \\} }
+        \\echo!(b.y)
+        \\Ok({})
+        \\}
+    );
+}
+
+fn inspectWideRecordConstruction(store: *const lir.LirStore, layouts: *const @import("layout").Store) harness.LowerToLirHarnessError!void {
+    var builds: usize = 0;
+    var projections: usize = 0;
+    for (0..store.cfStmtCount()) |index| {
+        const stmt = store.getCFStmt(@enumFromInt(@as(u32, @intCast(index))));
+        if (stmt == .assign_struct and stmt.assign_struct.fields.len == 50) builds += 1;
+        if (stmt != .assign_ref or stmt.assign_ref.op != .field) continue;
+        const source = store.getLocal(stmt.assign_ref.op.field.source);
+        const source_layout = layouts.getLayout(source.layout_idx);
+        if (source_layout.tag == .struct_ and layouts.getStructInfo(source_layout).fields.len == 50) projections += 1;
+    }
+    // The store is append-only: even statements later deleted by normalization
+    // count here. Updating one field must not emit a complete record each time.
+    try std.testing.expect(builds <= 2);
+    try std.testing.expect(projections <= 100);
+}
+
+test "issue 11130: lowering avoids constructing and projecting every record version" {
+    const source = try updateChain(std.testing.allocator, 50, 120);
+    defer std.testing.allocator.free(source);
+    try harness.expectLirInspection(source, inspectWideRecordConstruction);
+}

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -62,7 +62,17 @@ const max_rounds = 4096;
 /// Scalarizes eligible struct-typed join parameters across every proc in the
 /// store, repeating until no parameter qualifies.
 pub fn run(store: *LirStore, layouts: *const layout_mod.Store) ScalarizeError!void {
+    return runMeasured(store, layouts, null);
+}
+
+const Metrics = struct {
+    collected_statements: usize = 0,
+    alias_edges: usize = 0,
+};
+
+fn runMeasured(store: *LirStore, layouts: *const layout_mod.Store, metrics: ?*Metrics) ScalarizeError!void {
     var pass = Pass{
+        .metrics = metrics,
         .store = store,
         .layouts = layouts,
         .allocator = store.allocator,
@@ -79,6 +89,8 @@ pub fn run(store: *LirStore, layouts: *const layout_mod.Store) ScalarizeError!vo
         .alias_defs = collections.DenseMap(LIR.LocalId, AliasDef).init(store.allocator),
         .join_params = collections.DenseMap(LIR.LocalId, std.ArrayList(LIR.CFStmtId)).init(store.allocator),
         .transparent = collections.DenseMap(LIR.LocalId, void).init(store.allocator),
+        .alias_children = collections.DenseMap(LIR.LocalId, LIR.LocalId).init(store.allocator),
+        .alias_roots = collections.DenseMap(LIR.LocalId, LIR.LocalId).init(store.allocator),
         .removed = collections.DenseMap(LIR.CFStmtId, LIR.CFStmtId).init(store.allocator),
         .visited = collections.DenseMap(LIR.CFStmtId, void).init(store.allocator),
         .stack = .empty,
@@ -133,9 +145,11 @@ const AliasDef = struct {
     source: LIR.LocalId,
     /// A local defined by more than one alias statement is never transparent.
     def_count: u32,
+    next_sibling: ?LIR.LocalId = null,
 };
 
 const Pass = struct {
+    metrics: ?*Metrics,
     store: *LirStore,
     layouts: *const layout_mod.Store,
     allocator: Allocator,
@@ -182,6 +196,11 @@ const Pass = struct {
     join_params: collections.DenseMap(LIR.LocalId, std.ArrayList(LIR.CFStmtId)),
     /// Aliases proved transparent this round.
     transparent: collections.DenseMap(LIR.LocalId, void),
+    /// Explicit reverse alias dependencies; closure queries visit only members.
+    alias_children: collections.DenseMap(LIR.LocalId, LIR.LocalId),
+    /// Canonical roots computed once after transparency has settled.
+    alias_roots: collections.DenseMap(LIR.LocalId, LIR.LocalId),
+    alias_work: std.ArrayList(LIR.LocalId) = .empty,
     /// Deleted build statements mapped to their continuations, for edge
     /// patching.
     removed: collections.DenseMap(LIR.CFStmtId, LIR.CFStmtId),
@@ -206,6 +225,9 @@ const Pass = struct {
         self.alias_defs.deinit();
         self.join_params.deinit();
         self.transparent.deinit();
+        self.alias_children.deinit();
+        self.alias_roots.deinit();
+        self.alias_work.deinit(self.allocator);
         self.removed.deinit();
         self.visited.deinit();
         self.stack.deinit(self.allocator);
@@ -248,6 +270,9 @@ const Pass = struct {
         self.alias_defs.clearRetainingCapacity();
         self.join_params.clearRetainingCapacity();
         self.transparent.clearRetainingCapacity();
+        self.alias_children.clearRetainingCapacity();
+        self.alias_roots.clearRetainingCapacity();
+        self.alias_work.clearRetainingCapacity();
         self.removed.clearRetainingCapacity();
         self.visited.clearRetainingCapacity();
         self.stack.clearRetainingCapacity();
@@ -351,59 +376,57 @@ const Pass = struct {
             if (def.def_count == 1 and
                 !self.join_params.contains(target) and
                 !self.write_other.contains(target) and
-                self.init_writes.get(target) == null)
+                !self.struct_builds.contains(target) and
+                !self.tag_builds.contains(target) and
+                !self.init_writes.contains(target))
             {
                 try self.transparent.put(target, {});
+                if (self.use_other.contains(target)) try self.alias_work.append(self.allocator, target);
+            } else if (def.def_count == 1) {
+                // Seed every initially opaque source before propagation, even
+                // when its alias was excluded because of another definition.
+                try self.noteUse(def.source);
+                try self.alias_work.append(self.allocator, def.source);
             }
         }
-
-        var changed = true;
-        while (changed) {
-            changed = false;
-            var candidates = self.alias_defs.iterator();
-            while (candidates.next()) |entry| {
-                const target = entry.key_ptr.*;
-                if (!self.transparent.contains(target)) continue;
-                if (self.use_other.contains(target)) {
-                    _ = self.transparent.remove(target);
-                    try self.noteUse(entry.value_ptr.source);
-                    changed = true;
-                }
-            }
+        // Each transparent alias can lose transparency once. Its source is
+        // the only new dependency affected by that transition.
+        while (self.alias_work.pop()) |target| {
+            if (self.metrics) |metrics| metrics.alias_edges += 1;
+            if (!self.transparent.remove(target)) continue;
+            const source = self.alias_defs.get(target).?.source;
+            try self.noteUse(source);
+            try self.alias_work.append(self.allocator, source);
         }
 
-        // A multiply-defined alias already counted its sources at collection.
         var settled = self.alias_defs.iterator();
         while (settled.next()) |entry| {
             const target = entry.key_ptr.*;
-            const def = entry.value_ptr.*;
-            if (self.transparent.contains(target)) {
-                // Transparent reads still count toward initializer-build
-                // qualification: a build read through an alias must not be
-                // splatted away, or the alias's reads would dangle.
-                if (self.struct_builds.getPtr(self.transparentRoot(def.source))) |build| {
-                    build.uses += 1;
-                }
-                if (self.tag_builds.getPtr(self.transparentRoot(def.source))) |build| {
-                    build.uses += 1;
-                }
-            } else if (def.def_count == 1) {
-                try self.noteUse(def.source);
-            }
-        }
-    }
+            if (!self.transparent.contains(target)) continue;
+            const source = entry.value_ptr.source;
+            entry.value_ptr.next_sibling = self.alias_children.get(source);
+            try self.alias_children.put(source, target);
 
-    /// Follow a transparent-alias chain to the local whose value it reads.
-    fn transparentRoot(self: *const Pass, source: LIR.LocalId) LIR.LocalId {
-        var root = source;
-        var steps: usize = 0;
-        while (self.transparent.contains(root)) {
-            const def = self.alias_defs.get(root) orelse break;
-            root = def.source;
-            steps += 1;
-            if (steps > self.alias_defs.count()) break;
+            var root = source;
+            self.alias_work.clearRetainingCapacity();
+            while (self.transparent.contains(root)) {
+                if (self.alias_roots.get(root)) |known| {
+                    root = known;
+                    break;
+                }
+                try self.alias_work.append(self.allocator, root);
+                if (self.metrics) |metrics| metrics.alias_edges += 1;
+                // Ordinary single-definition aliases have dominating defs;
+                // cyclic value transfer must instead use explicit join writes.
+                std.debug.assert(self.alias_work.items.len <= self.alias_defs.count());
+                root = self.alias_defs.get(root).?.source;
+            }
+            for (self.alias_work.items) |alias| try self.alias_roots.put(alias, root);
+            try self.alias_roots.put(target, root);
+            if (self.struct_builds.getPtr(root)) |build| build.uses += 1;
+            if (self.tag_builds.getPtr(root)) |build| build.uses += 1;
         }
-        return root;
+        self.alias_work.clearRetainingCapacity();
     }
 
     /// The transparent aliases rooted at `param`, in dependency order, plus
@@ -435,12 +458,14 @@ const Pass = struct {
             .struct_forwards = .empty,
         };
         errdefer closure.deinit(self.allocator);
-        var it = self.alias_defs.iterator();
-        while (it.next()) |entry| {
-            const target = entry.key_ptr.*;
-            if (!self.transparent.contains(target)) continue;
-            if (self.transparentRoot(entry.value_ptr.source) != param) continue;
-            try closure.stmts.append(self.allocator, entry.value_ptr.stmt);
+        self.alias_work.clearRetainingCapacity();
+        if (self.alias_children.get(param)) |child| try self.alias_work.append(self.allocator, child);
+        while (self.alias_work.pop()) |target| {
+            if (self.metrics) |metrics| metrics.alias_edges += 1;
+            const def = self.alias_defs.get(target).?;
+            try closure.stmts.append(self.allocator, def.stmt);
+            if (def.next_sibling) |sibling| try self.alias_work.append(self.allocator, sibling);
+            if (self.alias_children.get(target)) |child| try self.alias_work.append(self.allocator, child);
             if (self.field_reads.getPtr(target)) |reads| {
                 try closure.reads.appendSlice(self.allocator, reads.items);
             }
@@ -470,11 +495,14 @@ const Pass = struct {
         const proc_args = try GuardedList.dupe(self.allocator, LIR.LocalId, self.store.getLocalSpan(self.store.getProcSpec(proc_id).args));
         defer self.allocator.free(proc_args);
 
-        // Find one scalarizable parameter; the fixpoint loop picks up the
-        // rest on later rounds.
+        // Ordinary constructor candidates have disjoint definitions and
+        // projections. A constructor used as another constructor's operand is
+        // a whole-value use and cannot qualify in this analysis, so these
+        // deletions can be committed together. Join rewrites change edge ABIs
+        // and are considered only against a fresh analysis.
         var changed = false;
 
-        // Eliminate one ordinary constructor/projection temporary before
+        // Eliminate ordinary constructor/projection temporaries before
         // considering join parameters. Case fusion exposes these when a tag
         // payload contains a wrapper struct: the wrapper has one literal
         // definition and is observed only through field projections, so its
@@ -484,16 +512,13 @@ const Pass = struct {
         while (tag_builds.next()) |entry| {
             if (try self.tryEliminateLocalTag(entry.key_ptr.*, entry.value_ptr.*)) {
                 changed = true;
-                break;
             }
         }
 
         var builds = self.struct_builds.iterator();
         while (builds.next()) |entry| {
-            if (changed) break;
             if (try self.tryEliminateLocalStruct(entry.key_ptr.*, entry.value_ptr.*)) {
                 changed = true;
-                break;
             }
         }
 
@@ -563,7 +588,7 @@ const Pass = struct {
     }
 
     fn tryEliminateLocalStruct(self: *Pass, local: LIR.LocalId, build: StructBuild) ScalarizeError!bool {
-        if (self.join_params.contains(local) or self.write_other.contains(local) or self.use_other.contains(local)) return false;
+        if (self.join_params.contains(local) or self.write_other.contains(local) or self.use_other.contains(local) or self.alias_defs.contains(local)) return false;
         if (build.builds.items.len != 1) return false;
         const site = build.builds.items[0];
         const operands = self.store.getLocalSpan(site.fields);
@@ -710,7 +735,7 @@ const Pass = struct {
     }
 
     fn tryEliminateLocalTag(self: *Pass, local: LIR.LocalId, build: TagBuild) ScalarizeError!bool {
-        if (self.join_params.contains(local) or self.write_other.contains(local) or self.use_other.contains(local)) return false;
+        if (self.join_params.contains(local) or self.write_other.contains(local) or self.use_other.contains(local) or self.alias_defs.contains(local)) return false;
         if (build.builds.items.len != 1) return false;
         const payload_layout = self.singleVariantPayloadLayout(local) orelse return false;
         const site = build.builds.items[0];
@@ -1440,15 +1465,23 @@ const Pass = struct {
         }
     }
 
-    fn resolveRemoved(self: *const Pass, stmt: LIR.CFStmtId) LIR.CFStmtId {
-        var cursor = stmt;
+    fn resolveRemoved(self: *Pass, stmt: LIR.CFStmtId) LIR.CFStmtId {
+        var root = stmt;
         var steps: usize = 0;
-        while (self.removed.get(cursor)) |next| {
-            cursor = next;
+        while (self.removed.get(root)) |next| {
+            root = next;
             steps += 1;
-            if (steps > self.removed.count()) break;
+            std.debug.assert(steps <= self.removed.count());
         }
-        return cursor;
+        // A batch can delete a long shared continuation. Compress its redirects
+        // once, rather than walking the whole chain for every incoming edge.
+        var cursor = stmt;
+        while (self.removed.getPtr(cursor)) |edge| {
+            const next = edge.*;
+            edge.* = root;
+            cursor = next;
+        }
+        return root;
     }
 
     fn collect(self: *Pass, body: LIR.CFStmtId) ScalarizeError!void {
@@ -1460,6 +1493,7 @@ const Pass = struct {
         while (self.stack.pop()) |current| {
             if (self.visited.contains(current)) continue;
             try self.visited.put(current, {});
+            if (self.metrics) |metrics| metrics.collected_statements += 1;
             switch (self.store.getCFStmt(current)) {
                 .assign_struct => |assign| {
                     try self.noteStructBuild(assign.target, current, assign.fields);
@@ -1517,6 +1551,7 @@ const Pass = struct {
         while (self.stack.pop()) |current| {
             if (self.visited.contains(current)) continue;
             try self.visited.put(current, {});
+            if (self.metrics) |metrics| metrics.collected_statements += 1;
             switch (self.store.getCFStmt(current)) {
                 .assign_ref => |assign| {
                     switch (assign.op) {
@@ -2532,4 +2567,107 @@ test "scalarize splits a parameter shared by two joins" {
     try testing.expectEqual(GuardedList.at(outer_params, 0), new_read_n.op.local);
     const new_read_s = store.getCFStmt(read_s).assign_ref;
     try testing.expectEqual(GuardedList.at(inner_params, 1), new_read_s.op.local);
+}
+
+test "scalarize batches independent constructors without recollecting each one" {
+    var fixture = try ScalarizeTest.init(testing.allocator);
+    defer fixture.deinit();
+    const store = &fixture.store;
+    const number = try store.addLocal(.{ .layout_idx = .i64 });
+    const text = try store.addLocal(.{ .layout_idx = .str });
+    var body = try store.addCFStmt(.{ .ret = .{ .value = number } });
+    for (0..500) |_| {
+        const wrapper = try store.addLocal(.{ .layout_idx = fixture.pair });
+        const projected = try store.addLocal(.{ .layout_idx = .i64 });
+        body = try store.addCFStmt(.{ .assign_ref = .{
+            .target = projected,
+            .op = .{ .field = .{ .source = wrapper, .field_idx = 0 } },
+            .next = body,
+        } });
+        body = try store.addCFStmt(.{ .assign_struct = .{
+            .target = wrapper,
+            .fields = try store.addLocalSpan(&.{ number, text }),
+            .next = body,
+        } });
+    }
+    _ = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = try store.addLocalSpan(&.{ number, text }),
+        .body = body,
+        .ret_layout = .i64,
+    });
+    var metrics = Metrics{};
+    try runMeasured(store, &fixture.layouts, &metrics);
+    try testing.expect(metrics.collected_statements < 5000);
+}
+
+test "scalarize propagates escaping alias chains in linear work" {
+    var fixture = try ScalarizeTest.init(testing.allocator);
+    defer fixture.deinit();
+    const store = &fixture.store;
+    var aliases: [1001]LIR.LocalId = undefined;
+    for (&aliases) |*alias| alias.* = try store.addLocal(.{ .layout_idx = fixture.pair });
+    var body = try store.addCFStmt(.{ .ret = .{ .value = aliases[1000] } });
+    var index: usize = 1000;
+    while (index != 0) {
+        body = try store.addCFStmt(.{ .assign_ref = .{
+            .target = aliases[index],
+            .op = .{ .local = aliases[index - 1] },
+            .next = body,
+        } });
+        index -= 1;
+    }
+    _ = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = try store.addLocalSpan(aliases[0..1]),
+        .body = body,
+        .ret_layout = fixture.pair,
+    });
+    var metrics = Metrics{};
+    try runMeasured(store, &fixture.layouts, &metrics);
+    try testing.expect(metrics.alias_edges <= aliases.len);
+    try testing.expectEqual(body, store.getProcSpec(@enumFromInt(@as(u32, 0))).body.?);
+}
+
+test "scalarize keeps a constructor with an alias definition and its source" {
+    var fixture = try ScalarizeTest.init(testing.allocator);
+    defer fixture.deinit();
+    const store = &fixture.store;
+    const first = try store.addLocal(.{ .layout_idx = .i64 });
+    const second = try store.addLocal(.{ .layout_idx = .i64 });
+    const text = try store.addLocal(.{ .layout_idx = .str });
+    const source = try store.addLocal(.{ .layout_idx = fixture.pair });
+    const alias = try store.addLocal(.{ .layout_idx = fixture.pair });
+    const result = try store.addLocal(.{ .layout_idx = .i64 });
+    const ret = try store.addCFStmt(.{ .ret = .{ .value = result } });
+    const overwrite = try store.addCFStmt(.{ .assign_struct = .{
+        .target = alias,
+        .fields = try store.addLocalSpan(&.{ second, text }),
+        .next = ret,
+    } });
+    const read = try store.addCFStmt(.{ .assign_ref = .{
+        .target = result,
+        .op = .{ .field = .{ .source = alias, .field_idx = 0 } },
+        .next = overwrite,
+    } });
+    const copy = try store.addCFStmt(.{ .assign_ref = .{
+        .target = alias,
+        .op = .{ .local = source },
+        .next = read,
+    } });
+    const original = try store.addCFStmt(.{ .assign_struct = .{
+        .target = source,
+        .fields = try store.addLocalSpan(&.{ first, text }),
+        .next = copy,
+    } });
+    const proc = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = try store.addLocalSpan(&.{ first, second, text }),
+        .body = original,
+        .ret_layout = .i64,
+    });
+    try run(store, &fixture.layouts);
+    try testing.expectEqual(original, store.getProcSpec(proc).body.?);
+    try testing.expect(store.getCFStmt(read).assign_ref.op == .field);
+    try testing.expectEqual(alias, store.getCFStmt(read).assign_ref.op.field.source);
 }

--- a/src/postcheck/mod.zig
+++ b/src/postcheck/mod.zig
@@ -44,6 +44,7 @@ pub const Boxy = @import("boxy/mod.zig");
 pub const StructuralTest = @import("structural_test.zig");
 
 test "postcheck declarations are referenced" {
+    std.testing.refAllDecls(@import("record_fields.zig"));
     std.testing.refAllDecls(@This());
     std.testing.refAllDecls(@import("common.zig"));
     std.testing.refAllDecls(@import("monotype/ast.zig"));

--- a/src/postcheck/record_fields.zig
+++ b/src/postcheck/record_fields.zig
@@ -1,0 +1,95 @@
+//! Persistent field bindings for records under construction. Leaves name
+//! evaluated LIR values; changing one field copies only its tree path.
+
+const std = @import("std");
+const LIR = @import("lir_core").LIR;
+
+/// Store-local identity of one immutable field tree.
+pub const Id = enum(u32) { _ };
+const Node = union(enum) {
+    leaf: LIR.LocalId,
+    branch: struct { left: Id, right: Id },
+};
+
+/// Procedure-local storage shared by immutable record versions.
+pub const Store = struct {
+    allocator: std.mem.Allocator,
+    nodes: std.ArrayList(Node) = .empty,
+
+    pub fn deinit(self: *Store) void {
+        self.nodes.deinit(self.allocator);
+    }
+
+    fn add(self: *Store, node: Node) std.mem.Allocator.Error!Id {
+        const id: Id = @enumFromInt(@as(u32, @intCast(self.nodes.items.len)));
+        try self.nodes.append(self.allocator, node);
+        return id;
+    }
+
+    pub fn build(self: *Store, fields: []const LIR.LocalId) std.mem.Allocator.Error!Id {
+        std.debug.assert(fields.len != 0);
+        if (fields.len == 1) return self.add(.{ .leaf = fields[0] });
+        const mid = fields.len / 2;
+        const left = try self.build(fields[0..mid]);
+        const right = try self.build(fields[mid..]);
+        return self.add(.{ .branch = .{ .left = left, .right = right } });
+    }
+
+    pub fn update(self: *Store, root: Id, len: usize, index: usize, value: LIR.LocalId) std.mem.Allocator.Error!Id {
+        std.debug.assert(index < len);
+        if (len == 1) return self.add(.{ .leaf = value });
+        var branch = self.nodes.items[@intFromEnum(root)].branch;
+        const mid = len / 2;
+        if (index < mid) {
+            branch.left = try self.update(branch.left, mid, index, value);
+        } else {
+            branch.right = try self.update(branch.right, len - mid, index - mid, value);
+        }
+        return self.add(.{ .branch = branch });
+    }
+
+    pub fn get(self: *const Store, root: Id, len: usize, index: usize) LIR.LocalId {
+        std.debug.assert(index < len);
+        if (len == 1) return self.nodes.items[@intFromEnum(root)].leaf;
+        const branch = self.nodes.items[@intFromEnum(root)].branch;
+        const mid = len / 2;
+        return if (index < mid)
+            self.get(branch.left, mid, index)
+        else
+            self.get(branch.right, len - mid, index - mid);
+    }
+
+    pub fn write(self: *const Store, root: Id, out: []LIR.LocalId) void {
+        std.debug.assert(out.len != 0);
+        if (out.len == 1) {
+            out[0] = self.nodes.items[@intFromEnum(root)].leaf;
+            return;
+        }
+        const branch = self.nodes.items[@intFromEnum(root)].branch;
+        const mid = out.len / 2;
+        self.write(branch.left, out[0..mid]);
+        self.write(branch.right, out[mid..]);
+    }
+};
+
+test "record field versions share unchanged bindings with logarithmic update work" {
+    var store = Store{ .allocator = std.testing.allocator };
+    defer store.deinit();
+    var fields: [50]LIR.LocalId = undefined;
+    for (&fields, 0..) |*field, i| field.* = @enumFromInt(@as(u32, @intCast(i)));
+    const original = try store.build(&fields);
+    const initial_count = store.nodes.items.len;
+    var current = original;
+    for (0..500) |i| {
+        current = try store.update(current, fields.len, i % fields.len, @enumFromInt(@as(u32, @intCast(i + 50))));
+    }
+    try std.testing.expect(store.nodes.items.len - initial_count <= 500 * 7);
+    var actual: [50]LIR.LocalId = undefined;
+    store.write(original, &actual);
+    try std.testing.expectEqualSlices(LIR.LocalId, &fields, &actual);
+    store.write(current, &actual);
+    for (actual, 0..) |value, i| {
+        try std.testing.expectEqual(@as(u32, @intCast(500 + i)), @intFromEnum(value));
+        try std.testing.expectEqual(value, store.get(current, fields.len, i));
+    }
+}

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -4234,7 +4234,7 @@ const Lowerer = struct {
     }
 
     /// Whole-value consumers, including retained join locals, must request the
-    /// same definition-site materialization before using a physical local.
+    /// same definition-site aggregate construction before using an LIR local.
     fn materializeRecordBinding(self: *Lowerer, local: Lifted.LocalId) Common.LowerError!?struct { local: LIR.LocalId, ty: Type.TypeId } {
         const aggregates = self.aggregate_bindings orelse return null;
         const id = aggregates.bindings.get(local) orelse return null;

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -23,6 +23,7 @@ const LambdaMono = @import("lambda_mono/ast.zig");
 const LambdaMonoLower = @import("lambda_mono/lower.zig");
 const MonoType = @import("monotype/type.zig");
 const Type = @import("lambda_mono/type.zig");
+const RecordFields = @import("record_fields.zig");
 const lir_core = @import("lir_core");
 const LIR = lir_core.LIR;
 const LirStore = lir_core.LirStore;
@@ -587,6 +588,8 @@ const Lowerer = struct {
     /// Persistent scratch is indexed by executor lane, whose callbacks are
     /// exclusive. Escaping body shards never borrow storage from these entries.
     worker_workspaces: []?FnBodyWorkspace,
+
+    aggregate_bindings: ?*AggregateBindings = null,
 
     const ProcLocalSet = std.AutoArrayHashMapUnmanaged(u32, void);
 
@@ -1724,6 +1727,11 @@ const Lowerer = struct {
             self.result.store.current_region = saved_region;
         }
 
+        var aggregates = AggregateBindings.init(self.allocator);
+        defer aggregates.deinit();
+        const saved_aggregates = self.aggregate_bindings;
+        self.aggregate_bindings = &aggregates;
+        defer self.aggregate_bindings = saved_aggregates;
         self.current_ret_ty = initializer.ty;
         self.current_proc_locals = &proc_locals;
         self.current_fn = null;
@@ -1753,6 +1761,11 @@ const Lowerer = struct {
     }
 
     fn lowerFnSpec(self: *Lowerer, fn_id: Type.FnId, spec: FnSpec) Common.LowerError!?LoweredFnBody {
+        var aggregates = AggregateBindings.init(self.allocator);
+        defer aggregates.deinit();
+        const saved_aggregates = self.aggregate_bindings;
+        self.aggregate_bindings = &aggregates;
+        defer self.aggregate_bindings = saved_aggregates;
         const proc_id = try self.procPlaceholder(fn_id);
         const entry = self.fn_entries.items[@intFromEnum(fn_id)];
         const source_fn = self.solved.lifted.getFn(spec.source);
@@ -2221,6 +2234,10 @@ const Lowerer = struct {
     }
 
     fn lowerLocalInto(self: *Lowerer, target: LIR.LocalId, local: Lifted.LocalId, ty: Type.TypeId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+        if (try self.materializeRecordBinding(local)) |source| {
+            try self.noteReturnForwardingLocal(target, source.local);
+            return try self.assignTypedBoundary(target, ty, source.local, source.ty, next);
+        }
         if (self.typed_local_map.get(.{ .local = local, .ty = ty })) |source| {
             try self.noteLocal(source);
             try self.noteReturnForwardingLocal(target, source);
@@ -2257,6 +2274,11 @@ const Lowerer = struct {
         // Equal committed layouts make assignTypedBoundary emit one explicit
         // local alias. Layout similarity alone is not allocation provenance.
         if (target_layout != source_layout) return;
+        try self.noteReturnForwardingSource(source);
+    }
+
+    fn noteReturnForwardingSource(self: *Lowerer, source: LIR.LocalId) Common.LowerError!void {
+        if (self.return_forwarding_repeatable_depth != 0) return;
         const existing_candidates = self.return_forwarding_locals.count();
         const candidate = try self.return_forwarding_locals.getOrPut(source);
         if (!candidate.found_existing) {
@@ -4093,6 +4115,291 @@ const Lowerer = struct {
         return current;
     }
 
+    /// Builder-owned record versions. Components are fresh locals evaluated at
+    /// the binding's original position, never expressions evaluated on demand.
+    const AggregateBindings = struct {
+        allocator: std.mem.Allocator,
+        fields: RecordFields.Store,
+        bindings: collections.DenseMap(Lifted.LocalId, usize),
+        shapes: collections.DenseMap(Type.TypeId, RecordShape),
+        plans: std.ArrayList(RecordPlan) = .empty,
+
+        fn init(allocator: std.mem.Allocator) AggregateBindings {
+            return .{
+                .allocator = allocator,
+                .fields = .{ .allocator = allocator },
+                .bindings = collections.DenseMap(Lifted.LocalId, usize).init(allocator),
+                .shapes = collections.DenseMap(Type.TypeId, RecordShape).init(allocator),
+            };
+        }
+
+        fn deinit(self: *AggregateBindings) void {
+            for (self.plans.items) |plan| {
+                self.allocator.free(plan.values);
+                self.allocator.free(plan.seeds);
+            }
+            self.plans.deinit(self.allocator);
+            var shapes = self.shapes.valueIterator();
+            while (shapes.next()) |shape| {
+                shape.indices.deinit();
+                self.allocator.free(shape.fields);
+                self.allocator.free(shape.field_layouts);
+            }
+            self.shapes.deinit();
+            self.bindings.deinit();
+            self.fields.deinit();
+        }
+    };
+
+    const RecordShape = struct {
+        fields: []const Type.Field,
+        field_layouts: []const layout.Idx,
+        return_child: ?usize,
+        indices: collections.DenseMap(Type.names.RecordFieldNameId, u16),
+        layout_idx: layout.Idx,
+    };
+
+    const RecordValue = struct {
+        index: u16,
+        local: LIR.LocalId,
+        expr: Lifted.ExprId,
+
+        fn lessThan(_: void, lhs: RecordValue, rhs: RecordValue) bool {
+            return lhs.index < rhs.index;
+        }
+    };
+
+    const RecordSeed = struct {
+        target: LIR.LocalId,
+        target_ty: Type.TypeId,
+        source_ty: Type.TypeId,
+        source_index: u16,
+    };
+
+    const RecordPlan = struct {
+        producer: enum { constructor, update, alias },
+        ty: Type.TypeId,
+        root: RecordFields.Id,
+        values: []const RecordValue,
+        seeds: []const RecordSeed,
+        base: ?struct { expr: Lifted.ExprId, local: LIR.LocalId, ty: Type.TypeId },
+        materialized: ?LIR.LocalId = null,
+    };
+
+    const RecordBindingRestore = struct {
+        local: Lifted.LocalId,
+        previous: ?usize,
+    };
+
+    fn recordShape(self: *Lowerer, ty: Type.TypeId) Common.LowerError!RecordShape {
+        const aggregates = self.aggregate_bindings.?;
+        if (aggregates.shapes.get(ty)) |shape| return shape;
+        const fields = try GuardedList.dupe(self.allocator, Type.Field, self.recordFields(ty));
+        errdefer self.allocator.free(fields);
+        var indices = collections.DenseMap(Type.names.RecordFieldNameId, u16).init(self.allocator);
+        errdefer indices.deinit();
+        for (fields, 0..) |field, index| try indices.putNoClobber(field.name, @intCast(index));
+        const layout_idx = try self.layoutOfType(ty);
+        const field_layouts = try self.allocator.alloc(layout.Idx, fields.len);
+        errdefer self.allocator.free(field_layouts);
+        var record_layout = self.result.layouts.getLayout(layout_idx);
+        if (record_layout.tag == .box) record_layout = self.result.layouts.getLayout(record_layout.getIdx());
+        if (self.result.layouts.isZeroSized(record_layout)) {
+            @memset(field_layouts, .zst);
+        } else {
+            if (record_layout.tag != .struct_) Common.invariant("record shape expected a committed struct layout");
+            const committed = self.result.layouts.getStructInfo(record_layout).fields;
+            var named_fields: usize = 0;
+            for (0..committed.len) |index| {
+                const field = committed.get(@intCast(index));
+                if (field.is_padding) continue;
+                std.debug.assert(field.index < fields.len);
+                field_layouts[field.index] = field.layout;
+                named_fields += 1;
+            }
+            if (named_fields != fields.len) Common.invariant("record layout named field count differed from its type");
+        }
+        const field_tys = try self.allocator.alloc(Type.TypeId, fields.len);
+        defer self.allocator.free(field_tys);
+        for (fields, 0..) |field, index| field_tys[index] = field.ty;
+        const shape = RecordShape{
+            .fields = fields,
+            .field_layouts = field_layouts,
+            .return_child = self.singleErasedResultChildIndex(field_tys),
+            .indices = indices,
+            .layout_idx = layout_idx,
+        };
+        try aggregates.shapes.put(ty, shape);
+        return shape;
+    }
+
+    /// Whole-value consumers, including retained join locals, must request the
+    /// same definition-site materialization before using a physical local.
+    fn materializeRecordBinding(self: *Lowerer, local: Lifted.LocalId) Common.LowerError!?struct { local: LIR.LocalId, ty: Type.TypeId } {
+        const aggregates = self.aggregate_bindings orelse return null;
+        const id = aggregates.bindings.get(local) orelse return null;
+        const plan = aggregates.plans.items[id];
+        const source = plan.materialized orelse blk: {
+            const slot = try self.bindLocalForTyped(local, plan.ty);
+            aggregates.plans.items[id].materialized = slot;
+            break :blk slot;
+        };
+        try self.noteLocal(source);
+        return .{ .local = source, .ty = plan.ty };
+    }
+
+    fn restoreRecordBinding(self: *Lowerer, binding: RecordBindingRestore) void {
+        const bindings = &self.aggregate_bindings.?.bindings;
+        if (binding.previous) |previous| {
+            bindings.getPtr(binding.local).?.* = previous;
+        } else {
+            _ = bindings.remove(binding.local);
+        }
+    }
+
+    fn planRecordBinding(self: *Lowerer, pat_id: Lifted.PatId, value: Lifted.ExprId) Common.LowerError!?RecordBindingRestore {
+        const aggregates = self.aggregate_bindings orelse return null;
+        const pattern = self.pat(pat_id);
+        if (pattern.data != .bind) return null;
+        const local = pattern.data.bind;
+        const expr = self.solved.lifted.getExpr(value).data;
+        if (expr != .record and expr != .record_update and expr != .local) return null;
+        const ty = try self.lowerPatTy(pat_id);
+        // Descriptor-governed and recursive boxed representations are ordinary
+        // materialized values. These bindings describe by-value records only.
+        if (self.result.layouts.getLayout(try self.layoutOfType(ty)).tag != .struct_) return null;
+        const runtime_ty = self.runtimeBackingType(ty);
+        if (self.types.get(runtime_ty) != .record) return null;
+        const shape = try self.recordShape(ty);
+        if (shape.fields.len == 0) return null;
+
+        var source_plan: ?RecordPlan = null;
+        const base_expr: ?Lifted.ExprId = if (expr == .record_update) expr.record_update.base else null;
+        const base_local = if (expr == .local) expr.local else if (base_expr) |record_base| blk: {
+            const data = self.solved.lifted.getExpr(record_base).data;
+            break :blk if (data == .local) data.local else null;
+        } else null;
+        if (base_local) |source| {
+            if (aggregates.bindings.get(source)) |id| {
+                const plan = aggregates.plans.items[id];
+                if (plan.ty == ty) source_plan = plan;
+            }
+        }
+        if (expr == .local and source_plan == null) return null;
+
+        var values: std.ArrayList(RecordValue) = .empty;
+        defer values.deinit(self.allocator);
+        if (expr != .local) {
+            const span = if (expr == .record) expr.record else expr.record_update.fields;
+            const fields = try GuardedList.dupe(self.allocator, Lifted.FieldExpr, self.solved.lifted.fieldExprSpan(span));
+            defer self.allocator.free(fields);
+            for (fields) |field| {
+                const index = shape.indices.get(field.name) orelse Common.invariant("record field missing from committed type");
+                const component = try self.addLocalForLayout(shape.field_layouts[index]);
+                try self.local_types.put(component, shape.fields[index].ty);
+                try values.append(self.allocator, .{ .index = index, .local = component, .expr = field.value });
+            }
+            std.mem.sort(RecordValue, values.items, {}, RecordValue.lessThan);
+            for (values.items, 0..) |field, index| {
+                if (index != 0 and values.items[index - 1].index == field.index) Common.invariant("record field defined twice");
+            }
+        }
+
+        var seeds: std.ArrayList(RecordSeed) = .empty;
+        defer seeds.deinit(self.allocator);
+        var record_base: @FieldType(RecordPlan, "base") = null;
+        var root: RecordFields.Id = undefined;
+        if (source_plan) |source| {
+            root = source.root;
+            for (values.items) |field| root = try aggregates.fields.update(root, shape.fields.len, field.index, field.local);
+        } else {
+            const components = try self.allocator.alloc(LIR.LocalId, shape.fields.len);
+            defer self.allocator.free(components);
+            var source_shape: ?RecordShape = null;
+            if (base_expr) |base_value| {
+                const base_ty = try self.lowerExprContextTy(base_value);
+                record_base = .{ .expr = base_value, .local = try self.addTemp(base_ty), .ty = base_ty };
+                source_shape = try self.recordShape(base_ty);
+            }
+            var changed_index: usize = 0;
+            for (shape.fields, 0..) |field, index| {
+                if (changed_index < values.items.len and values.items[changed_index].index == index) {
+                    components[index] = values.items[changed_index].local;
+                    changed_index += 1;
+                } else {
+                    const source = source_shape orelse Common.invariant("record constructor omitted a field");
+                    const source_index = source.indices.get(field.name) orelse Common.invariant("record update source omitted a field");
+                    components[index] = try self.addLocalForLayout(shape.field_layouts[index]);
+                    try self.local_types.put(components[index], field.ty);
+                    try seeds.append(self.allocator, .{
+                        .target = components[index],
+                        .target_ty = field.ty,
+                        .source_ty = source.fields[source_index].ty,
+                        .source_index = source_index,
+                    });
+                }
+            }
+            root = try aggregates.fields.build(components);
+        }
+        const owned_values = try values.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(owned_values);
+        const owned_seeds = try seeds.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(owned_seeds);
+        const id = aggregates.plans.items.len;
+        try aggregates.plans.append(self.allocator, .{ .producer = if (expr == .record) .constructor else if (expr == .record_update) .update else .alias, .ty = ty, .root = root, .values = owned_values, .seeds = owned_seeds, .base = record_base });
+        errdefer _ = aggregates.plans.pop();
+        const previous = aggregates.bindings.get(local);
+        try aggregates.bindings.put(local, id);
+        return .{ .local = local, .previous = previous };
+    }
+
+    fn emitRecordBinding(self: *Lowerer, id: usize, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+        const aggregates = self.aggregate_bindings.?;
+        const plan = aggregates.plans.items[id];
+        const shape = aggregates.shapes.get(plan.ty).?;
+        var current = next;
+        const saved_return_target = self.current_return_target;
+        defer self.current_return_target = saved_return_target;
+        if (plan.materialized != null and plan.materialized == saved_return_target and plan.producer != .update) {
+            // Forward the explicit unique result-component demand through shared
+            // record versions to the original evaluated component's producer.
+            if (shape.return_child) |child| {
+                try self.noteReturnForwardingSource(aggregates.fields.get(plan.root, shape.fields.len, child));
+            }
+            self.current_return_target = null;
+        }
+        if (plan.materialized) |target| {
+            const components = try self.allocator.alloc(LIR.LocalId, shape.fields.len);
+            defer self.allocator.free(components);
+            aggregates.fields.write(plan.root, components);
+            current = try self.result.store.addCFStmt(.{ .assign_struct = .{
+                .target = target,
+                .fields = try self.result.store.addLocalSpan(components),
+                .next = current,
+            } });
+        }
+        var index = plan.values.len;
+        while (index != 0) {
+            index -= 1;
+            const field = plan.values[index];
+            const forwarding = self.enterReturnForwarding(field.local);
+            defer self.leaveReturnForwarding(forwarding);
+            current = try self.lowerExprIntoAtType(field.local, field.expr, shape.fields[field.index].ty, current);
+        }
+        if (plan.base) |record_base| {
+            index = plan.seeds.len;
+            while (index != 0) {
+                index -= 1;
+                const seed = plan.seeds[index];
+                const forwarding = self.enterReturnForwarding(seed.target);
+                defer self.leaveReturnForwarding(forwarding);
+                current = try self.assignTypedRefRead(seed.target, seed.target_ty, seed.source_ty, self.localFieldLayout(record_base.local, seed.source_index), .{ .field = .{ .source = record_base.local, .field_idx = seed.source_index } }, current);
+            }
+            current = try self.lowerExprIntoAtType(record_base.local, record_base.expr, record_base.ty, current);
+        }
+        return current;
+    }
+
     fn lowerRecordInto(
         self: *Lowerer,
         target: LIR.LocalId,
@@ -4100,20 +4407,20 @@ const Lowerer = struct {
         span: Lifted.Span(Lifted.FieldExpr),
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
-        const type_fields = self.recordFields(ty);
+        const shape = try self.recordShape(ty);
+        const type_fields = shape.fields;
         const expr_fields = self.solved.lifted.fieldExprSpan(span);
+        if (expr_fields.len != type_fields.len) Common.invariant("record expression missing field output by Lambda Mono type");
         const ordered = try self.allocator.alloc(Lifted.ExprId, type_fields.len);
         defer self.allocator.free(ordered);
         const field_tys = try self.allocator.alloc(Type.TypeId, type_fields.len);
         defer self.allocator.free(field_tys);
 
-        for (0..type_fields.len) |i| {
-            const field = GuardedList.at(type_fields, i);
-            ordered[i] = for (0..expr_fields.len) |expr_index| {
-                const expr_field = GuardedList.at(expr_fields, expr_index);
-                if (expr_field.name == field.name) break expr_field.value;
-            } else Common.invariant("record expression missing field output by Lambda Mono type");
-            field_tys[i] = field.ty;
+        for (type_fields, 0..) |field, index| field_tys[index] = field.ty;
+        for (0..expr_fields.len) |index| {
+            const field = GuardedList.at(expr_fields, index);
+            const position = shape.indices.get(field.name) orelse Common.invariant("record field missing from committed type");
+            ordered[position] = field.value;
         }
 
         return try self.lowerStructExprsIntoAtTypes(target, ordered, field_tys, next);
@@ -4132,15 +4439,15 @@ const Lowerer = struct {
             return try self.lowerRecordUpdateInto(backing_local, ty, update, boundary);
         }
 
-        const type_fields = try GuardedList.dupe(self.allocator, Type.Field, self.recordFields(ty));
-        defer self.allocator.free(type_fields);
+        const shape = try self.recordShape(ty);
+        const type_fields = shape.fields;
         const update_fields = try GuardedList.dupe(self.allocator, Lifted.FieldExpr, self.solved.lifted.fieldExprSpan(update.fields));
         defer self.allocator.free(update_fields);
         const updates_by_field = try self.allocator.alloc(?Lifted.ExprId, type_fields.len);
         defer self.allocator.free(updates_by_field);
         @memset(updates_by_field, null);
         for (update_fields) |field| {
-            const field_index = Lowerer.recordFieldIndexInFields(type_fields, field.name);
+            const field_index = shape.indices.get(field.name) orelse Common.invariant("record update field missing from committed type");
             if (updates_by_field[field_index] != null) Common.invariant("record update contained the same field more than once");
             updates_by_field[field_index] = field.value;
         }
@@ -4177,6 +4484,7 @@ const Lowerer = struct {
         }
 
         const source_ty = self.storageTypeOfLocalOr(base_local, base_ty);
+        const source_shape = try self.recordShape(source_ty);
         index = type_fields.len;
         while (index > 0) {
             index -= 1;
@@ -4185,8 +4493,8 @@ const Lowerer = struct {
                 current = try self.assignZst(field_locals[index], current);
                 continue;
             }
-            const source_index = self.recordFieldIndex(source_ty, type_fields[index].name);
-            const source_field_ty = self.recordFieldType(source_ty, type_fields[index].name);
+            const source_index = source_shape.indices.get(type_fields[index].name) orelse Common.invariant("record update source omitted a field");
+            const source_field_ty = source_shape.fields[source_index].ty;
             current = try self.assignTypedRefRead(
                 field_locals[index],
                 type_fields[index].ty,
@@ -4812,6 +5120,8 @@ const Lowerer = struct {
         let_: anytype,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
+        const planned = try self.planRecordBinding(let_.bind, let_.value);
+        defer if (planned) |binding| self.restoreRecordBinding(binding);
         const rest = try self.lowerExprIntoAtType(target, let_.rest, result_ty, next);
         const binding_pat = self.pat(let_.bind);
         if (binding_pat.data == .bind) {
@@ -4822,15 +5132,12 @@ const Lowerer = struct {
         return try self.lowerExprInto(value_local, let_.value, bind);
     }
 
-    fn lowerDirectBindValue(
-        self: *Lowerer,
-        pat_id: Lifted.PatId,
-        local: Lifted.LocalId,
-        value: Lifted.ExprId,
-        next: LIR.CFStmtId,
-    ) Common.LowerError!LIR.CFStmtId {
-        const bind_ty = try self.lowerPatTy(pat_id);
-        const value_local = self.existingLocalForTyped(local, bind_ty) orelse try self.addTemp(bind_ty);
+    const ReturnForwardingScope = struct {
+        saved_target: ?LIR.LocalId,
+        finishes_ambiguous_group: bool,
+    };
+
+    fn enterReturnForwarding(self: *Lowerer, value_local: LIR.LocalId) ReturnForwardingScope {
         const is_return_candidate = self.return_forwarding_locals.remove(value_local);
         const forwards_return = is_return_candidate and
             !self.return_forwarding_ambiguous and
@@ -4840,10 +5147,30 @@ const Lowerer = struct {
             self.return_forwarding_locals.count() == 0;
         const saved_return_target = self.current_return_target;
         if (forwards_return) self.current_return_target = value_local;
-        defer {
-            self.current_return_target = saved_return_target;
-            if (finishes_ambiguous_group) self.return_forwarding_ambiguous = false;
+        return .{ .saved_target = saved_return_target, .finishes_ambiguous_group = finishes_ambiguous_group };
+    }
+
+    fn leaveReturnForwarding(self: *Lowerer, scope: ReturnForwardingScope) void {
+        self.current_return_target = scope.saved_target;
+        if (scope.finishes_ambiguous_group) self.return_forwarding_ambiguous = false;
+    }
+
+    fn lowerDirectBindValue(
+        self: *Lowerer,
+        pat_id: Lifted.PatId,
+        local: Lifted.LocalId,
+        value: Lifted.ExprId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const planned_id = if (self.aggregate_bindings) |aggregates| aggregates.bindings.get(local) else null;
+        if (planned_id) |id| {
+            if (self.aggregate_bindings.?.plans.items[id].materialized == null) return self.emitRecordBinding(id, next);
         }
+        const bind_ty = try self.lowerPatTy(pat_id);
+        const value_local = self.existingLocalForTyped(local, bind_ty) orelse try self.addTemp(bind_ty);
+        const forwarding = self.enterReturnForwarding(value_local);
+        defer self.leaveReturnForwarding(forwarding);
+        if (planned_id) |id| return self.emitRecordBinding(id, next);
         return try self.lowerExprIntoAtType(value_local, value, self.typeOfLocalOr(value_local, bind_ty), next);
     }
 
@@ -5780,7 +6107,29 @@ const Lowerer = struct {
         if (segments.len == 0) Common.invariant("field access path had no segments");
 
         const receiver_ty = try self.lowerExprContextTy(receiver);
-        const receiver_local = try self.addTemp(receiver_ty);
+        var source_ty = receiver_ty;
+        var first_segment: usize = 0;
+        var component: ?LIR.LocalId = null;
+        const receiver_data = self.solved.lifted.getExpr(receiver).data;
+        if (receiver_data == .local) {
+            if (self.aggregate_bindings) |aggregates| {
+                if (aggregates.bindings.get(receiver_data.local)) |id| {
+                    const plan = aggregates.plans.items[id];
+                    if (plan.ty == receiver_ty) {
+                        const shape = aggregates.shapes.get(plan.ty).?;
+                        const field = shape.indices.get(GuardedList.at(segments, 0).field).?;
+                        component = aggregates.fields.get(plan.root, shape.fields.len, field);
+                        source_ty = shape.fields[field].ty;
+                        first_segment = 1;
+                    }
+                }
+            }
+        }
+        const receiver_local = component orelse try self.addTemp(receiver_ty);
+        if (first_segment == segments.len) {
+            try self.noteReturnForwardingLocal(target, receiver_local);
+            return self.assignTypedBoundary(target, self.typeOfLocalOr(target, source_ty), receiver_local, source_ty, next);
+        }
 
         const FieldRead = struct {
             target: LIR.LocalId,
@@ -5790,12 +6139,12 @@ const Lowerer = struct {
             source_field_index: u16,
             storage_layout: ?layout.Idx,
         };
-        const reads = try self.allocator.alloc(FieldRead, segments.len);
+        const reads = try self.allocator.alloc(FieldRead, segments.len - first_segment);
         defer self.allocator.free(reads);
 
-        var logical_source_ty = receiver_ty;
+        var logical_source_ty = source_ty;
         var source_local = receiver_local;
-        for (0..segments.len) |index| {
+        for (first_segment..segments.len) |index| {
             const segment = GuardedList.at(segments, index);
             const target_field_index = self.recordFieldIndex(logical_source_ty, segment.field);
             const target_fields = self.recordFields(logical_source_ty);
@@ -5809,7 +6158,7 @@ const Lowerer = struct {
             const source_field_index = self.recordFieldIndex(storage_source_ty, segment.field);
             const source_fields = self.recordFields(storage_source_ty);
             const source_field_ty = GuardedList.at(source_fields, @intCast(source_field_index)).ty;
-            reads[index] = .{
+            reads[index - first_segment] = .{
                 .target = destination,
                 .target_ty = target_field_ty,
                 .source = source_local,
@@ -5842,7 +6191,7 @@ const Lowerer = struct {
             else
                 try self.assignZst(read.target, current);
         }
-        return try self.lowerExprIntoAtType(receiver_local, receiver, receiver_ty, current);
+        return if (component != null) current else try self.lowerExprIntoAtType(receiver_local, receiver, receiver_ty, current);
     }
 
     fn lowerTupleAccessInto(self: *Lowerer, target: LIR.LocalId, tuple: Lifted.ExprId, elem_index: u32, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
@@ -6254,6 +6603,22 @@ const Lowerer = struct {
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
         const stmts = self.solved.lifted.stmtSpan(stmts_span);
+        var planned: std.ArrayList(RecordBindingRestore) = .empty;
+        defer {
+            var index = planned.items.len;
+            while (index != 0) {
+                index -= 1;
+                self.restoreRecordBinding(planned.items[index]);
+            }
+            planned.deinit(self.allocator);
+        }
+        for (0..stmts.len) |index| {
+            const stmt = self.solved.lifted.getStmt(GuardedList.at(stmts, index));
+            if (stmt != .let_ or stmt.let_.recursive) continue;
+            if (try self.planRecordBinding(stmt.let_.pat, stmt.let_.value)) |binding| {
+                try planned.append(self.allocator, binding);
+            }
+        }
         var current = if (self.solved.lifted.getExpr(final_expr).data == .@"unreachable") blk: {
             if (stmts.len == 0) {
                 Common.invariant("unreachable block-final marker had no preceding terminating statement");
@@ -8663,6 +9028,7 @@ const Lowerer = struct {
     }
 
     fn localForTyped(self: *Lowerer, local: Lifted.LocalId, ty: Type.TypeId) Common.LowerError!LIR.LocalId {
+        if (try self.materializeRecordBinding(local)) |source| return source.local;
         if (self.typed_local_map.get(.{ .local = local, .ty = ty })) |existing| {
             try self.noteLocal(existing);
             return existing;

--- a/test/echo/issue_11130_record_versions.roc
+++ b/test/echo/issue_11130_record_versions.roc
@@ -1,0 +1,37 @@
+consume = |record| "${record.left}:${record.right}"
+
+main! = |args| {
+	original = {
+		left: {
+			echo!("first\n")
+			"old"
+		},
+		right: args.len().to_str(),
+	}
+	updated = {
+		..original,
+		left: {
+			echo!("second\n")
+			"new"
+		},
+	}
+	alias = original
+	echo!("${consume(original)}\n")
+	echo!("${consume(updated)}\n")
+	echo!("${alias.left}\n")
+	chosen = if args.is_empty() {
+		original
+	} else {
+		updated
+	}
+	echo!("${chosen.left}\n")
+	unused = {
+		..updated,
+		left: {
+			echo!("unused\n")
+			"discarded"
+		},
+	}
+	_ = unused.right
+	Ok({})
+}


### PR DESCRIPTION
Record updates now share evaluated field bindings during direct LIR lowering, copying only the paths to changed fields and materializing a record when a whole-value consumer needs it. This avoids constructing and then eliminating a complete record for every update while preserving eager evaluation, record versions, and committed layouts. Field-name and layout mappings are cached per type.

Scalarization propagates alias opacity along dependencies, shares resolved roots, and visits alias closures through explicit reverse edges. Independent constructor eliminations share one analysis; locals with multiple definitions retain their representation. Fixes #11130.
