### PR TITLE
Preserve receiver grouping when formatting pipe targets

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1608,7 +1608,7 @@ const Formatter = struct {
             .field_access => |fa| {
                 const receiver_expr = fmt.ast.store.getExpr(fa.receiver);
                 const flatten_pipe_receiver = receiver_expr == .arrow_call and multiline;
-                const parenthesize_receiver = (receiver_expr == .arrow_call and !flatten_pipe_receiver) or fmt.exprIsNumericAccessReceiver(fa.receiver);
+                const parenthesize_receiver = (receiver_expr == .arrow_call and !flatten_pipe_receiver) or fmt.postfixReceiverNeedsParens(fa.receiver);
                 const expand_parenthesized_receiver = receiver_expr == .arrow_call and
                     fmt.nodeWillBeMultiline(AST.Expr.Idx, fa.receiver);
                 const receiver = if (parenthesize_receiver)
@@ -1652,7 +1652,7 @@ const Formatter = struct {
             .method_call => |mc| {
                 const left_expr = fmt.ast.store.getExpr(mc.receiver);
                 const flatten_pipe_receiver = left_expr == .arrow_call and multiline;
-                const parenthesize_receiver = (left_expr == .arrow_call and !flatten_pipe_receiver) or fmt.exprIsNumericAccessReceiver(mc.receiver);
+                const parenthesize_receiver = (left_expr == .arrow_call and !flatten_pipe_receiver) or fmt.postfixReceiverNeedsParens(mc.receiver);
                 const expand_parenthesized_receiver = left_expr == .arrow_call and
                     fmt.nodeWillBeMultiline(AST.Expr.Idx, mc.receiver);
                 const receiver = if (parenthesize_receiver)
@@ -1830,7 +1830,7 @@ const Formatter = struct {
             .tuple_access => |ta| {
                 const receiver_expr = fmt.ast.store.getExpr(ta.expr);
                 const flatten_pipe_receiver = receiver_expr == .arrow_call and multiline;
-                const parenthesize_receiver = (receiver_expr == .arrow_call and !flatten_pipe_receiver) or fmt.exprIsNumericAccessReceiver(ta.expr);
+                const parenthesize_receiver = (receiver_expr == .arrow_call and !flatten_pipe_receiver) or fmt.postfixReceiverNeedsParens(ta.expr);
                 if (parenthesize_receiver) try fmt.push('(');
                 const target = try fmt.formatExprWithInfo(ta.expr);
                 _ = try fmt.continueAfterMultilineStringLine(target);
@@ -3912,12 +3912,55 @@ const Formatter = struct {
         try fmt.pushVerbatim(text);
     }
 
-    fn exprIsNumericAccessReceiver(fmt: *Formatter, expr_idx: AST.Expr.Idx) bool {
-        const expr = fmt.ast.store.getExpr(expr_idx);
-        const tag = std.meta.activeTag(expr);
-        if (tag == .int or tag == .frac or tag == .typed_int or tag == .typed_frac) return true;
-        if (tag == .unary_op) return fmt.exprIsNumericAccessReceiver(expr.unary_op.expr);
-        return false;
+    // Pipe-target grouping is not stored as a tuple node. Restore parentheses
+    // when attaching a postfix to an expression whose grammar would otherwise
+    // absorb that postfix into its operand or body. Numeric receivers also need
+    // parentheses to keep the dot from becoming part of the numeric token.
+    // Pipe receivers have their own continuation/grouping rule at the call sites.
+    fn postfixReceiverNeedsParens(fmt: *Formatter, expr_idx: AST.Expr.Idx) bool {
+        return switch (fmt.ast.store.getExpr(expr_idx)) {
+            .int,
+            .frac,
+            .typed_int,
+            .typed_frac,
+            .bin_op,
+            .unary_op,
+            .lambda,
+            .if_then_else,
+            .if_without_else,
+            .dbg,
+            .crash,
+            .@"return",
+            .for_expr,
+            => true,
+            .ident,
+            .tag,
+            .single_quote,
+            .string_part,
+            .string,
+            .typed_string,
+            .multiline_string,
+            .typed_multiline_string,
+            .list,
+            .tuple,
+            .record,
+            .record_builder,
+            .nominal_record,
+            .apply,
+            .nominal_apply,
+            .record_updater,
+            .field_access,
+            .method_call,
+            .tuple_access,
+            .suffix_single_question,
+            .arrow_call,
+            .match,
+            .block,
+            .ellipsis,
+            .@"break",
+            .malformed,
+            => false,
+        };
     }
 
     fn exprCanStartPipeTargetUnparenthesized(fmt: *Formatter, expr_idx: AST.Expr.Idx) bool {
@@ -5045,6 +5088,26 @@ test "literal method pipe targets and grouped result calls format stably" {
             "d = x |> (receiver.method())\n",
         result,
     );
+}
+
+test "issue 11160: pipe method receivers preserve expression grouping" {
+    const cases = [_]struct { input: []const u8, expected: []const u8 }{
+        .{ .input = "t=0|>(0%0).y()", .expected = "t = 0 |> (0 % 0).y()\n" },
+        .{ .input = "t=x|>(a+b).y()", .expected = "t = x |> (a + b).y()\n" },
+        .{ .input = "t=x|>(-a).y()", .expected = "t = x |> (-a).y()\n" },
+        .{ .input = "t=x|>(|v|v).y()", .expected = "t = x |> (|v| v).y()\n" },
+        .{ .input = "t=x|>(if a b else c).y()", .expected = "t = x |> (if a b else c).y()\n" },
+        .{ .input = "t=x|>(dbg a).y()", .expected = "t = x |> (dbg a).y()\n" },
+        .{ .input = "t=x|>(crash \"failed\").y()", .expected = "t = x |> (crash \"failed\").y()\n" },
+        .{ .input = "t=x|>((a+b).y())", .expected = "t = x |> ((a + b).y())\n" },
+        .{ .input = "t=x|>(a+b).field.y()", .expected = "t = x |> (a + b).field.y()\n" },
+        .{ .input = "t=x|>(a+b).0.y()", .expected = "t = x |> (a + b).0.y()\n" },
+    };
+    for (cases) |case| {
+        const result = try moduleFmtsStable(std.testing.allocator, case.input, false);
+        defer std.testing.allocator.free(result);
+        try std.testing.expectEqualStrings(case.expected, result);
+    }
 }
 
 test "formatter preserves an old arrow's postfix grouping during migration" {


### PR DESCRIPTION
Fixes #11160.

Formatting `t=0|>(0%0).y()` removed the receiver's parentheses and produced invalid source. The parser deliberately unwraps pipe-target grouping, so the method receiver is a binary expression directly. Postfix formatting previously restored parentheses only for numeric and pipe receivers.

Use an exhaustive expression-grammar rule shared by method calls, field access, and tuple access to parenthesize receivers whose operands or bodies would otherwise absorb the postfix. The reproducer now formats as `t = 0 |> (0 % 0).y()`. Preserve the existing distinction between method insertion and calling a grouped method result.

Regression coverage asserts exact output, successful reparsing, and idempotence for numeric and identifier binary expressions, unary expressions, lambdas, conditionals, dbg/crash expressions, grouped method results, and field/tuple access chains.

Validation:
- Confirmed the issue's reproducer fails before the fix and passes afterward.
- `zig build run-test-zig-module-fmt run-test-zig-module-parse --summary all`: 184/184 tests passed.
- `zig fmt --check src/fmt/fmt.zig` and `git diff --check` passed.
- Full MiniCI was not run.
