### PR TITLE
Fix quadratic specialization of nested lambdas

### DIFF
--- a/design.md
+++ b/design.md
@@ -4007,10 +4007,14 @@ representation decision.
 
 Recursive specialization contributes an explicit second proof of the dynamic
 tier. Each in-progress specialization snapshots every permanent member of each
-ordered argument's union class. When a recursive edge reaches that
-specialization, a request argument introduced after the snapshot is recorded as
-a representation-growing recursive slot before the two function interfaces are
-related. If that slot subsequently joins distinct minted iterator identities,
+ordered argument's union class. The snapshot retains the first and last
+permanent node of the class-member list at entry. Unions only concatenate
+lists, so links inside the saved segment never change: stopping at its saved
+last node preserves exact historical membership without copying the class or
+adding history maintenance to union operations. When a recursive edge reaches
+that specialization, a request argument introduced after the snapshot is
+recorded as a representation-growing recursive slot before the two function
+interfaces are related. If that slot subsequently joins distinct minted iterator identities,
 the graph records that the resulting iterator class must use the forced-dynamic
 fixed point. Recursion through any alias already present in the initial class is
 not representation growth and remains eligible for the minted tier. This makes
@@ -7694,6 +7698,24 @@ specialize predictably across module boundaries: checked bodies remain
 immutable, every monomorphic specialization records its own closed
 instantiation, and interface solving never depends on lowering a body into its
 caller.
+
+Draft nested lookup first checks exact callable-family membership. An absent
+family proves a miss without enumerating interface aliases, regardless of the
+size of the enclosing graph. Existing families retain exact interface, evidence,
+capture, and recursive-reference checks; no mutable union-root key is treated
+as an immutable specialization identity.
+
+Draft commit indexes sealed specialization records by their explicit draft
+function ids, and indexes prior retained identities by the same digest bucket
+as the durable specialization store. Exact type, codec-contract, and evidence
+equality remain collision authorities. Suppressed lexical children never enter
+that index, and equal retained identities keep the first assigned function
+slot. Commit work does not scan earlier functions or specialization tables for
+each new lambda.
+
+Structural backing walks reuse graph-owned sparse scratch. Each walk visits
+only its backing chain and returns the first repeated node on a cycle; graph
+size does not determine scratch initialization work.
 
 The specialization store must make this lookup direct. It must not scan all
 specializations for a callable family and recompute recursive type digests while

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -16013,7 +16013,7 @@ fn monotypeSpecializationCounters(diagnostics: postcheck.Monotype.Lower.Diagnost
     };
 }
 
