### PR TITLE
Allow empty record literals for defaulted nominal records

### DIFF
--- a/design.md
+++ b/design.md
@@ -5600,9 +5600,13 @@ Restrictions:
   default-incompatible—the `defaulted(d1) ~ defaulted(d2)` conflict and its
   "Incompatible Defaults" report are no longer constructible from source and
   remain as identity-skew invariants, pinned at the unify level—and every
-  omission site of a defaulted field is a syntactically explicit nominal
-  construction (`Cfg.{...}`), which is what enables canonicalize-side
-  default-cycle analysis for the pure-expression defaults work. Derived
+  omission site of a defaulted field constructs a nominal, either explicitly
+  (`Cfg.{...}`) or through an expected nominal type (`cfg : Cfg; cfg = {}`).
+  Empty and nonempty literals use the same backing-row relation: omission
+  validates every field and the complete extension before retaining the nominal
+  result, and records each default on its source construction. Canonicalization
+  analyzes cycles through explicit constructors; checking also analyzes the
+  omissions determined by expected types. Derived
   codecs reach defaulted fields through the nominal's derived methods
   (`parser_for : _` etc.), which derive against the backing row.
 - `?:` and `??` do not combine: a default makes the field never missing,
@@ -5635,8 +5639,8 @@ Restrictions:
     (lookups resolving to same-module defs, walked into their bodies—
     except lambda bodies, per the function-value rule below) and
     OMISSION edges (a LOCAL nominal construction whose literal omits a
-    declared defaulted field—syntactically explicit post the nominal-only
-    restriction). Value references only point down the import DAG, so a
+    declared defaulted field through an explicit constructor). Value references
+    only point down the import DAG, so a
     name-resolvable cycle can never leave the declaring module; the pass
     is module-local without loss. Each cyclic SCC containing a default
     reports `record_default_reference_cycle` ("Default Value Cycle")
@@ -5683,8 +5687,12 @@ Restrictions:
     `defaultMaterializationIsRecursive` walk descends every expression
     form and additionally follows same-module reference edges,
     DISPATCH-RESOLVED call targets, type-dispatch method bindings, and
