### PR TITLE
Avoid Binaryen’s default pipeline after LLVM O3 for wasm speed builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3751,6 +3751,9 @@ pub fn build(b: *std.Build) void {
     // Store CLI runner step reference so we can add glue host dependency later.
     var run_cli_test_step: ?*std.Build.Step = null;
 
+    const cli_test_options = b.addOptions();
+    cli_test_options.addOption(bool, "binaryen", !use_system_llvm and user_llvm_path == null);
+
     // CLI integration tests: one harness-backed runner covers platforms,
     // subcommands, echo, and glue. Focus locally with:
     //   zig build run-test-cli -- --suite echo --filter "case name"
@@ -3776,6 +3779,7 @@ pub fn build(b: *std.Build) void {
             }),
         });
         parallel_cli_runner_exe.root_module.link_libc = true;
+        parallel_cli_runner_exe.root_module.addOptions("cli_test_options", cli_test_options);
         build_test_cli_runners_step.dependOn(&parallel_cli_runner_exe.step);
 
         const run_cli = b.addRunArtifact(parallel_cli_runner_exe);
@@ -5801,6 +5805,7 @@ pub fn build(b: *std.Build) void {
         }),
         .filters = test_filters,
     });
+    cli_runner_unit_test.root_module.addOptions("cli_test_options", cli_test_options);
     test_suites.register(.{
         .step_suffix = "cli-runner-unit",
         .description = "Run CLI runner Zig unit tests",

--- a/design.md
+++ b/design.md
@@ -12760,13 +12760,31 @@ during the final link. Undefined functions referenced by the linked objects may
 remain host imports, but the linker must not treat a missing declared export as
 such an import or silently discard it.
 
-After the final wasm link, size builds run Binaryen at optimize level 2 and
+After the final wasm link, LLVM speed builds run an explicit Binaryen cleanup
+pipeline: directize, remove-unused-brs, optimize-instructions, dce, vacuum,
+duplicate-function elimination, unused module item removal, and memory
+packing. These passes simplify the final wasm instructions and use
+the resolved function/table identities and final module reachability that
+were unavailable before linking. They do not invoke Binaryen's default
+optimization pipeline or repeat inlining, precomputation, or local coalescing
+over LLVM's optimized output. The CLI selects the pass list explicitly;
+the Binaryen bridge executes that list without selecting additional passes.
+Lowering Binaryen's optimize level is not a way to select this pipeline:
+even level zero runs local coalescing through `BinaryenModuleOptimize`.
+
+Size builds run Binaryen's default pipeline at optimize level 2 and
 shrink level 2, validate the resulting module, and remove debug, producer, and
 target-feature custom sections from non-debug output. Removing the
 target-feature custom section does not alter the wasm code section; Binaryen
 validates the module after the metadata is removed. The removed custom section
 is not part of the runtime ABI. Debug builds retain debugging and
 target-feature metadata.
+
+Validation and metadata stripping are independent of optimization pass
+selection. Both speed and size builds validate the final module, preserve
+the platform's imported-memory initialization contract and target instruction
+features, and strip debug metadata only for non-debug output. Both remove
+producer metadata; only non-debug size builds remove target-feature metadata.
 
 ## Host Symbol ABI
 

--- a/design.md
+++ b/design.md
@@ -12768,7 +12768,7 @@ the resolved function/table identities and final module reachability that
 were unavailable before linking. They do not invoke Binaryen's default
 optimization pipeline or repeat inlining, precomputation, or local coalescing
 over LLVM's optimized output. The CLI selects the pass list explicitly;
-the Binaryen bridge executes that list without selecting additional passes.
+`RocBinaryenOptimizeWasm` executes that list without selecting additional passes.
 Lowering Binaryen's optimize level is not a way to select this pipeline:
 even level zero runs local coalescing through `BinaryenModuleOptimize`.
 

--- a/src/build/zig_binaryen.cpp
+++ b/src/build/zig_binaryen.cpp
@@ -11,6 +11,8 @@ extern "C" {
 typedef struct RocBinaryenOptimizeConfig {
     int optimize_level;
     int shrink_level;
+    const char* const* passes;
+    unsigned int pass_count;
     uint8_t zero_filled_memory;
     uint8_t debug_info;
     uint8_t strip_debug;
@@ -107,7 +109,14 @@ extern "C" int RocBinaryenOptimizeWasm(
         return RocBinaryenStatusReadFailed;
     }
 
-    BinaryenModuleOptimize(module);
+    if (config.passes == nullptr) {
+        BinaryenModuleOptimize(module);
+    } else {
+        // The C API takes a mutable array pointer but only reads the pass names.
+        BinaryenModuleRunPasses(module,
+                               const_cast<const char**>(config.passes),
+                               config.pass_count);
+    }
 
     const char* strip_passes[4];
     BinaryenIndex strip_count = 0;

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -30,6 +30,9 @@ const binaryen_available = if (@import("builtin").is_test) false else @import("c
 const RocBinaryenOptimizeConfig = extern struct {
     optimize_level: c_int,
     shrink_level: c_int,
+    /// Null selects Binaryen's default pipeline; otherwise run exactly this list.
+    passes: ?[*]const [*:0]const u8,
+    pass_count: c_uint,
     zero_filled_memory: u8,
     debug_info: u8,
     strip_debug: u8,
@@ -987,6 +990,21 @@ fn binaryenStatusName(status: c_int) []const u8 {
     };
 }
 
+// LLVM has already optimized the app and builtins. These passes clean up
+// final wasm instructions, table calls, duplicate functions, and data after
+// linking. Do not use the default pipeline for speed builds: even level zero
+// runs local coalescing, and the optimizing inliner can run it again.
+const wasm_speed_passes = [_][*:0]const u8{
+    "directize",
+    "remove-unused-brs",
+    "optimize-instructions",
+    "dce",
+    "vacuum",
+    "duplicate-function-elimination",
+    "remove-unused-module-elements",
+    "memory-packing",
+};
+
 fn binaryenConfig(config: LinkConfig) RocBinaryenOptimizeConfig {
     const Levels = struct {
         optimize: c_int,
@@ -1000,6 +1018,8 @@ fn binaryenConfig(config: LinkConfig) RocBinaryenOptimizeConfig {
     return .{
         .optimize_level = levels.optimize,
         .shrink_level = levels.shrink,
+        .passes = if (config.wasm_optimize == .speed) &wasm_speed_passes else null,
+        .pass_count = if (config.wasm_optimize == .speed) wasm_speed_passes.len else 0,
         .zero_filled_memory = @intFromBool(config.wasm_zero_filled_memory),
         .debug_info = @intFromBool(config.wasm_debug_info),
         .strip_debug = @intFromBool(!config.wasm_debug_info),

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -9011,8 +9011,8 @@ fn configuredWasmZeroFilledMemory(wasm: ?roc_target.WasmTargetConfig) bool {
 }
 
 /// Binaryen post-link optimization mode for linked wasm output, derived from
-/// the build's opt level: LLVM opt levels get the matching Binaryen pass;
-/// dev/interpreter builds skip Binaryen entirely.
+/// the build's opt level: speed uses explicit cleanup after LLVM O3, size uses
+/// Binaryen's size pipeline, and dev/interpreter builds skip Binaryen entirely.
 fn wasmOptimizeMode(opt: cli_args.OptLevel) linker.WasmOptimizeMode {
     return switch (opt) {
         .size => .size,

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -388,6 +388,7 @@ const CustomCase = enum {
     default_platform_wasm32_archive_reproducible,
     issue_10733_wasm_boxy_dev_sealed_object,
     issue_10827_private_compiler_support,
+    issue_11134_wasm_post_llvm_pipeline,
     macos_output_basename_reproducible,
     default_platform_crash_x64musl,
     default_platform_crash_arm64musl,
@@ -1581,6 +1582,7 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "issue 10733: LLVM size wasm32 links the Boxy runtime", .backend = .size, .body = .{ .command = .{ .args = &.{ "build", "--target=wasm32", "--opt=size", "--no-cache", "--output=boxed_closure_size.wasm" }, .roc_file = "test/wasm/boxed_closure_app.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "UnresolvedBuiltinImport" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "issue 10733: LLVM speed wasm32 links the Boxy runtime", .backend = .speed, .body = .{ .command = .{ .args = &.{ "build", "--target=wasm32", "--opt=speed", "--no-cache", "--output=boxed_closure_speed.wasm" }, .roc_file = "test/wasm/boxed_closure_app.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "UnresolvedBuiltinImport" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "issue 10827: Roc compiler support is private from a strong-intrinsic wasm host", .backend = .dev, .body = .{ .custom = .issue_10827_private_compiler_support } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 11134: wasm speed uses explicit post-LLVM passes", .backend = .speed, .body = .{ .custom = .issue_11134_wasm_post_llvm_pipeline } },
     // issue 10951: https://github.com/roc-lang/roc/issues/10951
     // The wasm32 linker exports exactly what the platform header's `exports:`
     // field names, so a header that omits the field links a module with no
@@ -2867,6 +2869,7 @@ fn runCustomCase(
         .default_platform_wasm32_archive_reproducible => customDefaultPlatformWasm32ArchiveReproducible(io, allocator, &env, &timer, timeout_ms),
         .issue_10733_wasm_boxy_dev_sealed_object => customIssue10733WasmBoxyDevSealedObject(io, allocator, &env, &timer, timeout_ms),
         .issue_10827_private_compiler_support => customIssue10827PrivateCompilerSupport(io, allocator, &env, &timer, timeout_ms),
+        .issue_11134_wasm_post_llvm_pipeline => customWasmPostLlvmPipeline(io, allocator, &env, &timer, timeout_ms),
         .macos_output_basename_reproducible => customMacosOutputBasenameReproducible(io, allocator, &env, &timer, timeout_ms),
         .default_platform_crash_x64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .x64musl, .crash),
         .default_platform_crash_arm64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .arm64musl, .crash),
@@ -5396,6 +5399,73 @@ fn validateWasmOutput(
     defer module_def.destroy();
     module_def.decode(wasm_bytes) catch |err|
         return customFailure(allocator, timer, "generated invalid wasm {s}: {}", .{ path, err });
+    return null;
+}
+
+fn customWasmPostLlvmPipeline(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+) ?TestResult {
+    if (!@import("cli_test_options").binaryen) {
+        return .{ .status = .skip, .phase = .setup, .message = "requires bundled Binaryen" };
+    }
+
+    var trace_env = CaseEnv{
+        .dirs = env.dirs,
+        .env_map = env.env_map.clone(allocator) catch |err|
+            return customInfraFailure(allocator, timer, "failed to clone wasm test environment: {}", .{err}),
+    };
+    defer trace_env.env_map.deinit();
+    trace_env.env_map.put("BINARYEN_PASS_DEBUG", "1") catch |err|
+        return customInfraFailure(allocator, timer, "failed to enable Binaryen pass tracing: {}", .{err});
+
+    const wasm_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "pipeline.wasm" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate wasm output path: {}", .{err});
+    defer allocator.free(wasm_path);
+    const output_arg = outputArg(allocator, wasm_path) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate wasm output argument: {}", .{err});
+    defer allocator.free(output_arg);
+
+    const modes = [_]struct { opt: OptMode, debug: bool }{
+        .{ .opt = .speed, .debug = false },
+        .{ .opt = .speed, .debug = true },
+        .{ .opt = .size, .debug = false },
+        .{ .opt = .size, .debug = true },
+    };
+    for (modes) |mode| {
+        const speed = mode.opt == .speed;
+        const opt_arg = if (speed) "--opt=speed" else "--opt=size";
+        const args = [_][]const u8{ "build", "--target=wasm32", "--no-cache", opt_arg, output_arg, "--debug" };
+        const contains = [_]OutputNeedle{
+            .{ .stream = .stderr, .text = "running pass: remove-unused-module-elements" },
+            .{ .stream = .stderr, .text = "running pass: memory-packing" },
+            .{ .stream = .stderr, .text = "(final validation)" },
+            .{ .stream = .stderr, .text = if (speed) "running pass: vacuum" else "running pass: coalesce-locals" },
+        };
+        const not_contains = [_]OutputNeedle{
+            .{ .stream = .stderr, .text = "running pass: coalesce-locals" },
+            .{ .stream = .stderr, .text = "running pass: merge-locals" },
+            .{ .stream = .stderr, .text = "running pass: precompute" },
+            .{ .stream = .stderr, .text = "running pass: inlining-optimizing" },
+        };
+        const occurrences = [_]OutputOccurrence{
+            .{ .stream = .stderr, .text = "running pass: strip-debug", .count = @intFromBool(!mode.debug) },
+            .{ .stream = .stderr, .text = "running pass: strip-dwarf", .count = @intFromBool(!mode.debug) },
+            .{ .stream = .stderr, .text = "running pass: strip-producers", .count = 1 },
+            .{ .stream = .stderr, .text = "running pass: strip-target-features", .count = @intFromBool(!speed and !mode.debug) },
+        };
+        if (runRocAndCheck(io, allocator, &trace_env, timer, timeout_ms, .{
+            .args = args[0..if (mode.debug) args.len else args.len - 1],
+            .roc_file = "test/wasm/str_concat_join_static_lib_app.roc",
+            .contains = &contains,
+            .not_contains = if (speed) &not_contains else &.{},
+            .occurrences = &occurrences,
+        })) |failure| return failure;
+        if (validateWasmOutput(io, allocator, timer, wasm_path)) |failure| return failure;
+    }
     return null;
 }
 


### PR DESCRIPTION
Wasm `--opt=speed` now runs an explicit post-LLVM cleanup pipeline instead of Binaryen's default O3 pipeline, avoiding repeated local coalescing, precomputation, and inlining after LLVM O3. Final validation, debug metadata handling, target features, and imported-memory assumptions are preserved; `--opt=size` keeps its existing pipeline.

On the issue's 2,000-procedure concatenation tree, isolated Binaryen CPU time drops from 4.31 s to 0.44 s and peak memory drops from 162 MiB to 108 MiB, with wasm output 6.5% larger.

Fixes #11134.