-fn monotypeGraphCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [23]progress.Counter {
+fn monotypeGraphCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [25]progress.Counter {
     const graph = diagnostics.graph;
     return .{
         .{ .name = "Graphs created", .count = diagnostics.body.graphs_created },
@@ -16039,10 +16039,12 @@ fn monotypeGraphCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [23]
         .{ .name = "Nominal backing instances scanned", .count = graph.nominal_backing_instances_scanned },
         .{ .name = "Nominal backing tombstone deletions", .count = graph.nominal_backing_tombstone_deletions },
         .{ .name = "Union-find resolutions", .count = graph.union_find_resolutions },
+        .{ .name = "Argument class snapshot nodes", .count = graph.argument_class_members_snapshotted },
+        .{ .name = "Structural backing visited slots", .count = graph.structural_backing_scan_slots },
     };
 }
 
-fn monotypeBodyCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [20]progress.Counter {
+fn monotypeBodyCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [22]progress.Counter {
     const body = diagnostics.body;
     return .{
         .{ .name = "Body contexts created", .count = body.body_contexts_created },
@@ -16065,6 +16067,8 @@ fn monotypeBodyCounters(diagnostics: postcheck.Monotype.Lower.Diagnostics) [20]p
         .{ .name = "Nested callable checks", .count = body.nested_callable_checks },
         .{ .name = "Nested lambdas prepared", .count = body.nested_lambdas_prepared },
         .{ .name = "Nested closures prepared", .count = body.nested_closures_prepared },
+        .{ .name = "Nested lookup probes", .count = body.nested_lookup_probes },
+        .{ .name = "Draft commit lookup steps", .count = body.draft_commit_lookup_steps },
     };
 }
 

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2693,6 +2693,95 @@ test "issue 10978 repeated recursive nominal constructions scan bounded backing 
     try std.testing.expect(find_growth_linear);
 }
 
+/// The event-handler view from issue 11144, with one nested lambda per item.
+fn issue11144EventHandlerViewSource(allocator: Allocator, item_count: usize) Allocator.Error![]u8 {
+    var source = std.ArrayList(u8).empty;
+    errdefer source.deinit(allocator);
+    try source.appendSlice(allocator,
+        \\Attribute(msg) := [Attr(Str, Str), On(Str, ({} -> msg))]
+        \\Html(msg) := [Text(Str), Element(Str, List(Attribute(msg)), List(Html(msg)))]
+        \\div : List(Attribute(msg)), List(Html(msg)) -> Html(msg)
+        \\div = |attrs, children| Element("div", attrs, children)
+        \\class : Str -> Attribute(msg)
+        \\class = |name| Attr("class", name)
+        \\text : Str -> Html(msg)
+        \\text = |s| Text(s)
+        \\render : Html(msg) -> Str
+        \\render = |html|
+        \\    match html {
+        \\        Text(s) => s
+        \\        Element(tag, _attrs, children) => "<${tag}>${Str.join_with(children.map(render), "")}</${tag}>"
+        \\    }
+        \\view : Str -> Html([Clicked(U64)])
+        \\view = |s| div([class("page")], [
+        \\
+    );
+    for (0..item_count) |index| {
+        const item = try std.fmt.allocPrint(
+            allocator,
+            "    div([class(\"item\"), On(\"click\", |{{}}| Clicked({d}))], [text(s), text(\"{d}\")]),\n",
+            .{ index + 1, index + 1 },
+        );
+        defer allocator.free(item);
+        try source.appendSlice(allocator, item);
+    }
+    try source.appendSlice(allocator,
+        \\])
+        \\main : Str
+        \\main = render(view("hi"))
+        \\
+    );
+    return try source.toOwnedSlice(allocator);
+}
+
+test "issue 11144 nested lambdas in one large body specialize in linear work" {
+    const allocator = std.testing.allocator;
+    {
+        const source = try issue11144EventHandlerViewSource(allocator, 2);
+        defer allocator.free(source);
+        var resources = try helpers.parseAndCheckProgramForProblemsWithBuiltin(
+            allocator,
+            .module,
+            source,
+            &.{},
+            try sharedPrePublishedBuiltin(),
+        );
+        defer resources.deinit(allocator);
+        const diagnostics = try resources.main.module_env.getDiagnostics();
+        defer allocator.free(diagnostics);
+        try std.testing.expectEqual(@as(usize, 0), resources.main.parse_ast.tokenize_diagnostics.items.len);
+        try std.testing.expectEqual(@as(usize, 0), resources.main.parse_ast.parse_diagnostics.items.len);
+        try std.testing.expectEqual(@as(usize, 0), diagnostics.len);
+        try std.testing.expectEqual(@as(usize, 0), resources.main.checker.problems.problems.items.len);
+    }
+    const Counts = struct { snapshots: u64, backing_slots: u64, lookup_probes: u64, commit_steps: u64 };
+    var counts: [3]Counts = undefined;
+    for ([_]usize{ 16, 32, 64 }, &counts) |n, *out| {
+        const source = try issue11144EventHandlerViewSource(allocator, n);
+        defer allocator.free(source);
+        var diagnostics = MonoLower.Diagnostics{};
+        var lowered = try lowerMonotypeModuleWithOptions(allocator, source, .{ .diagnostics = &diagnostics });
+        defer lowered.deinit(allocator);
+        out.* = .{
+            .snapshots = diagnostics.graph.argument_class_members_snapshotted,
+            .backing_slots = diagnostics.graph.structural_backing_scan_slots,
+            .lookup_probes = diagnostics.body.nested_lookup_probes,
+            .commit_steps = diagnostics.body.draft_commit_lookup_steps,
+        };
+    }
+    // Compare deltas to remove fixed module work. A linear delta doubles;
+    // quadratic work approaches four times the preceding delta.
+    inline for (std.meta.fields(Counts)) |field| {
+        const small = @field(counts[0], field.name);
+        const medium = @field(counts[1], field.name);
+        const large = @field(counts[2], field.name);
+        const linear = small <= medium and medium <= large and
+            large - medium <= ((medium - small) *| 5) / 2;
+        if (!linear) std.debug.print("issue 11144 {s} grew nonlinearly: {d}->{d}->{d}\n", .{ field.name, small, medium, large });
+        try std.testing.expect(linear);
+    }
+}
+
 test "closed direct method calls reuse specialization before durable key construction" {
     const allocator = std.testing.allocator;
     const one_call =

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -582,6 +582,10 @@ pub const SpecializationCounters = specialize.Counters;
 
 /// Deterministic counts for body-context, type-instantiation, and call work.
 pub const BodyDiagnostics = struct {
+    /// Nested specialization candidate-index probes and candidates examined.
+    nested_lookup_probes: u64 = 0,
+    /// Entries examined while mapping draft functions to committed identities.
+    draft_commit_lookup_steps: u64 = 0,
     graphs_created: u64 = 0,
     body_contexts_created: u64 = 0,
     instantiation_scopes_created: u64 = 0,
@@ -7944,6 +7948,8 @@ const Builder = struct {
         else
             source_ctx.activeCodecContractContext();
         const family = DraftNestedFamilyAddress.init(nested, source_ctx.method_scope.key, source_fn_key);
+        self.countBodyDiagnostic("nested_lookup_probes");
+        const family_exists = source_ctx.draft.nested_spec_families.contains(family);
         const stored_evidence = try self.constFnEvidence(requested_evidence);
         const evidence_digest = Ast.fnEvidenceDigest(stored_evidence.nodes, stored_evidence.frames, stored_evidence.head);
         const resolved_request_ty: ?Type.TypeId = if (try source_ctx.graph.typeIsResolved(request_fn_node))
@@ -7975,6 +7981,7 @@ const Builder = struct {
         if (resolved_lookup_address) |address| {
             if (source_ctx.draft.nested_spec_lookup.get(address)) |candidates| {
                 for (candidates.items) |raw_spec| {
+                    self.countBodyDiagnostic("nested_lookup_probes");
                     const spec = &source_ctx.draft.nested_specs.items[raw_spec];
                     if (signature_relation == .exact_graph and
                         source_ctx.draft.fns.items[@intFromEnum(spec.fn_id)].signature_relation != .exact_graph)
@@ -7991,10 +7998,11 @@ const Builder = struct {
                 }
             }
         }
-        if (selection.selected() == null) {
+        if (family_exists and selection.selected() == null) {
             if (open_shape_lookup_address) |address| {
                 if (source_ctx.draft.nested_spec_lookup.get(address)) |candidates| {
                     for (candidates.items) |raw_spec| {
+                        self.countBodyDiagnostic("nested_lookup_probes");
                         const spec = &source_ctx.draft.nested_specs.items[raw_spec];
                         if (spec.state != .lowered) continue;
                         if (spec.request_fn_ty != null) continue;
@@ -8015,10 +8023,11 @@ const Builder = struct {
             }
         }
         var interface = try source_ctx.graph.functionInterfaceIterator(request_fn_node);
-        if (selection.selected() == null) {
+        if (family_exists and selection.selected() == null) {
             while (interface.next()) |interface_node| {
                 var aliases = source_ctx.graph.classMemberIterator(interface_node);
                 while (aliases.next()) |member| {
+                    self.countBodyDiagnostic("nested_lookup_probes");
                     const lookup_address = DraftNestedLookupAddress{
                         .family = family,
                         .evidence_digest = evidence_digest.bytes,
@@ -8027,6 +8036,7 @@ const Builder = struct {
                     };
                     if (source_ctx.draft.nested_spec_lookup.get(lookup_address)) |candidates| {
                         for (candidates.items) |raw_spec| {
+                            self.countBodyDiagnostic("nested_lookup_probes");
                             const seen = try seen_specs.getOrPut(raw_spec);
                             if (seen.found_existing) continue;
                             const spec = &source_ctx.draft.nested_specs.items[raw_spec];
@@ -8067,7 +8077,7 @@ const Builder = struct {
         // A checked recursive reference whose fresh cells have not yet joined
         // any interface class above names the in-progress specialization of
         // the same site on its own ownership chain.
-        if (selection.selected() == null and recursive_reference) {
+        if (family_exists and selection.selected() == null and recursive_reference) {
             for (source_ctx.draft.nested_specs.items, 0..) |*spec, raw_spec_usize| {
                 if (spec.state != .lowering) continue;
                 if (spec.request_fn_ty != null) continue;
@@ -8136,6 +8146,7 @@ const Builder = struct {
             return .{ .draft = spec.fn_id };
         }
         self.count("nested_misses");
+        try source_ctx.draft.nested_spec_families.put(family, {});
 
         const fn_id = try source_ctx.draft.addFn(.{ .source = .{
             .fn_def = .{ .nested = nested },
@@ -9371,13 +9382,6 @@ const Builder = struct {
         const identities = try self.allocator.alloc(?Ast.SpecIdentity, body_draft.fns.items.len);
         defer self.allocator.free(identities);
         @memset(identities, null);
-        const allow_imported = try self.allocator.alloc(bool, body_draft.fns.items.len);
-        defer self.allocator.free(allow_imported);
-        @memset(allow_imported, false);
-        const allow_identity_merge = try self.allocator.alloc(bool, body_draft.fns.items.len);
-        defer self.allocator.free(allow_identity_merge);
-        @memset(allow_identity_merge, true);
-
         for (body_draft.sealed_nested_specs.items) |*spec| {
             spec.sealed_codec_contract = if (spec.codec_contract) |contract|
                 self.codecContractIdentity(.{
@@ -9390,12 +9394,30 @@ const Builder = struct {
                 null;
         }
 
+        // These sealed tables no longer change during commit. Index their
+        // producer-authored function ids once rather than searching per body.
+        var template_by_fn = collections.DenseMap(DraftFnId, *const SealedTemplateSpec).init(self.allocator);
+        defer template_by_fn.deinit();
+        for (body_draft.sealed_template_specs.items) |*spec| {
+            self.countBodyDiagnostic("draft_commit_lookup_steps");
+            try template_by_fn.put(spec.fn_id, spec);
+        }
+        var nested_by_fn = collections.DenseMap(DraftFnId, *const SealedNestedSpec).init(self.allocator);
+        defer nested_by_fn.deinit();
+        for (body_draft.sealed_nested_specs.items) |*spec| {
+            self.countBodyDiagnostic("draft_commit_lookup_steps");
+            try nested_by_fn.put(spec.fn_id, spec);
+        }
+        var prior_identities = std.AutoHashMap(specialize.SpecLookupAddress, u32).init(self.allocator);
+        defer prior_identities.deinit();
+        const previous_same_identity = try self.allocator.alloc(?u32, body_draft.fns.items.len);
+        defer self.allocator.free(previous_same_identity);
+
         var next_fn: u32 = @intCast(self.program.fnCount());
         for (body_draft.fns.items, 0..) |fn_, raw_index| {
             const draft_id: DraftFnId = @enumFromInt(@as(u32, @intCast(raw_index)));
-            const template_spec: ?*const SealedTemplateSpec = for (body_draft.sealed_template_specs.items) |*spec| {
-                if (spec.fn_id == draft_id) break spec;
-            } else null;
+            self.countBodyDiagnostic("draft_commit_lookup_steps");
+            const template_spec = template_by_fn.get(draft_id);
             if (template_spec) |spec| {
                 if (spec.state == .resolved) {
                     fn_slots[raw_index] = spec.resolved_slot orelse
@@ -9415,6 +9437,8 @@ const Builder = struct {
                 .head = fn_.source.const_evidence_frame_head,
             };
             var identity: ?Ast.SpecIdentity = null;
+            var allow_imported = false;
+            var allow_identity_merge = true;
             var lexical_owner: ?DraftOwner = null;
             if (template_spec) |spec| {
                 if (!spec.local_context_dependent) {
@@ -9438,28 +9462,25 @@ const Builder = struct {
                     );
                 }
                 lexical_owner = spec.lexical_owner;
-                allow_imported[raw_index] = !spec.requires_local;
-                allow_identity_merge[raw_index] = !spec.requires_local;
+                allow_imported = !spec.requires_local;
+                allow_identity_merge = !spec.requires_local;
             }
             if (identity == null) {
-                for (body_draft.sealed_nested_specs.items) |spec| {
-                    if (spec.fn_id == draft_id) {
-                        if (!spec.local_context_dependent) {
-                            identity = nestedSpecIdentity(
-                                spec.nested,
-                                spec.method_scope,
-                                spec.source_fn_key,
-                                sealed_template.evidence_digest,
-                                spec.capture_abi_digest,
-                                spec.sealed_codec_contract,
-                                fn_ty,
-                                digest,
-                            );
-                        }
-                        lexical_owner = spec.lexical_owner;
-                        allow_identity_merge[raw_index] = !spec.requires_local;
-                        break;
+                if (nested_by_fn.get(draft_id)) |spec| {
+                    if (!spec.local_context_dependent) {
+                        identity = nestedSpecIdentity(
+                            spec.nested,
+                            spec.method_scope,
+                            spec.source_fn_key,
+                            sealed_template.evidence_digest,
+                            spec.capture_abi_digest,
+                            spec.sealed_codec_contract,
+                            fn_ty,
+                            digest,
+                        );
                     }
+                    lexical_owner = spec.lexical_owner;
+                    allow_identity_merge = !spec.requires_local;
                 }
             }
             identities[raw_index] = identity;
@@ -9484,10 +9505,10 @@ const Builder = struct {
             };
 
             if (identity) |wanted| {
-                var prior: usize = 0;
-                while (prior < raw_index) : (prior += 1) {
-                    if (fn_slots[prior] == null) continue;
-                    if (!allow_identity_merge[raw_index] or !allow_identity_merge[prior]) continue;
+                const address = specialize.SpecLookupAddress.fromIdentity(wanted);
+                var candidate = if (allow_identity_merge) prior_identities.get(address) else null;
+                while (candidate) |prior| : (candidate = previous_same_identity[prior]) {
+                    self.countBodyDiagnostic("draft_commit_lookup_steps");
                     if (identities[prior]) |existing| {
                         if (try self.draftSpecIdentityEql(existing, wanted)) {
                             const prior_template = body_draft.fns.items[prior].source;
@@ -9508,9 +9529,9 @@ const Builder = struct {
                         }
                     }
                 } else {
-                    const committed: ?specialize.LookupResult = if (!allow_identity_merge[raw_index])
+                    const committed: ?specialize.LookupResult = if (!allow_identity_merge)
                         null
-                    else if (allow_imported[raw_index])
+                    else if (allow_imported)
                         try self.spec_store.find(wanted, specializationEvidenceView(requested_evidence))
                     else if (try self.spec_store.findLocal(wanted, specializationEvidenceView(requested_evidence))) |hit|
                         .{ .local = hit }
@@ -9535,6 +9556,11 @@ const Builder = struct {
                         fn_slots[raw_index] = .{ .local = @enumFromInt(next_fn) };
                         next_fn += 1;
                         emit_fns[raw_index] = true;
+                    }
+                    if (allow_identity_merge) {
+                        const entry = try prior_identities.getOrPut(address);
+                        previous_same_identity[raw_index] = if (entry.found_existing) entry.value_ptr.* else null;
+                        entry.value_ptr.* = @intCast(raw_index);
                     }
                 }
             } else {
@@ -13592,6 +13618,9 @@ const BodyDraftStore = struct {
     nested_specs: std.ArrayList(DraftNestedSpec),
     sealed_nested_specs: std.ArrayList(SealedNestedSpec),
     nested_spec_lookup: std.AutoHashMap(DraftNestedLookupAddress, std.ArrayList(u32)),
+    /// Exact family membership proves a new site's miss without visiting any
+    /// graph aliases. It is independent of mutable interface root identity.
+    nested_spec_families: std.AutoHashMap(DraftNestedFamilyAddress, void),
     exprs: std.ArrayList(DraftExpr),
     pats: std.ArrayList(DraftPat),
     stmts: std.ArrayList(DraftStmt),
@@ -13702,6 +13731,7 @@ const BodyDraftStore = struct {
             .nested_specs = .empty,
             .sealed_nested_specs = .empty,
             .nested_spec_lookup = std.AutoHashMap(DraftNestedLookupAddress, std.ArrayList(u32)).init(allocator),
+            .nested_spec_families = std.AutoHashMap(DraftNestedFamilyAddress, void).init(allocator),
             .exprs = .empty,
             .pats = .empty,
             .stmts = .empty,
@@ -13899,6 +13929,7 @@ const BodyDraftStore = struct {
         var nested_lookup_lists = self.nested_spec_lookup.valueIterator();
         while (nested_lookup_lists.next()) |list| list.deinit(self.allocator);
         self.nested_spec_lookup.deinit();
+        self.nested_spec_families.deinit();
         self.owner_runs.deinit(self.allocator);
         self.stmt_impossibility_proofs.deinit(self.allocator);
         self.pat_impossibility_proofs.deinit(self.allocator);
@@ -14654,7 +14685,9 @@ const BodyDraftStore = struct {
         var nested_lookup_lists = self.nested_spec_lookup.valueIterator();
         while (nested_lookup_lists.next()) |list| list.deinit(self.allocator);
         self.nested_spec_lookup.deinit();
+        self.nested_spec_families.deinit();
         self.nested_spec_lookup = std.AutoHashMap(DraftNestedLookupAddress, std.ArrayList(u32)).init(self.allocator);
+        self.nested_spec_families = std.AutoHashMap(DraftNestedFamilyAddress, void).init(self.allocator);
         self.template_spec_by_fn.deinit();
         self.template_spec_by_fn = collections.DenseMap(DraftFnId, u32).init(self.allocator);
         self.closed_direct_specializations.deinit();
@@ -14684,6 +14717,7 @@ const BodyDraftStore = struct {
             self.impossibility_proofs.items.len != 0 or
             self.template_spec_lookup.count() != 0 or
             self.nested_spec_lookup.count() != 0 or
+            self.nested_spec_families.count() != 0 or
             self.template_specs.items.len != 0 or
             self.nested_specs.items.len != 0 or
             self.spec_job_workspace != null or

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -248,6 +248,10 @@ pub const OpenFunctionInterfaceShape = struct {
 /// `InstGraph.diagnostics` remains null unless detailed diagnostics were
 /// requested, so ordinary lowering does not count hot-path operations.
 pub const GraphDiagnostics = struct {
+    /// Node identities retained by argument-class snapshots.
+    argument_class_members_snapshotted: u64 = 0,
+    /// Visited-set slots initialized or touched by structural backing walks.
+    structural_backing_scan_slots: u64 = 0,
     nodes_created: u64 = 0,
     unify_requests: u64 = 0,
     class_unions: u64 = 0,
@@ -1101,21 +1105,27 @@ pub const InstGraph = struct {
         self.relation_state = .frozen;
     }
 
+    /// An immutable segment of the append-only class-member list. Union only
+    /// links a class tail to another class head, so no link inside this saved
+    /// segment can change. Its last node remains the boundary after any union.
     pub const ArgumentClassSnapshot = struct {
-        members: []const NodeId,
+        first: NodeId,
+        last: NodeId,
 
-        fn contains(self: ArgumentClassSnapshot, node: NodeId) bool {
-            for (self.members) |member| {
+        fn contains(self: ArgumentClassSnapshot, graph: *const InstGraph, node: NodeId) bool {
+            var member = self.first;
+            while (true) {
                 if (member == node) return true;
+                if (member == self.last) return false;
+                member = graph.class_member_next.items[@intFromEnum(member)] orelse
+                    Common.invariant("argument class snapshot lost an interior link");
             }
-            return false;
         }
     };
 
-    /// Snapshot every permanent member of each ordered argument class before
-    /// a specialization body can add recursive relations. Root choice is not
-    /// stable under union, so recursive growth must compare permanent identity
-    /// against the whole initial class rather than one representative node.
+    /// Retain the exact initial membership without walking or copying the
+    /// class. Recursive growth tests permanent node identity against this
+    /// bounded segment, independently of later root choices and class joins.
     pub fn snapshotFunctionArgumentClasses(
         self: *InstGraph,
         fn_node: NodeId,
@@ -1123,15 +1133,12 @@ pub const InstGraph = struct {
         const args = (try self.functionNodes(fn_node)).args;
         const snapshots = try self.arena().alloc(ArgumentClassSnapshot, args.len);
         for (args, snapshots) |arg, *snapshot| {
-            var count: usize = 0;
-            var counting = self.classMemberIterator(arg);
-            while (counting.next() != null) count += 1;
-
-            const members = try self.arena().alloc(NodeId, count);
-            var filling = self.classMemberIterator(arg);
-            var index: usize = 0;
-            while (filling.next()) |member| : (index += 1) members[index] = member;
-            snapshot.* = .{ .members = members };
+            const root = @intFromEnum(self.find(arg));
+            snapshot.* = .{
+                .first = self.class_member_head.items[root],
+                .last = self.class_member_tail.items[root],
+            };
+            self.countDiagnosticBy("argument_class_members_snapshotted", 2);
         }
         return snapshots;
     }
@@ -1148,7 +1155,7 @@ pub const InstGraph = struct {
             Common.invariant("recursive function interface changed argument arity");
         }
         for (initial_active_arg_classes, request.args) |initial_class, request_arg| {
-            if (!initial_class.contains(request_arg)) {
+            if (!initial_class.contains(self, request_arg)) {
                 try self.recursive_argument_slots.append(self.allocator, request_arg);
             }
         }
@@ -4532,13 +4539,13 @@ pub const InstGraph = struct {
     }
 
     fn findStructuralBackingNode(self: *InstGraph, raw: NodeId, owner: InstNamed) Allocator.Error!StructuralBacking {
-        var seen = try std.DynamicBitSetUnmanaged.initEmpty(self.allocator, self.nodes.items.len);
-        defer seen.deinit(self.allocator);
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         var current = self.find(raw);
         while (true) {
-            const index = @intFromEnum(current);
-            if (seen.isSet(index)) return .{ .node = current, .recursive = true };
-            seen.set(index);
+            self.countDiagnostic("structural_backing_scan_slots");
+            const entry = try seen.getOrPut(current);
+            if (entry.found_existing) return .{ .node = current, .recursive = true };
             const next = self.structuralBackingNext(current, owner) orelse return .{ .node = current, .recursive = false };
             current = next;
         }
@@ -6805,6 +6812,103 @@ test "resolved graph type detection does not default open cells" {
     try graph.unify(unresolved, str);
     try std.testing.expect(try graph.typeIsResolved(open_list));
     try std.testing.expect(try graph.typeCanSealFromExplicitEvidence(open_list));
+}
+
+test "argument class snapshots preserve entry membership through unions on both sides" {
+    const gpa = std.testing.allocator;
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+
+    // Both outsiders predate the snapshot: node age cannot stand in for
+    // membership, and either side may become the representative later.
+    const before = try graph.newNode(.empty_record);
+    const after = try graph.newNode(.empty_record);
+    const first = try graph.newNode(.empty_record);
+    const last = try graph.newNode(.empty_record);
+    try graph.union_(first, last);
+    const ret = try graph.newNode(.{ .primitive = .bool });
+    const active = try graph.newNode(.{ .func = .{
+        .args = try graph.arena().dupe(NodeId, &.{first}),
+        .ret = ret,
+    } });
+    const initial = try graph.snapshotFunctionArgumentClasses(active);
+    try graph.union_(before, first);
+    try graph.union_(before, after);
+    const new_node = try graph.newNode(.empty_record);
+    try graph.union_(new_node, before);
+    const later = try graph.snapshotFunctionArgumentClasses(active);
+
+    for ([_]NodeId{ first, last }) |member| {
+        try std.testing.expect(initial[0].contains(graph, member));
+        const request = try graph.newNode(.{ .func = .{
+            .args = try graph.arena().dupe(NodeId, &.{member}),
+            .ret = ret,
+        } });
+        try graph.unifyRecursiveFunctionInterface(active, initial, request);
+    }
+    try std.testing.expectEqual(@as(usize, 0), graph.recursive_argument_slots.items.len);
+    for ([_]NodeId{ before, after, new_node }) |member| {
+        try std.testing.expect(!initial[0].contains(graph, member));
+        try std.testing.expect(later[0].contains(graph, member));
+        const request = try graph.newNode(.{ .func = .{
+            .args = try graph.arena().dupe(NodeId, &.{member}),
+            .ret = ret,
+        } });
+        try graph.unifyRecursiveFunctionInterface(active, initial, request);
+    }
+    try std.testing.expectEqualSlices(NodeId, &.{ before, after, new_node }, graph.recursive_argument_slots.items);
+    // Re-reading a snapshot after another snapshot and recursive relations
+    // must still stop at its original tail.
+    try std.testing.expect(!initial[0].contains(graph, after));
+}
+
+test "structural backing traversal preserves cycle entry and clears only visited scratch" {
+    const gpa = std.testing.allocator;
+    for ([_]?usize{ null, 0, 1, 7 }) |cycle_entry| {
+        var type_store = Type.Store.init(gpa);
+        defer type_store.deinit();
+        var name_store = names.NameStore.init(gpa);
+        defer name_store.deinit();
+        const graph = try InstGraph.create(gpa, &type_store, &name_store);
+        defer graph.destroy();
+        const module_identity = try name_store.internModuleIdentity(&([_]u8{0xAC} ** 32));
+        const type_name = try name_store.internTypeName("Chain");
+        const terminal = try graph.newNode(.empty_record);
+        var nodes: [12]NodeId = undefined;
+        for (&nodes) |*node| node.* = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
+        for (nodes, 0..) |node, index| {
+            const next = if (index + 1 < nodes.len) nodes[index + 1] else if (cycle_entry) |entry| nodes[entry] else terminal;
+            graph.setContent(node, .{ .named = .{
+                .named_type = .{ .module = .{}, .ty = testCheckedTypeId(1) },
+                .def = .{ .module = module_identity, .type_name = type_name },
+                .kind = .nominal,
+                .builtin_owner = null,
+                .args = &.{},
+                .backing = .{ .node = next, .use = .inspectable },
+            } });
+        }
+        var diagnostics = GraphDiagnostics{};
+        graph.diagnostics = &diagnostics;
+        const owner = graph.content(nodes[0]).named;
+        const expected = if (cycle_entry) |entry| nodes[entry] else terminal;
+        var prior_steps: ?u64 = null;
+        for (0..2) |_| {
+            const before_steps = diagnostics.structural_backing_scan_slots;
+            const result = try graph.findStructuralBackingNode(nodes[0], owner);
+            try std.testing.expectEqual(expected, result.node);
+            try std.testing.expectEqual(cycle_entry != null, result.recursive);
+            const steps = diagnostics.structural_backing_scan_slots - before_steps;
+            try std.testing.expect(steps <= 8 * nodes.len);
+            if (prior_steps) |previous| try std.testing.expectEqual(previous, steps);
+            prior_steps = steps;
+            // Unrelated graph growth must not increase the next walk's work.
+            for (0..1000) |_| _ = try graph.newNode(.empty_record);
+        }
+    }
 }
 
 test "open draft function interfaces use related graph classes directly" {

--- a/src/postcheck/monotype/specialize.zig
+++ b/src/postcheck/monotype/specialize.zig
@@ -152,7 +152,7 @@ const SpecEntryId = union(enum(u8)) {
 /// the source function type digest, and one closed monomorphic function type
 /// digest (a record is reachable under its requested digest and, once ready
 /// with a different solved type, under its solved digest as an alias).
-const SpecLookupAddress = struct {
+pub const SpecLookupAddress = struct {
     callable_kind: u8,
     module_bytes: [32]u8,
     method_scope: [32]u8,
@@ -169,6 +169,12 @@ const SpecLookupAddress = struct {
     evidence_digest: [32]u8,
     codec_contract_digest: [32]u8,
     type_digest: [32]u8,
+
+    /// Share the durable identity bucket between reservation and draft commit.
+    /// Exact type and evidence equality remain the caller's collision checks.
+    pub fn fromIdentity(identity: Ast.SpecIdentity) SpecLookupAddress {
+        return from(identity.callable, identity.method_scope, identity.source_fn_ty_digest, identity.evidence_digest, identity.codec_contract_digest, identity.request_fn_ty_digest);
+    }
 
     fn from(
         callable: Ast.CallableIdentity,


### PR DESCRIPTION
Fix quadratic specialization work in large bodies containing many lambdas. Preserve historical argument classes with constant-size snapshots, avoid alias scans for new callable families, reuse sparse backing-walk scratch, and index draft commits while retaining exact specialization and recursion checks.

Fixes #11144.