-    omitted defaulted fields on SOLVED rows (which also covers
-    foreign-omission edges). It applies the same invoked-ness rules as
+    the exact omitted-default entries emitted by unification (which also
+    covers implicit nominal lifting and foreign-omission edges). A dense
+    construction index and links into the omission table are built once per
+    judgment, so each walk visits only that construction's omissions rather
+    than scanning the module or reconstructing omissions from solved types.
+    It applies the same invoked-ness rules as
     CAN—a lambda or closure reached as a value walks its captures but
     not its body; invoked-ness follows name-resolvable reference chains
     to the def body they name (re-traversed by necessity: a mixed cycle

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -25580,8 +25580,16 @@ fn checkDefaultRestrictions(self: *Self) std.mem.Allocator.Error!void {
     var recursive_defaults: std.ArrayList(PendingDefaultCheck) = .empty;
     defer recursive_defaults.deinit(self.gpa);
 
-    var evidence = DefaultWalkEvidence{};
+    var evidence = DefaultWalkEvidence{
+        .omitted_defaults_by_expr = .init(self.gpa),
+        .next_omitted_default = try self.gpa.alloc(?u32, self.cir.record_omitted_defaults.items.items.len),
+    };
     defer evidence.deinit(self.gpa);
+    for (self.cir.record_omitted_defaults.items.items, 0..) |omitted, index| {
+        const entry = try evidence.omitted_defaults_by_expr.getOrPut(omitted.expr);
+        evidence.next_omitted_default[index] = if (entry.found_existing) entry.value_ptr.* else null;
+        entry.value_ptr.* = @intCast(index);
+    }
 
     // Top-level binder pattern -> def body, for following reference edges
     // through def bodies during the residue walk. A destructuring def
@@ -25892,6 +25900,10 @@ fn rejectDefaultParameterAliasing(
 /// Prebuilt evidence indexes for one `checkDefaultRestrictions` run (built
 /// once, shared by every default's residue walk).
 const DefaultWalkEvidence = struct {
+    /// Construction -> first recorded omission, with links into the CIR table.
+    /// Built once so cycle walks consume exact omission evidence in O(fields).
+    omitted_defaults_by_expr: collections.DenseMap(CIR.Expr.Idx, u32),
+    next_omitted_default: []?u32,
     pattern_to_def_expr: std.AutoHashMapUnmanaged(CIR.Pattern.Idx, CIR.Expr.Idx) = .empty,
     /// Local instantiating node -> scheme-use record indices
     /// (`value_use`/`nested_function_use` slots only).
@@ -25903,6 +25915,8 @@ const DefaultWalkEvidence = struct {
     instantiations_by_var: std.AutoHashMapUnmanaged(Var, std.ArrayListUnmanaged(u32)) = .empty,
 
     fn deinit(evidence: *DefaultWalkEvidence, gpa: std.mem.Allocator) void {
+        evidence.omitted_defaults_by_expr.deinit();
+        gpa.free(evidence.next_omitted_default);
         evidence.pattern_to_def_expr.deinit(gpa);
         var node_lists = evidence.node_to_scheme_uses.valueIterator();
         while (node_lists.next()) |list| list.deinit(gpa);
@@ -25926,7 +25940,7 @@ const DefaultWalkEvidence = struct {
 /// were already dropped by canonicalization's cycle pass), dispatch-resolved
 /// call targets (`dispatch_target_instantiations`, joined through scheme-use
 /// evidence, see `followDispatchSeed`), type-dispatch method bindings, and
-/// every omitted defaulted field on a construction's SOLVED row. Foreign
+/// the recorded omitted defaults owned by each construction. Foreign
 /// defaults were validated in their declaring module, which cannot reference
 /// this one.
 fn defaultMaterializationIsRecursive(
@@ -26190,7 +26204,7 @@ fn defaultMaterializationIsRecursive(
             .e_empty_record => {
                 if (try self.appendOmittedDefaultDependencies(
                     expr_idx,
-                    &.{},
+                    evidence,
                     self_module,
                     target_expr_node,
                     &visited_defaults,
@@ -26202,7 +26216,7 @@ fn defaultMaterializationIsRecursive(
                 if (record.ext == null) {
                     if (try self.appendOmittedDefaultDependencies(
                         expr_idx,
-                        fields,
+                        evidence,
                         self_module,
                         target_expr_node,
                         &visited_defaults,
@@ -26449,95 +26463,28 @@ fn appendDefaultWalkStmtExprs(
     }
 }
 
-fn recordLiteralSuppliesField(
-    self: *const Self,
-    fields: []const CIR.RecordField.Idx,
-    field_name: Ident.Idx,
-) bool {
-    for (fields) |field_idx| {
-        if (self.cir.store.getRecordField(field_idx).name == field_name) return true;
-    }
-    return false;
-}
-
-/// Append the local default expressions that `record_expr` materializes by
-/// omission. Returns true immediately when one is the target default.
+/// Append the local defaults recorded for this construction by unification.
+/// Solved types alone cannot identify omissions: an implicitly lifted record's
+/// root is nominal, and the nominal declaration does not say what this site
+/// supplied. Returns true immediately when one omission is the target default.
 fn appendOmittedDefaultDependencies(
     self: *Self,
     record_expr: CIR.Expr.Idx,
-    supplied_fields: []const CIR.RecordField.Idx,
+    evidence: *const DefaultWalkEvidence,
     self_module: base.ModuleIdentity.Idx,
     target_expr_node: u32,
     visited_defaults: *std.AutoHashMapUnmanaged(u32, void),
     expr_work: *std.ArrayList(CIR.Expr.Idx),
 ) std.mem.Allocator.Error!bool {
-    var current = ModuleEnv.varFrom(record_expr);
-    var visited_rows: std.AutoHashMapUnmanaged(Var, void) = .empty;
-    defer visited_rows.deinit(self.gpa);
-
-    while (true) {
-        const resolved = self.types.resolveVar(current);
-        const seen = try visited_rows.getOrPut(self.gpa, resolved.var_);
-        if (seen.found_existing) return false;
-
-        switch (resolved.desc.content) {
-            .alias => |alias| current = self.types.getAliasBackingVar(alias),
-            .structure => |flat| switch (flat) {
-                .record => |record| {
-                    if (try self.appendDefaultsFromRecordFields(
-                        record.fields,
-                        supplied_fields,
-                        self_module,
-                        target_expr_node,
-                        visited_defaults,
-                        expr_work,
-                    )) return true;
-                    current = record.ext;
-                },
-                .record_unbound => |fields| return try self.appendDefaultsFromRecordFields(
-                    fields,
-                    supplied_fields,
-                    self_module,
-                    target_expr_node,
-                    visited_defaults,
-                    expr_work,
-                ),
-                .empty_record => return false,
-                .tuple,
-                .nominal_type,
-                .fn_pure,
-                .fn_effectful,
-                .fn_unbound,
-                .tag_union,
-                .empty_tag_union,
-                => return false,
-            },
-            .flex, .rigid, .field_presence, .err => return false,
-        }
-    }
-}
-
-fn appendDefaultsFromRecordFields(
-    self: *Self,
-    fields_range: types_mod.RecordField.SafeMultiList.Range,
-    supplied_fields: []const CIR.RecordField.Idx,
-    self_module: base.ModuleIdentity.Idx,
-    target_expr_node: u32,
-    visited_defaults: *std.AutoHashMapUnmanaged(u32, void),
-    expr_work: *std.ArrayList(CIR.Expr.Idx),
-) std.mem.Allocator.Error!bool {
-    const fields = self.types.getRecordFieldsSlice(fields_range);
-    for (fields.items(.name), fields.items(.presence)) |field_name, presence| {
-        if (self.recordLiteralSuppliesField(supplied_fields, field_name)) continue;
-        const presence_var = presence.presenceVar() orelse continue;
-        const presence_content = self.types.resolveVar(presence_var).desc.content;
-        if (presence_content != .field_presence or presence_content.field_presence != .defaulted) continue;
-        const default_id = presence_content.field_presence.defaulted;
-        if (default_id.origin_module != self_module) continue;
-        if (default_id.expr_node == target_expr_node) return true;
-        const seen = try visited_defaults.getOrPut(self.gpa, default_id.expr_node);
+    var next = evidence.omitted_defaults_by_expr.get(record_expr);
+    while (next) |index| {
+        const omitted = self.cir.record_omitted_defaults.items.items[index];
+        next = evidence.next_omitted_default[index];
+        if (omitted.origin_module != self_module) continue;
+        if (omitted.default_expr_node == target_expr_node) return true;
+        const seen = try visited_defaults.getOrPut(self.gpa, omitted.default_expr_node);
         if (!seen.found_existing) {
-            try expr_work.append(self.gpa, @enumFromInt(default_id.expr_node));
+            try expr_work.append(self.gpa, @enumFromInt(omitted.default_expr_node));
         }
     }
     return false;

--- a/src/check/test/repros_test.zig
+++ b/src/check/test/repros_test.zig
@@ -916,6 +916,146 @@ test "check - associated underscore annotation with a body is inferred normally"
     try test_env.assertNoErrors();
 }
 
+test "check - repro - issue 11024 - empty record literal satisfies an all-defaulted nominal annotation" {
+    // Repro for https://github.com/roc-lang/roc/issues/11024: every field of
+    // `Foo` has a default, so the annotation-driven `{}` literal supplies a
+    // complete record and should check as `Foo`.
+    const src =
+        \\main! = |_args| {}
+        \\
+        \\Foo := { bar : U64 ?? 0, baz : U64 ?? 0 }
+        \\
+        \\y : Foo
+        \\y = {}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertDefType("y", "Foo");
+}
+
+test "check - issue 11024 - nested empty literals own their omitted defaults" {
+    const src =
+        \\Foo := { bar : U64 ?? 3, baz : U64 ?? 7 }
+        \\xs : List(Foo)
+        \\xs = [{}, {}]
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertDefType("xs", "List(Foo)");
+
+    const omissions = env.module_env.record_omitted_defaults.items.items;
+    try std.testing.expectEqual(4, omissions.len);
+    for (omissions) |omission| {
+        try std.testing.expect(env.module_env.store.getExpr(omission.expr) == .e_empty_record);
+        var owned_count: usize = 0;
+        for (omissions) |other| {
+            if (other.expr == omission.expr) owned_count += 1;
+        }
+        try std.testing.expectEqual(2, owned_count);
+    }
+}
+
+test "check - issue 11024 - empty nominal construction rejects required fields" {
+    const src =
+        \\Foo := { bar : U64 ?? 0, baz : U64 }
+        \\y : Foo
+        \\y = {}
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertOneTypeError("Type Mismatch");
+}
+
+test "check - issue 11024 - committed empty argument cannot acquire defaults" {
+    const src =
+        \\Foo := { bar : U64 ?? 0 }
+        \\read : Foo -> U64
+        \\read = |foo| foo.bar
+        \\use : {} -> U64
+        \\use = |empty| read(empty)
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertOneTypeError("Type Mismatch");
+}
+
+test "check - issue 11024 - existing empty value is not a defaulted nominal backing" {
+    const src =
+        \\Foo := { bar : U64 ?? 0 }
+        \\make : {} -> Foo
+        \\make = |empty| Foo.(empty)
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertOneTypeError("Invalid Nominal Type");
+}
+
+test "check - issue 11024 - inferred empty construction rejects a recursive default" {
+    const src =
+        \\Foo := { bar : U64 ?? make({}).bar }
+        \\make : {} -> Foo
+        \\make = |_| {}
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertOneTypeError("Recursive Default Value");
+}
+
+test "check - issue 11024 - supplied implicit field breaks the default dependency cycle" {
+    const src =
+        \\Foo := { bar : U64 ?? make({}).bar }
+        \\make : {} -> Foo
+        \\make = |_| { bar: 5 }
+        \\y : Foo
+        \\y = {}
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertDefType("y", "Foo");
+}
+
+test "check - issue 11024 - imported transparent defaults lift" {
+    var cfg = try TestEnv.init("Cfg",
+        \\Cfg := { bar : U64 ?? 7 }
+    );
+    defer cfg.deinit();
+    try cfg.assertNoErrors();
+
+    var good = try TestEnv.initWithImport("Good",
+        \\import Cfg
+        \\y : Cfg.Cfg
+        \\y = {}
+    , "Cfg", &cfg);
+    defer good.deinit();
+    try good.assertDefType("y", "Cfg");
+}
+
+test "check - issue 11024 - imported opaque empty records reject lifting in both orders" {
+    var secret = try TestEnv.init("Secret", "Secret :: {}\n");
+    defer secret.deinit();
+    try secret.assertNoErrors();
+
+    var bad = try TestEnv.initWithImport("Bad",
+        \\import Secret
+        \\y : Secret.Secret
+        \\y = {}
+    , "Secret", &secret);
+    defer bad.deinit();
+    try bad.assertCanErrors(&.{});
+    try bad.assertOneTypeError("Type Mismatch");
+
+    var inverse = try TestEnv.initWithImport("Inverse",
+        \\import Secret
+        \\empty : Secret.Secret -> {}
+        \\empty = |value| value
+    , "Secret", &secret);
+    defer inverse.deinit();
+    try inverse.assertCanErrors(&.{});
+    try inverse.assertOneTypeError("Type Mismatch");
+}
+
 test "check - repro - issue 10490 - standard library errors compose through open unions" {
     // Repro for https://github.com/roc-lang/roc/issues/10490: standard library
     // errors should compose through `?` without callers mapping their tags.

--- a/src/check/test/repros_test.zig
+++ b/src/check/test/repros_test.zig
@@ -957,6 +957,20 @@ test "check - issue 11024 - nested empty literals own their omitted defaults" {
     }
 }
 
+test "check - issue 11024 - implicit defaulted nominal constructions instantiate type parameters independently" {
+    const src =
+        \\Cfg(a) := { values : List(a) ?? [] }
+        \\numbers : Cfg(U8)
+        \\numbers = {}
+        \\strings : Cfg(Str)
+        \\strings = {}
+    ;
+    var env = try TestEnv.init("Test", src);
+    defer env.deinit();
+    try env.assertDefType("numbers", "Cfg(U8)");
+    try env.assertDefType("strings", "Cfg(Str)");
+}
+
 test "check - issue 11024 - empty nominal construction rejects required fields" {
     const src =
         \\Foo := { bar : U64 ?? 0, baz : U64 }

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -970,6 +970,91 @@ test "unify - anonymous tag union with multiple tags unifies" {
     try std.testing.expect(resolved.desc.content.structure == .nominal_type);
 }
 
+test "unify - issue 11024 - empty nominal row absorption respects field kinds and width in both orders" {
+    const Kind = enum { optional, defaulted, required, unresolved };
+    for ([_]Kind{ .optional, .defaulted, .required, .unresolved }) |kind| {
+        for ([_]bool{ false, true }) |exact| {
+            for (0..2) |order| {
+                var env = try TestEnv.init(std.testing.allocator);
+                defer env.deinit();
+                const store = &env.module_env.types;
+                const value = try store.freshFromContent(.{ .structure = .empty_record });
+                const default_id = types_mod.DefaultId{
+                    .origin_module = env.module_env.selfModuleIdentity(),
+                    .expr_node = 123,
+                };
+                const presence = try store.freshFromContent(switch (kind) {
+                    .optional => .{ .field_presence = .optional },
+                    .defaulted => .{ .field_presence = .{ .defaulted = default_id } },
+                    .required => .{ .field_presence = .required },
+                    .unresolved => .{ .flex = Flex.init() },
+                });
+                const backing = try store.freshFromContent((try env.mkRecordClosed(&.{
+                    try env.mkUnknownRecordField("field", presence, value),
+                })).content);
+                const nominal = try store.freshFromContent(try env.mkNominalType("Cfg", backing, &.{}));
+                const empty = try store.freshFromContent(.{ .structure = .empty_record });
+                const a = if (order == 0) nominal else empty;
+                const b = if (order == 0) empty else nominal;
+                const result = if (exact) try env.unifyExact(a, b) else try env.unifyWriteNoReport(a, b);
+                const accepts = !exact and (kind == .optional or kind == .defaulted);
+                try std.testing.expectEqual(@as(Result, if (accepts) .unified else .mismatch), result);
+                if (accepts) {
+                    try std.testing.expect(store.resolveVar(empty).desc.content.structure == .nominal_type);
+                    try std.testing.expect(store.resolveVar(backing).desc.content.structure == .record);
+                }
+                const omissions = env.scratch.absorbed_record_defaults.items.items;
+                try std.testing.expectEqual(@as(usize, if (accepts and kind == .defaulted) 1 else 0), omissions.len);
+                if (omissions.len != 0) {
+                    try std.testing.expectEqual(empty, omissions[0].record_var);
+                    try std.testing.expectEqual(default_id, omissions[0].default);
+                }
+            }
+        }
+    }
+}
+
+test "unify - issue 11024 - zero-field nominal head still checks its required extension" {
+    for (0..2) |order| {
+        var env = try TestEnv.init(std.testing.allocator);
+        defer env.deinit();
+        const store = &env.module_env.types;
+        const value = try store.freshFromContent(.{ .structure = .empty_record });
+        const tail = try store.freshFromContent((try env.mkRecordClosed(&.{
+            try env.mkRecordField("required_tail", value),
+        })).content);
+        const backing = try store.freshFromContent((try env.mkRecord(&.{}, tail)).content);
+        const nominal = try store.freshFromContent(try env.mkNominalType("Cfg", backing, &.{}));
+        const empty = try store.freshFromContent(.{ .structure = .empty_record });
+        const result = if (order == 0)
+            try env.unifyWriteNoReport(nominal, empty)
+        else
+            try env.unifyWriteNoReport(empty, nominal);
+        try std.testing.expectEqual(Result.mismatch, result);
+        try std.testing.expectEqual(Content{ .structure = .empty_record }, store.resolveVar(empty).desc.content);
+    }
+}
+
+test "unify - issue 11024 - zero-field nominal backing stays structural across constructions" {
+    for (0..2) |order| {
+        var env = try TestEnv.init(std.testing.allocator);
+        defer env.deinit();
+        const store = &env.module_env.types;
+        const backing = try store.freshFromContent((try env.mkRecordClosed(&.{})).content);
+        const nominal = try store.freshFromContent(try env.mkNominalType("Cfg", backing, &.{}));
+        for (0..2) |_| {
+            const empty = try store.freshFromContent(.{ .structure = .empty_record });
+            const result = if (order == 0)
+                try env.unifyExact(nominal, empty)
+            else
+                try env.unifyExact(empty, nominal);
+            try std.testing.expectEqual(Result.unified, result);
+            const record = store.resolveVar(backing).desc.content.structure.record;
+            try std.testing.expectEqual(Content{ .structure = .empty_record }, store.resolveVar(record.ext).desc.content);
+        }
+    }
+}
+
 // unification - empty nominal types //
 
 test "unify - empty nominal type with empty tag union (nominal on left)" {

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -1306,7 +1306,7 @@ const Unifier = struct {
                             try self.merge(vars, .err);
                             return;
                         }
-                        try self.unifyEmptyWithNominal(vars, b_type, .empty_record, .b_is_nominal, .skip_opacity);
+                        try self.unifyEmptyWithNominal(vars, b_type, .empty_record, .b_is_nominal, .enforce_opacity);
                     },
                     .tuple,
                     .fn_pure,
@@ -1578,7 +1578,7 @@ const Unifier = struct {
         direction: NominalDirection,
         comptime opacity: OpacityGate,
     ) Error!void {
-        if (empty_shape == .empty_record or opacity == .enforce_opacity) {
+        if (opacity == .enforce_opacity) {
             // If this nominal is opaque and we're not in the origin module, error
             if (!nominal_type.canLiftInner(self.self_module_identity)) {
                 return error.TypeMismatch;

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -1207,7 +1207,7 @@ const Unifier = struct {
             .record => |a_record| {
                 switch (b_flat_type) {
                     .empty_record => {
-                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_b.?, a_record.fields, a_record.ext);
+                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_b.?, a_record.fields, a_record.ext, null);
                     },
                     .record => |b_record| {
                         try self.unifyTwoRecords(
@@ -1247,7 +1247,7 @@ const Unifier = struct {
             .record_unbound => |a_fields| {
                 switch (b_flat_type) {
                     .empty_record => {
-                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_b.?, a_fields, null);
+                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_b.?, a_fields, null, null);
                     },
                     .record => |b_record| {
                         try self.unifyTwoRecords(
@@ -1295,10 +1295,10 @@ const Unifier = struct {
                     },
 
                     .record => |b_record| {
-                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_a.?, b_record.fields, b_record.ext);
+                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_a.?, b_record.fields, b_record.ext, null);
                     },
                     .record_unbound => |b_fields| {
-                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_a.?, b_fields, null);
+                        try self.unifyRowWithEmptyRecord(vars, self.unresolved_a.?, b_fields, null, null);
                     },
                     .nominal_type => |b_type| {
                         // Try to unify empty record (a) with nominal record (b)
@@ -1563,12 +1563,13 @@ const Unifier = struct {
         return .{ .opened = opened };
     }
 
-    /// Which shape an empty anonymous side must find in the nominal's backing.
+    /// The shape of the empty anonymous operand.
     const EmptyShape = enum { empty_record, empty_tag_union };
     const OpacityGate = enum { enforce_opacity, skip_opacity };
 
-    /// Unify an empty anonymous record/tag union with a nominal whose backing
-    /// is (an equivalent of) the same empty shape; the nominal wins.
+    /// Empty records use ordinary backing-row unification, including default
+    /// and optional field omission. Empty tag unions require an empty backing.
+    /// In either case the nominal wins only after the backing relation succeeds.
     fn unifyEmptyWithNominal(
         self: *Self,
         vars: *const ResolvedVarDescs,
@@ -1577,7 +1578,7 @@ const Unifier = struct {
         direction: NominalDirection,
         comptime opacity: OpacityGate,
     ) Error!void {
-        if (opacity == .enforce_opacity) {
+        if (empty_shape == .empty_record or opacity == .enforce_opacity) {
             // If this nominal is opaque and we're not in the origin module, error
             if (!nominal_type.canLiftInner(self.self_module_identity)) {
                 return error.TypeMismatch;
@@ -1594,24 +1595,39 @@ const Unifier = struct {
             return;
         }
 
-        const backing_is_empty = blk: {
-            if (backing_content != .structure) break :blk false;
-            const backing_flat = backing_content.structure;
-            switch (empty_shape) {
-                .empty_record => {
-                    if (backing_flat == .empty_record) break :blk true;
-                    if (backing_flat == .record) {
-                        const fields = self.types_store.getRecordFieldsSlice(backing_flat.record.fields);
-                        if (fields.len == 0) break :blk true;
-                    }
-                    break :blk false;
-                },
-                .empty_tag_union => {
-                    break :blk backing_flat == .empty_tag_union;
-                },
+        if (backing_content != .structure) return error.TypeMismatch;
+        if (empty_shape == .empty_record) {
+            switch (backing_content.structure) {
+                .record, .empty_record => {},
+                .record_unbound,
+                .nominal_type,
+                .tuple,
+                .fn_pure,
+                .fn_effectful,
+                .fn_unbound,
+                .tag_union,
+                .empty_tag_union,
+                => return error.TypeMismatch,
             }
-        };
-        if (backing_is_empty) {
+
+            try self.retainOuterRecordMismatch(vars, opened, direction);
+            if (backing_content.structure == .empty_record) {
+                try self.mergeToNominal(vars, direction);
+            } else {
+                const record = backing_content.structure.record;
+                const source = switch (direction) {
+                    .a_is_nominal => self.unresolved_b.?,
+                    .b_is_nominal => self.unresolved_a.?,
+                };
+                // Relate the source construction directly to the backing row.
+                // Never merge the opened backing root with the nominal result:
+                // later constructions may reuse that structural opening.
+                try self.unifyRowWithEmptyRecord(vars, source, record.fields, record.ext, direction);
+            }
+            return;
+        }
+
+        if (backing_content.structure == .empty_tag_union) {
             // Both are empty—merge to the NOMINAL side.
             try self.mergeToNominal(vars, direction);
         } else {
@@ -2321,15 +2337,27 @@ const Unifier = struct {
     }
 
     /// Absorb an optional/defaulted row only for a fresh construction relation.
+    /// A nominal result retains its wrapper without merging it into the opened
+    /// backing or its extension; those structures may serve other constructions.
     fn unifyRowWithEmptyRecord(
         self: *Self,
         vars: *const ResolvedVarDescs,
         record_var: Var,
         fields: RecordFieldSafeMultiList.Range,
         mb_ext: ?Var,
+        nominal_direction: ?NominalDirection,
     ) Error!void {
         if (fields.len() == 0) {
-            if (mb_ext) |ext| {
+            if (nominal_direction) |direction| {
+                _ = try self.scratch.unify_work_stack.append(self.scratch.gpa, .{ .merge_to_nominal = .{
+                    .vars = vars.*,
+                    .direction = direction,
+                } });
+                if (mb_ext) |ext| {
+                    const empty_var = try self.fresh(vars, .{ .structure = .empty_record });
+                    try self.unifyGuarded(ext, empty_var);
+                }
+            } else if (mb_ext) |ext| {
                 try self.unifyGuarded(ext, record_var);
             } else {
                 try self.merge(vars, .{ .structure = .empty_record });
@@ -2342,13 +2370,20 @@ const Unifier = struct {
         try self.recordAbsorbedRecordDefaults(record_var, fields, mb_ext);
 
         const empty_var = try self.fresh(vars, .{ .structure = .empty_record });
+        if (nominal_direction) |direction| {
+            _ = try self.scratch.unify_work_stack.append(self.scratch.gpa, .{ .merge_to_nominal = .{
+                .vars = vars.*,
+                .direction = direction,
+            } });
+        } else {
+            try self.merge(vars, Content{ .structure = .{ .record = .{
+                .fields = fields,
+                .ext = mb_ext orelse empty_var,
+            } } });
+        }
         if (mb_ext) |ext| {
             try self.unifyGuarded(ext, empty_var);
         }
-        try self.merge(vars, Content{ .structure = .{ .record = .{
-            .fields = fields,
-            .ext = mb_ext orelse empty_var,
-        } } });
     }
 
     /// Unify two extensible records.

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -21,6 +21,59 @@ const simd_tests = @import("eval_simd_tests.zig");
 /// Every value-producing test is observed solely through `Str.inspect(...)`.
 const core_tests = [_]TestCase{
     .{
+        .name = "issue 11024: implicit empty nominal records materialize defaults at every site",
+        .source_kind = .module,
+        .source =
+        \\Foo := { bar : U64 ?? 3, baz : U64 ?? 7 }
+        \\top : Foo
+        \\top = {}
+        \\make : U64 -> Foo
+        \\make = |n| if n == 0 {} else { bar: n }
+        \\main = {
+        \\    local : Foo
+        \\    local = {}
+        \\    xs : List(Foo)
+        \\    xs = [{}, {}]
+        \\    total = List.fold(xs, 0, |sum, foo| sum + foo.bar + foo.baz)
+        \\    top.bar + top.baz + local.bar + local.baz + make(0).bar + make(5).bar + total
+        \\}
+        ,
+        .expected = .{ .inspect_str = "48" },
+    },
+    .{
+        .name = "issue 11024: implicit empty record mixes missing optional and heap defaults",
+        .source_kind = .module,
+        .source =
+        \\Foo := { text : Str ?? "a heap-allocated default string longer than the inline capacity", count ?: U64 }
+        \\make : {} -> Foo
+        \\make = |_| {}
+        \\main = {
+        \\    first = make({})
+        \\    second = make({})
+        \\    if (first.text == second.text) and ((first.?count ?? 9) == 9) first.text else "wrong"
+        \\}
+        ,
+        .expected = .{ .inspect_str = "\"a heap-allocated default string longer than the inline capacity\"" },
+    },
+    .{
+        .name = "issue 11024: imported implicit empty records materialize callable defaults",
+        .source_kind = .module,
+        .imports = &.{.{ .name = "Cfg", .source = "Cfg := { f : U8 -> U8 ?? |n| n + 5 }\n" }},
+        .source =
+        \\import Cfg
+        \\cfg : Cfg.Cfg
+        \\cfg = {}
+        \\make : {} -> Cfg.Cfg
+        \\make = |_| {}
+        \\main = {
+        \\    first = cfg.f
+        \\    second = make({}).f
+        \\    first(1) + second(2)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "13" },
+    },
+    .{
         .name = "defaulted record field: omitted at construction materializes the default",
         .source_kind = .module,
         .source =

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -3517,6 +3517,42 @@ test "boxy lowering preserves a runtime-built crash message" {
     return error.TestUnexpectedResult;
 }
 
+test "issue 11024 boxy materializes imported defaults for repeated empty constructions" {
+    const allocator = std.testing.allocator;
+    const cfg_module =
+        \\Cfg := { f : U8 -> U8 ?? |n| n + 5, amount : U8 ?? 7, extra ?: U8 }
+    ;
+    const source =
+        \\import Cfg
+        \\make : {} -> Cfg.Cfg
+        \\make = |_| {}
+        \\main = {
+        \\    first = make({})
+        \\    second = make({})
+        \\    f = first.f
+        \\    g = second.f
+        \\    f(1) + g(2) + first.amount + second.amount + (first.?extra ?? 9)
+        \\}
+    ;
+    var compiled = try helpers.compileInspectedProgramForTargetWithBuiltin(
+        allocator,
+        std.testing.io,
+        .module,
+        source,
+        &.{.{ .name = "Cfg", .source = cfg_module }},
+        .native,
+        try sharedPrePublishedBuiltin(),
+        null,
+        .boxy,
+    );
+    defer compiled.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), compiled.resources.checker.problems.problems.items.len);
+    const output = try helpers.lirInterpreterInspectedStr(allocator, &compiled.lowered);
+    defer allocator.free(output);
+    try std.testing.expectEqualStrings("36", output);
+}
+
 test "issue 11099 boxy dispatches an imported procedure stored in a record" {
     const allocator = std.testing.allocator;
     const tp_module =


### PR DESCRIPTION
Allow an empty record literal to satisfy a nominal annotation when every omitted field is defaulted or optional. Empty literals now use the ordinary row checks while preserving the reusable structural backing, construction ownership, exact-width restrictions, and opacity.

Default-cycle checking consumes indexed omission evidence from unification so cycles introduced through implicit nominal construction are rejected, without reconstructing omissions from solved types.

Fixes #11024.
