### PR TITLE
Avoid quadratic ARC group liveness and restitution work

### DIFF
--- a/design.md
+++ b/design.md
@@ -10739,8 +10739,8 @@ all ownership variants reuse it. Singleton-only frames use identity numbering
 without a mapping allocation. The extra group and borrowed-result bits keep
 their original meanings and remain outside the raw resource-bit prefix.
 Queries excluding one group member inspect only that group's raw-bit range,
-with the excluded bit removed. Sparse snapshots answer range existence from
-canonical empty subtrees and descend only at interval boundaries; neither
+with the excluded bit removed. Sparse snapshots answer range-existence queries
+using null pointers for empty subtrees and descend only at interval boundaries; neither
 resource count nor group membership count is scanned per query. No mutable
 per-statement group counters or additional membership sets are maintained.
 Solver-only resource anchors participate exactly like concrete RC resources in
@@ -10935,7 +10935,7 @@ Restitution consumes the structural lift's existing procedure statement
 inventory. Its reusable scratch arrays and statement-to-ordinal lookup contain
 only the active procedure's statements. Initialization, per-parameter scratch
 merges, and final receipt emission iterate that compact domain, never the
-module statement count. Only the final published receipt table is indexed by
+module statement count. Only the final receipt table output is indexed by
 module statement id.
 
 The analysis is a polynomial product of independent finite resource states, not

--- a/design.md
+++ b/design.md
@@ -10732,7 +10732,20 @@ proc liveness domain counts exactly the members in its own frame, since an
 outside member cannot occur on one of that proc's paths. It derives those
 counts in one linear frame scan from the solved leader relation, so the module
 solution retains no redundant flat group-member table.
-Join ownership sets use the resource prefix of this same per-proc domain.
+Ownership indices retain producer-local order independently of raw liveness
+numbering. Each source procedure's immutable liveness graph owns one compact
+mapping that places its resource locals contiguously by solved borrow group;
+all ownership variants reuse it. Singleton-only frames use identity numbering
+without a mapping allocation. The extra group and borrowed-result bits keep
+their original meanings and remain outside the raw resource-bit prefix.
+Queries excluding one group member inspect only that group's raw-bit range,
+with the excluded bit removed. Sparse snapshots answer range existence from
+canonical empty subtrees and descend only at interval boundaries; neither
+resource count nor group membership count is scanned per query. No mutable
+per-statement group counters or additional membership sets are maintained.
+Solver-only resource anchors participate exactly like concrete RC resources in
+these queries. Group-extension bits are not substitutes for raw member bits:
+their read-before-rebind kill equations differ.
 Consequently neither ownership nor liveness rows are widened by locals from
 other procedures. Unrelated scalar locals are not ARC resources and never
 receive raw liveness bits. This distinction is load-bearing for wide static
@@ -10917,6 +10930,13 @@ same-value alias clears that entry bit. Borrowing reads leave it set. At each
 normal return, the bits still set are intersected with every other path that
 returns the same discriminant. A loop is the ordinary finite fixed point over
 the per-resource rows below.
+
+Restitution consumes the structural lift's existing procedure statement
+inventory. Its reusable scratch arrays and statement-to-ordinal lookup contain
+only the active procedure's statements. Initialization, per-parameter scratch
+merges, and final receipt emission iterate that compact domain, never the
+module statement count. Only the final published receipt table is indexed by
+module statement id.
 
 The analysis is a polynomial product of independent finite resource states, not
 an enumeration of parameter subsets. For each represented entry parameter

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -13001,7 +13001,7 @@ test "RC outcome restitution solves sixteen independent conditional arguments po
     try testing.expect(work <= count * f.store.cfStmtCount() * 2);
 }
 
-fn outcomeScratchWork(proc_count: usize) !u64 {
+fn outcomeScratchWork(proc_count: usize) (Allocator.Error || error{TestExpectedEqual})!u64 {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();
     const outcome_layout = try f.layouts.putTagUnion(&.{ try f.layouts.ensureZstLayout(), f.list_i64 });

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -39,6 +39,9 @@ pub const ResourceError = std.mem.Allocator.Error;
 /// and profiling. Not updated in release builds.
 pub var solver_iterations: u64 = 0;
 
+/// Debug-only count of locals examined by borrow-group liveness queries.
+pub var group_liveness_member_visits: u64 = 0;
+
 /// Options for ARC insertion.
 pub const InsertOptions = struct {
     /// Root procs whose ownership signature is pinned all-owned by ABI.
@@ -268,6 +271,76 @@ const ProcArcDomain = struct {
             }
             self.global_local_index[local_index] = no_proc_local_index;
         }
+    }
+};
+
+/// Immutable raw-liveness numbering, built once with a source's graph and
+/// shared by its ownership variants. Ownership keeps its original indices
+/// and release order; only raw liveness bits are grouped by solved leader.
+const GroupLivenessIndex = struct {
+    const Range = struct { start: u32 = 0, end: u32 = 0 };
+
+    /// Ownership resource index -> raw liveness bit. Empty means identity,
+    /// which needs no storage when every frame group is a singleton.
+    raw_bits: []const u32 = &.{},
+    /// Indexed by the domain's existing multi-member group ordinal. Groups
+    /// containing only non-resource locals have empty ranges.
+    ranges: []const Range = &.{},
+
+    fn init(allocator: Allocator, domain: *const ProcArcDomain, solution: *const arc_solve.Solution) ResourceError!GroupLivenessIndex {
+        if (domain.group_leaders.len == 0) return .{};
+        const raw_bits = try allocator.alloc(u32, domain.resource_locals.len);
+        const ranges = try allocator.alloc(Range, domain.group_leaders.len);
+        @memset(ranges, .{});
+        var singletons: u32 = 0;
+        for (domain.resource_locals) |local| {
+            if (domain.groupBitOf(solution.leaderOf(local))) |bit| {
+                ranges[bit - raw_bits.len].end += 1;
+            } else {
+                singletons += 1;
+            }
+        }
+        var offset = singletons;
+        for (ranges) |*range| {
+            const count = range.end;
+            range.* = .{ .start = offset, .end = offset };
+            offset += count;
+        }
+        std.debug.assert(offset == raw_bits.len);
+        var singleton_bit: u32 = 0;
+        for (domain.resource_locals, raw_bits) |local, *raw_bit| {
+            if (domain.groupBitOf(solution.leaderOf(local))) |bit| {
+                const range = &ranges[bit - raw_bits.len];
+                raw_bit.* = range.end;
+                range.end += 1;
+            } else {
+                raw_bit.* = singleton_bit;
+                singleton_bit += 1;
+            }
+        }
+        return .{ .raw_bits = raw_bits, .ranges = ranges };
+    }
+
+    fn rawBitOf(self: *const GroupLivenessIndex, domain: *const ProcArcDomain, local: LIR.LocalId) ?usize {
+        const resource_bit = domain.resourceBitOf(local) orelse return null;
+        return if (self.raw_bits.len == 0) resource_bit else self.raw_bits[resource_bit];
+    }
+
+    fn usedExcept(self: *const GroupLivenessIndex, domain: *const ProcArcDomain, reads: *const ExactBitSet, leader: LIR.LocalId, except: LIR.LocalId) bool {
+        const range = if (domain.groupBitOf(leader)) |bit|
+            self.ranges[bit - domain.resource_locals.len]
+        else {
+            if (leader == except) return false;
+            const bit = self.rawBitOf(domain, leader) orelse return false;
+            if (builtin.mode == .Debug) group_liveness_member_visits += 1;
+            return reads.isSet(bit);
+        };
+        if (self.rawBitOf(domain, except)) |bit| {
+            if (range.start <= bit and bit < range.end) {
+                return reads.anySetInRange(range.start, bit) or reads.anySetInRange(bit + 1, range.end);
+            }
+        }
+        return reads.anySetInRange(range.start, range.end);
     }
 };
 
@@ -870,6 +943,20 @@ const ExactBitSet = struct {
         const word_index: u32 = @intCast(bit / 64);
         const mask = @as(u64, 1) << @intCast(bit % 64);
         return self.words.get(word_index) & mask != 0;
+    }
+
+    /// Exact range existence, without enumerating either members or live bits.
+    fn anySetInRange(self: *const ExactBitSet, start: usize, end: usize) bool {
+        std.debug.assert(start <= end and end <= self.bit_len);
+        if (start == end) return false;
+        const first_word: u32 = @intCast(start / 64);
+        const last_word: u32 = @intCast((end - 1) / 64);
+        const first_mask = @as(u64, std.math.maxInt(u64)) << @as(u6, @intCast(start % 64));
+        const last_mask = @as(u64, std.math.maxInt(u64)) >> @as(u6, @intCast(63 - (end - 1) % 64));
+        if (first_word == last_word) return self.words.get(first_word) & first_mask & last_mask != 0;
+        if (self.words.get(first_word) & first_mask != 0) return true;
+        if (self.words.get(last_word) & last_mask != 0) return true;
+        return self.words.hasNonEmptyInRange(first_word + 1, last_word);
     }
 
     fn unsetAll(self: *ExactBitSet) void {
@@ -5812,6 +5899,7 @@ const Inserter = struct {
 
     const ReadBeforeRebindGraph = struct {
         allocator: Allocator,
+        group_liveness: GroupLivenessIndex,
         nodes: std.ArrayList(ReadBeforeRebindNode),
         /// Node indices, resolved exactly once while each edge is appended.
         successors: std.ArrayList(u32),
@@ -5821,9 +5909,10 @@ const Inserter = struct {
         /// Compact node bits whose forward paths can reach a loop boundary.
         reaches_loop_edge: std.bit_set.DynamicBitSetUnmanaged = .{},
 
-        fn init(allocator: Allocator) ReadBeforeRebindGraph {
+        fn init(allocator: Allocator, proc_domain: *const ProcArcDomain, solution: *const arc_solve.Solution) ResourceError!ReadBeforeRebindGraph {
             return .{
                 .allocator = allocator,
+                .group_liveness = try GroupLivenessIndex.init(allocator, proc_domain, solution),
                 .nodes = .empty,
                 .successors = .empty,
             };
@@ -5881,10 +5970,18 @@ const Inserter = struct {
         graph.nodes.items[node_index].successor_len += 1;
     }
 
-    /// Raw liveness-bit position for a refcounted resource local or one of
-    /// its explicit solved ownership-unit / borrow-group representatives.
+    /// Immutable numbering shared by every emission of the source procedure.
+    fn groupLivenessIndex(self: *const Inserter) *const GroupLivenessIndex {
+        const graph = if (self.liveness_graphs[@intFromEnum(self.current_source_proc)]) |*entry|
+            entry
+        else
+            arcInvariant("ARC raw-liveness query lacked its source graph");
+        return &graph.group_liveness;
+    }
+
+    /// Raw liveness-bit position for a concrete resource or solved anchor.
     fn rawLivenessBitOf(self: *const Inserter, local: LIR.LocalId) ?usize {
-        return self.domain().resourceBitOf(local);
+        return self.groupLivenessIndex().rawBitOf(self.domain(), local);
     }
 
     fn noteReadBeforeRebindLocal(self: *const Inserter, reads: *ExactBitSet, local: LIR.LocalId) ResourceError!void {
@@ -6054,7 +6151,7 @@ const Inserter = struct {
         if (source_index >= self.liveness_graphs.len) arcInvariant("ARC liveness source proc exceeded its graph table");
         const graph_slot = &self.liveness_graphs[source_index];
         if (graph_slot.* != null) arcInvariant("ARC keep-free liveness graph existed without its requested row");
-        graph_slot.* = ReadBeforeRebindGraph.init(self.liveness_allocator);
+        graph_slot.* = try ReadBeforeRebindGraph.init(self.liveness_allocator, self.domain(), self.solution);
         var graph = graph_slot.*.?;
         const graph_allocator = graph.allocator;
         var work = std.ArrayList(u32).empty;
@@ -6866,16 +6963,16 @@ const Inserter = struct {
 
     /// Value liveness for one raw local (no group extension). Borrowed call
     /// results have a dedicated value-use bit; other resources use their raw
-    /// ownership bit.
+    /// liveness bit.
     fn valueUsedInPath(
         self: *Inserter,
         start: LIR.CFStmtId,
         needle: LIR.LocalId,
         loop_keep: ?LoopKeep,
     ) ResourceError!bool {
+        const reads = try self.livenessRow(start, loop_keep);
         const bit = self.valueUseBitOf(needle) orelse self.rawLivenessBitOf(needle) orelse
             arcInvariant("ARC value-use query for a local without a value-use bit");
-        const reads = try self.livenessRow(start, loop_keep);
         return reads.isSet(bit);
     }
 
@@ -6937,18 +7034,7 @@ const Inserter = struct {
     ) ResourceError!bool {
         const reads = try self.livenessRow(start, loop_keep);
         const leader = self.solution.leaderOf(local);
-        // Resource locals include concrete RC values plus the solver-authored
-        // ownership-unit and borrow-group representatives. Those synthetic
-        // anchors have liveness bits even though they need no concrete RC
-        // helper of their own, and must participate in lender-death checks.
-        for (self.domain().resource_locals) |member_local| {
-            if (self.solution.leaderOf(member_local) != leader) continue;
-            if (member_local == except) continue;
-            const bit = self.rawLivenessBitOf(member_local) orelse
-                arcInvariant("ARC refcounted borrow-group member missing its raw liveness bit");
-            if (reads.isSet(bit)) return true;
-        }
-        return false;
+        return self.groupLivenessIndex().usedExcept(self.domain(), reads, leader, except);
     }
 
     fn retainSpanExceptPositions(
@@ -9211,6 +9297,86 @@ test "ARC lender-death query sees a live solver-only borrow anchor" {
     try testing.expect(try inserter.groupUsedInPathExcept(use_anchor, concrete, concrete, null));
 }
 
+test "ARC grouped raw liveness agrees with exhaustive resource queries" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    var locals: [513]LIR.LocalId = undefined;
+    for (&locals) |*local| local.* = try f.local(.str);
+    const scalar = try f.local(.i64);
+    var body = try f.ret(scalar);
+    body = try f.assignI64(scalar, 0, body);
+    var index = locals.len;
+    while (index > 0) {
+        index -= 1;
+        const use = try f.expectStmt(locals[index], body);
+        body = if (index < 3)
+            try f.assignStr(locals[index], "root", use)
+        else
+            try f.assignRefLocal(locals[index], locals[index % 3], use);
+    }
+    const proc = try f.addProc(&.{}, body, .i64);
+    var rc = [_]bool{true} ** (locals.len + 1);
+    rc[locals.len] = false;
+    var solution = try arc_solve.solve(testing.allocator, &f.store, &f.layouts, &rc, &.{}, &.{}, true);
+    defer solution.deinit();
+    for (locals, 0..) |local, i| try testing.expectEqual(locals[i % 3], solution.leaderOf(local));
+    var indices = [_]u32{no_proc_local_index} ** rc.len;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var domain = try ProcArcDomain.init(arena.allocator(), &f.store, &solution, &rc, &indices, f.store.getProcSpec(proc).frame_locals);
+    defer domain.clearGlobalIndices();
+    const grouped = try GroupLivenessIndex.init(arena.allocator(), &domain, &solution);
+    var reads = try ExactBitSet.initEmpty(arena.allocator(), domain.livenessBitLen());
+    var expected = [_]bool{false} ** locals.len;
+    var prng = std.Random.DefaultPrng.init(11127);
+    const random = prng.random();
+    for (0..20) |round| {
+        // Include empty rows, one-member rows, dense rows, and shared unions.
+        var next = try ExactBitSet.initEmpty(arena.allocator(), domain.livenessBitLen());
+        for (locals, 0..) |local, i| {
+            const live = if (round == 0) false else if (round == 1) i == 64 else random.boolean();
+            if (live) try next.set(grouped.rawBitOf(&domain, local).?);
+            expected[i] = if (round % 3 == 0) expected[i] or live else live;
+        }
+        if (round % 3 == 0) try reads.setUnion(next) else reads = next;
+        for (locals, 0..) |local, i| {
+            try testing.expectEqual(local, domain.resourceLocalAt(i));
+            try testing.expectEqual(expected[i], reads.isSet(grouped.rawBitOf(&domain, local).?));
+        }
+        for (0..3) |group| {
+            for (0..locals.len + 1) |excluded| {
+                const except = if (excluded == locals.len) scalar else locals[excluded];
+                var used = false;
+                for (locals, 0..) |local, i| {
+                    if (i % 3 == group and local != except and expected[i]) used = true;
+                }
+                try testing.expectEqual(used, grouped.usedExcept(&domain, &reads, locals[group], except));
+            }
+        }
+    }
+}
+
+test "ARC raw-liveness ranges exclude boundary bits without scanning wide empty groups" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var reads = try ExactBitSet.initEmpty(arena.allocator(), 1_000_001);
+    for ([_]usize{ 0, 63, 64, 511, 512, 999999, 1000000 }) |bit| try reads.set(bit);
+    const boundaries = [_]usize{ 0, 1, 63, 64, 65, 511, 512, 513, 999999, 1000000, 1000001 };
+    for (boundaries) |start| {
+        for (boundaries) |end| {
+            if (end < start) continue;
+            var expected = false;
+            for ([_]usize{ 0, 63, 64, 511, 512, 999999, 1000000 }) |bit| {
+                if (start <= bit and bit < end) expected = true;
+            }
+            try testing.expectEqual(expected, reads.anySetInRange(start, end));
+        }
+    }
+    const before = @import("arc_state.zig").range_query_node_visits;
+    try testing.expect(!reads.anySetInRange(513, 999999));
+    if (builtin.mode == .Debug) try testing.expect(@import("arc_state.zig").range_query_node_visits - before <= 2 * 8 * 11);
+}
+
 test "RC pass-through: non-refcounted i64 block unchanged" {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();
@@ -10565,6 +10731,53 @@ test "RC join summary solver work grows linearly with chained joins" {
     const large = try chainedJoinSolveWork(16);
     // Doubling the join count must stay near double the solver work;
     // per-join region re-walks would grow it quadratically.
+    try testing.expect(large <= small * 3);
+}
+
+/// Chained string concats from https://github.com/roc-lang/roc/issues/11127.
+fn strConcatChainGroupLivenessWork(chain_len: usize) Allocator.Error!u64 {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const seed = try f.local(.str);
+    const literals = try testing.allocator.alloc(LIR.LocalId, chain_len);
+    defer testing.allocator.free(literals);
+    const results = try testing.allocator.alloc(LIR.LocalId, chain_len);
+    defer testing.allocator.free(results);
+    for (literals, results) |*literal, *result| {
+        literal.* = try f.local(.str);
+        result.* = try f.local(.str);
+    }
+    var current = try f.ret(results[chain_len - 1]);
+    var index = chain_len;
+    while (index > 0) {
+        index -= 1;
+        const source = if (index == 0) seed else results[index - 1];
+        current = try f.store.addCFStmt(.{ .assign_low_level = .{
+            .target = results[index],
+            .op = .str_concat,
+            .rc_effect = LIR.LowLevel.str_concat.rcEffect(),
+            .args = try f.span(&.{ source, literals[index] }),
+            .next = current,
+        } });
+        current = try f.assignStr(literals[index], "x", current);
+    }
+    const body = try f.assignStr(seed, "seed", current);
+    _ = try f.addProc(&.{}, body, .str);
+    const before = group_liveness_member_visits;
+    try f.run();
+    return group_liveness_member_visits - before;
+}
+
+test "RC borrow-group liveness work grows linearly with chained string concats" {
+    if (builtin.mode != .Debug) return;
+    const small = try strConcatChainGroupLivenessWork(32);
+    const large = try strConcatChainGroupLivenessWork(64);
+    if (large > small * 3) {
+        std.debug.print(
+            "borrow-group liveness work grew nonlinearly: {d} member visits at 32 concats, {d} at 64\n",
+            .{ small, large },
+        );
+    }
     try testing.expect(large <= small * 3);
 }
 
@@ -12786,6 +12999,62 @@ test "RC outcome restitution solves sixteen independent conditional arguments po
     // Each parameter has only present/spent rows at each statement. The old
     // full-mask walk materialized all 2^16 subsets at the final continuation.
     try testing.expect(work <= count * f.store.cfStmtCount() * 2);
+}
+
+fn outcomeScratchWork(proc_count: usize) !u64 {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const outcome_layout = try f.layouts.putTagUnion(&.{ try f.layouts.ensureZstLayout(), f.list_i64 });
+    for (0..proc_count) |_| {
+        const param = try f.local(f.list_i64);
+        const choose = try f.local(.i64);
+        const changed = try f.local(f.list_i64);
+        const result = try f.local(outcome_layout);
+        const ret = try f.ret(result);
+        const success = try f.assignTag(result, 1, changed, ret);
+        const consume = try f.store.addCFStmt(.{ .assign_low_level = .{
+            .target = changed,
+            .op = .list_reverse,
+            .rc_effect = LIR.LowLevel.list_reverse.rcEffect(),
+            .args = try f.span(&.{param}),
+            .next = success,
+        } });
+        const failure = try f.assignTag(result, 0, null, ret);
+        const body = try f.switchStmt(choose, consume, failure, null);
+        // Explicit disjoint frames, unlike ArcTest's all-locals convenience.
+        _ = try f.store.addProcSpec(.{
+            .name = f.store.freshSyntheticSymbol(),
+            .args = try f.span(&.{ param, choose }),
+            .body = body,
+            .frame_locals = try f.span(&.{ param, choose, changed, result }),
+            .ret_layout = outcome_layout,
+        });
+    }
+    const rc = try testing.allocator.alloc(bool, f.store.localCount());
+    defer testing.allocator.free(rc);
+    for (rc, 0..) |*value, i| value.* = i % 4 != 1;
+    const before = arc_solve.outcome_scratch_entries;
+    var solution = try arc_solve.solve(testing.allocator, &f.store, &f.layouts, rc, &.{}, &.{}, true);
+    defer solution.deinit();
+    for (0..proc_count) |i| {
+        const span = solution.availableOutcomeSpanOf(@enumFromInt(@as(u32, @intCast(i))));
+        try testing.expectEqual(@as(u32, 2), span.len);
+        const failure = solution.outcomes[span.start];
+        const success = solution.outcomes[span.start + 1];
+        try testing.expectEqual(@as(u16, 0), failure.discriminant);
+        try testing.expectEqual(@as(arc_sig.ParamMask, 1), failure.restituted_params);
+        try testing.expectEqual(@as(u16, 1), success.discriminant);
+        try testing.expectEqual(@as(arc_sig.ParamMask, 0), success.restituted_params);
+    }
+    return arc_solve.outcome_scratch_entries - before;
+}
+
+test "RC restitution scratch work scales with disjoint procedure statements" {
+    if (builtin.mode != .Debug) return;
+    const small = try outcomeScratchWork(16);
+    const large = try outcomeScratchWork(32);
+    try testing.expect(small > 0);
+    try testing.expectEqual(small * 2, large);
 }
 
 test "RC outcome restitution follows an exact result through a terminal join" {

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -65,6 +65,9 @@ pub const SolveError = std.mem.Allocator.Error;
 /// polynomial state domain in scaling tests.
 pub var outcome_solver_iterations: u64 = 0;
 
+/// Debug-only number of scratch entries initialized or scanned by restitution.
+pub var outcome_scratch_entries: u64 = 0;
+
 const no_local: u32 = std.math.maxInt(u32);
 
 /// Presence-bit condition guarding a payload local whose storage may not be
@@ -1056,7 +1059,7 @@ pub fn solve(
         solution.pinned.deinit(allocator);
     }
 
-    try computeOutcomeRestitution(allocator, store, layouts, rc_local, consume_dead_boxes, &solution);
+    try computeOutcomeRestitution(allocator, store, layouts, rc_local, consume_dead_boxes, &solution, solver.proc_stmts);
 
     return solution;
 }
@@ -1205,18 +1208,24 @@ fn computeOutcomeRestitution(
     rc_local: []const bool,
     consume_dead_boxes: bool,
     solution: *Solution,
+    statements_by_proc: []const std.ArrayList(LIR.CFStmtId),
 ) SolveError!void {
     var all_outcomes = std.ArrayList(arc_sig.Outcome).empty;
     errdefer all_outcomes.deinit(allocator);
 
-    const escape_discriminants = try allocator.alloc(u32, store.cfStmtCount());
-    defer allocator.free(escape_discriminants);
-    const escape_masks = try allocator.alloc(arc_sig.ParamMask, store.cfStmtCount());
-    defer allocator.free(escape_masks);
-    const bit_escape_discriminants = try allocator.alloc(u32, store.cfStmtCount());
-    defer allocator.free(bit_escape_discriminants);
-    const bit_escape_present = try allocator.alloc(bool, store.cfStmtCount());
-    defer allocator.free(bit_escape_present);
+    // Reuse capacity across procedures, but address and initialize only the
+    // active procedure's explicit statement inventory. The structural lift
+    // has already collected it; restitution performs no reachability walk.
+    var statement_indices = collections.DenseMap(LIR.CFStmtId, u32).init(allocator);
+    defer statement_indices.deinit();
+    var discriminant_buffer = std.ArrayList(u32).empty;
+    defer discriminant_buffer.deinit(allocator);
+    var mask_buffer = std.ArrayList(arc_sig.ParamMask).empty;
+    defer mask_buffer.deinit(allocator);
+    var bit_discriminant_buffer = std.ArrayList(u32).empty;
+    defer bit_discriminant_buffer.deinit(allocator);
+    var bit_present_buffer = std.ArrayList(bool).empty;
+    defer bit_present_buffer.deinit(allocator);
     const ambiguous_discriminant = no_local - 1;
 
     for (0..store.procSpecCount()) |proc_index| {
@@ -1226,12 +1235,10 @@ fn computeOutcomeRestitution(
         const body = proc.body orelse continue;
         if (layouts.getLayout(proc.ret_layout).tag != .tag_union) continue;
 
-        var proc_stmts = std.ArrayList(LIR.CFStmtId).empty;
-        defer proc_stmts.deinit(allocator);
-        try collectProcStatements(allocator, store, body, &proc_stmts);
+        const proc_stmts = statements_by_proc[proc_index].items;
         var returned_local: ?LIR.LocalId = null;
         var return_shape_valid = true;
-        for (proc_stmts.items) |stmt_id| {
+        for (proc_stmts) |stmt_id| {
             const stmt = store.getCFStmt(stmt_id);
             if (stmt != .ret) continue;
             const local = stmt.ret.value;
@@ -1249,8 +1256,6 @@ fn computeOutcomeRestitution(
         const ret_index = @intFromEnum(ret_local);
         if (ret_index >= rc_local.len or !rc_local[ret_index]) continue;
 
-        @memset(escape_discriminants, no_local);
-        @memset(escape_masks, 0);
         var initial: arc_sig.ParamMask = 0;
         const params = store.getLocalSpan(proc.args);
         for (0..GuardedList.borrowLen(params)) |position| {
@@ -1263,9 +1268,23 @@ fn computeOutcomeRestitution(
         }
         if (initial == 0) continue;
 
+        statement_indices.clearRetainingCapacity();
+        for (proc_stmts, 0..) |stmt, index| try statement_indices.putNoClobber(stmt, @intCast(index));
+        try discriminant_buffer.resize(allocator, proc_stmts.len);
+        try mask_buffer.resize(allocator, proc_stmts.len);
+        try bit_discriminant_buffer.resize(allocator, proc_stmts.len);
+        try bit_present_buffer.resize(allocator, proc_stmts.len);
+        const escape_discriminants = discriminant_buffer.items;
+        const escape_masks = mask_buffer.items;
+        const bit_escape_discriminants = bit_discriminant_buffer.items;
+        const bit_escape_present = bit_present_buffer.items;
+        @memset(escape_discriminants, no_local);
+        @memset(escape_masks, 0);
+        if (@import("builtin").mode == .Debug) outcome_scratch_entries += proc_stmts.len + escape_discriminants.len + escape_masks.len;
+
         var joins = collections.DenseMap(LIR.JoinPointId, LIR.CFStmtId).init(allocator);
         defer joins.deinit();
-        for (proc_stmts.items) |stmt_id| {
+        for (proc_stmts) |stmt_id| {
             const stmt = store.getCFStmt(stmt_id);
             if (stmt != .join) continue;
             const join_point = stmt.join;
@@ -1284,6 +1303,7 @@ fn computeOutcomeRestitution(
             const active_param = GuardedList.at(params, param_position);
             @memset(bit_escape_discriminants, no_local);
             @memset(bit_escape_present, false);
+            if (@import("builtin").mode == .Debug) outcome_scratch_entries += bit_escape_discriminants.len + bit_escape_present.len;
             var bit_accum = std.AutoHashMap(u16, OutcomeBitAccum).init(allocator);
             defer bit_accum.deinit();
             var stack = std.ArrayList(OutcomeWalkState).empty;
@@ -1549,7 +1569,8 @@ fn computeOutcomeRestitution(
                             break;
                         }
                         if (target_stmt == .ret and target_stmt.ret.value == ret_local and next_state.discriminant != no_local) {
-                            const stmt_index = @intFromEnum(current);
+                            const stmt_index = statement_indices.get(current) orelse
+                                solveInvariant("ARC outcome escape was outside its lifted procedure inventory");
                             const old = bit_escape_discriminants[stmt_index];
                             if (old == no_local) {
                                 bit_escape_discriminants[stmt_index] = next_state.discriminant;
@@ -1575,7 +1596,8 @@ fn computeOutcomeRestitution(
                         } else {
                             entry.value_ptr.* = .{ .present_on_all_paths = next_state.present };
                         }
-                        const stmt_index = @intFromEnum(current);
+                        const stmt_index = statement_indices.get(current) orelse
+                            solveInvariant("ARC outcome escape was outside its lifted procedure inventory");
                         const old = bit_escape_discriminants[stmt_index];
                         if (old == no_local) {
                             bit_escape_discriminants[stmt_index] = discriminant;
@@ -1620,6 +1642,7 @@ fn computeOutcomeRestitution(
                 if (!valid) break;
             }
 
+            if (@import("builtin").mode == .Debug) outcome_scratch_entries += bit_escape_discriminants.len;
             for (bit_escape_discriminants, 0..) |discriminant, stmt_index| {
                 if (discriminant == no_local) continue;
                 const old = escape_discriminants[stmt_index];
@@ -1657,11 +1680,12 @@ fn computeOutcomeRestitution(
             .start = @intCast(start),
             .len = @intCast(all_outcomes.items.len - start),
         };
+        if (@import("builtin").mode == .Debug) outcome_scratch_entries += escape_discriminants.len;
         for (escape_discriminants, 0..) |discriminant, stmt_index| {
             if (discriminant == no_local or discriminant == ambiguous_discriminant) continue;
             const outcome = accum.get(@intCast(discriminant)) orelse
                 solveInvariant("ARC outcome escape named an unreturned discriminant");
-            solution.restitution_params_by_stmt[stmt_index] = escape_masks[stmt_index] & outcome.remaining_on_all_paths;
+            solution.restitution_params_by_stmt[@intFromEnum(proc_stmts[stmt_index])] = escape_masks[stmt_index] & outcome.remaining_on_all_paths;
         }
     }
 

--- a/src/lir/arc_state.zig
+++ b/src/lir/arc_state.zig
@@ -4,6 +4,9 @@ const std = @import("std");
 
 const Allocator = std.mem.Allocator;
 
+/// Debug-only work counter for exact sparse range queries.
+pub var range_query_node_visits: u64 = 0;
+
 /// A bounded-depth radix tree whose absent entries have one caller-declared
 /// value. Copying a snapshot shares its root; changing one entry allocates
 /// only the nodes on that entry's path. Depth grows only as needed and is
@@ -65,6 +68,41 @@ pub fn Snapshot(comptime T: type, comptime empty: T) type {
             }
             const leaf: *const Leaf = @ptrCast(@alignCast(node));
             return leaf.values[index & radix_mask];
+        }
+
+        /// Whether a half-open index range contains a non-default entry.
+        /// Canonical empty subtrees are null, so fully covered subtrees need
+        /// no descent. Only the two range boundaries can descend at each
+        /// level, independently of the range's width or population.
+        pub fn hasNonEmptyInRange(self: *const Self, start: u32, end: u64) bool {
+            std.debug.assert(start <= end and end <= @as(u64, 1) << 32);
+            if (start == end) return false;
+            return rangeHasValue(self.root, self.depth, 0, start, end);
+        }
+
+        fn rangeHasValue(maybe_node: ?*const anyopaque, depth: u8, base: u64, start: u64, end: u64) bool {
+            if (@import("builtin").mode == .Debug) range_query_node_visits += 1;
+            const node = maybe_node orelse return false;
+            const width = @as(u64, 1) << @as(u6, @intCast(leaf_bits + @as(usize, depth) * radix_bits));
+            if (end <= base or start >= base + width) return false;
+            if (start <= base and base + width <= end) return true;
+            if (depth == 0) {
+                const leaf: *const Leaf = @ptrCast(@alignCast(node));
+                const first: usize = @intCast(@max(start, base) - base);
+                const last: usize = @intCast(@min(end, base + width) - base);
+                for (leaf.values[first..last]) |value| {
+                    if (!std.meta.eql(value, empty)) return true;
+                }
+                return false;
+            }
+            const branch: *const Branch = @ptrCast(@alignCast(node));
+            const child_width = width / radix;
+            const first: usize = @intCast((@max(start, base) - base) / child_width);
+            const last: usize = @intCast((@min(end, base + width) - 1 - base) / child_width + 1);
+            for (first..last) |slot| {
+                if (rangeHasValue(branch.children[slot], depth - 1, base + slot * child_width, start, end)) return true;
+            }
+            return false;
         }
 
         pub fn put(self: *Self, index: u32, value: T) Allocator.Error!void {
@@ -363,4 +401,42 @@ test "persistent sparse snapshots share forks and meet exactly" {
     try std.testing.expectEqual(@as(u32, 9), left.get(70_000));
     try std.testing.expectEqual(@as(u32, 0), left.get(90_000));
     try std.testing.expect(left.eql(&left.clone()));
+}
+
+test "sparse range queries are exact across tree boundaries and shared updates" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const Sparse = Snapshot(u32, 0);
+    var original = Sparse.init(arena.allocator(), 1);
+    const keys = [_]u32{ 0, 7, 8, 63, 64, 511, 512, 99999, std.math.maxInt(u32) };
+    for (keys) |key| try original.putUnique(key, 1);
+    var changed = original.clone();
+    for (keys, 0..) |key, i| {
+        if (i % 2 == 0) try changed.put(key, 0);
+    }
+    const boundaries = [_]u64{ 0, 1, 7, 8, 9, 63, 64, 65, 511, 512, 513, 99999, 100000, std.math.maxInt(u32), @as(u64, 1) << 32 };
+    for (boundaries[0 .. boundaries.len - 1]) |start| {
+        for (boundaries) |end| {
+            if (end < start) continue;
+            var original_expected = false;
+            var changed_expected = false;
+            for (keys, 0..) |key, i| {
+                if (start <= key and key < end) {
+                    original_expected = true;
+                    if (i % 2 != 0) changed_expected = true;
+                }
+            }
+            try std.testing.expectEqual(original_expected, original.hasNonEmptyInRange(@intCast(start), end));
+            try std.testing.expectEqual(changed_expected, changed.hasNonEmptyInRange(@intCast(start), end));
+        }
+    }
+    // A nearly full u32 range containing no entries must not scan its width.
+    const before = range_query_node_visits;
+    try std.testing.expect(!original.hasNonEmptyInRange(100000, std.math.maxInt(u32)));
+    if (@import("builtin").mode == .Debug) {
+        try std.testing.expect(range_query_node_visits - before <= 2 * 8 * 11);
+    }
+    for (keys) |key| try changed.put(key, 0);
+    try std.testing.expect(!changed.hasNonEmptyInRange(0, @as(u64, 1) << 32));
+    try std.testing.expect(original.hasNonEmptyInRange(0, @as(u64, 1) << 32));
 }


### PR DESCRIPTION
ARC’s borrow-group liveness queries scanned every resource local in a procedure, making long string-concat chains quadratic even when each result had its own borrow group. Grouped raw-liveness indices now answer exact queries from the existing sparse snapshots while preserving ownership order and solver-only borrow anchors. Outcome restitution also reuses the solver’s procedure statement inventory and compact scratch buffers, eliminating module-wide clearing and scanning for each procedure and parameter.

On the issue’s 1,000-procedure workload with 16 concats per procedure, median ARC time drops from 1.84 seconds to 177 milliseconds, and full compilation drops from 3.20 seconds to 1.55 seconds with 77% fewer instructions (ReleaseFast compiler, one worker, fixed CPU affinity).

Fixes #11127.
