### PR TITLE
Fix duplicate module names across packages panicking typed CIR

### DIFF
--- a/design.md
+++ b/design.md
@@ -1853,6 +1853,13 @@ runtime slice itself is not serialized, a cache consumer supplies the exact
 source-visible name already produced by the current canonicalization, and a
 debug invariant checks it against the serialized `display_module_name_idx`.
 
+Typed CIR module graphs retain the coordinator's explicit resolved import
+indices. They do not index modules by diagnostic names or require those names
+to be unique. Content-identical modules from distinct packages can load the
+same checked cache entry, including its recorded package-qualified display
+name; those names cannot distinguish graph entries. Cross-artifact semantic
+identity remains the checked content identity.
+
 The cache id does not include target ABI, pointer width, layout ids, field offsets,
 alignment decisions, backend choice, object format, code-generation options,
 post-check lowering strategy, or post-check specialization state.

--- a/src/check/typed_cir.zig
+++ b/src/check/typed_cir.zig
@@ -81,8 +81,10 @@ const ModuleData = struct {
 /// Owned collection of typed CIR modules used by later lowering stages.
 pub const Modules = struct {
     allocator: Allocator,
+    // Import edges carry explicit indices into this array. Display names are
+    // not unique: content-identical modules from separate packages can load
+    // the same cached environment, including its recorded display names.
     modules: []ModuleData,
-    module_idxs_by_name: std.StringHashMapUnmanaged(u32),
 
     /// Ways to provide a checked module env to typed CIR.
     pub const SourceModule = union(enum) {
@@ -151,22 +153,12 @@ pub const Modules = struct {
             modules[i] = try source_module.initModuleData(allocator);
         }
 
-        var module_idxs_by_name: std.StringHashMapUnmanaged(u32) = .{};
-        errdefer module_idxs_by_name.deinit(allocator);
-
         for (modules, 0..) |*module_data, i| {
             const module_ = Module{
                 .allocator = allocator,
                 .module_idx = @intCast(i),
                 .data_store = module_data,
             };
-            const module_name = module_.name();
-            const module_result = try module_idxs_by_name.getOrPut(allocator, module_name);
-            if (module_result.found_existing) {
-                std.debug.panic("typed_cir invariant violated: duplicate module name {s}", .{module_name});
-            }
-            module_result.value_ptr.* = @intCast(i);
-
             for (module_.moduleEnvConst().store.sliceDefs(module_.moduleEnvConst().top_level_value_defs)) |def_idx| {
                 const def = module_.def(def_idx);
                 if (def.data.kind != .let) continue;
@@ -182,13 +174,11 @@ pub const Modules = struct {
         return .{
             .allocator = allocator,
             .modules = modules,
-            .module_idxs_by_name = module_idxs_by_name,
         };
     }
 
     pub fn deinit(self: *Modules) void {
         for (self.modules) |*module_data| module_data.deinit(self.allocator);
-        self.module_idxs_by_name.deinit(self.allocator);
         self.allocator.free(self.modules);
     }
 
@@ -202,10 +192,6 @@ pub const Modules = struct {
             .module_idx = module_idx,
             .data_store = @constCast(&self.modules[module_idx]),
         };
-    }
-
-    pub fn moduleIdxByName(self: @This(), target_name: []const u8) ?u32 {
-        return self.module_idxs_by_name.get(target_name);
     }
 };
 

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -7819,3 +7819,76 @@ test "exact path spelling preserves case and honors platform separators" {
         try std.testing.expect(!pathsHaveExactSpelling("Dir/Module.roc", "Dir\\Module.roc"));
     }
 }
+
+test "issue 11065: identical modules across packages compile with cold and warm caches" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "cache");
+    try writeCacheKeyPurityFixture(&tmp, "workspace");
+    for ([_][]const u8{ "custom0", "custom1" }) |package| {
+        const dir = try std.fmt.allocPrint(allocator, "workspace/app/{s}", .{package});
+        defer allocator.free(dir);
+        try tmp.dir.createDirPath(io, dir);
+        const root = try std.fmt.allocPrint(allocator, "{s}/main.roc", .{dir});
+        defer allocator.free(root);
+        try tmp.dir.writeFile(io, .{ .sub_path = root, .data = "package [Plugin]\n" });
+        const plugin = try std.fmt.allocPrint(allocator, "{s}/Plugin.roc", .{dir});
+        defer allocator.free(plugin);
+        try tmp.dir.writeFile(io, .{
+            .sub_path = plugin,
+            .data =
+            \\Plugin := [].{
+            \\    value = 42
+            \\}
+            ,
+        });
+    }
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "workspace/app/main.roc",
+        .data =
+        \\app [main!] { pf: platform "./.roc_echo_platform/main.roc", custom0: "./custom0/main.roc", custom1: "./custom1/main.roc" }
+        \\import custom0.Plugin as Custom0
+        \\import custom1.Plugin as Custom1
+        \\expect Custom0.value == 42
+        \\expect Custom1.value == 42
+        \\main! = |_args| Ok({})
+        ,
+    });
+    const cache_dir = try tmp.dir.realPathFileAlloc(io, "cache", allocator);
+    defer allocator.free(cache_dir);
+    const app_path = try tmp.dir.realPathFileAlloc(io, "workspace/app/main.roc", allocator);
+    defer allocator.free(app_path);
+    var cold = try compileAppRootIdentity(allocator, cache_dir, app_path);
+    defer cold.deinit(allocator);
+    var warm = try compileAppRootIdentity(allocator, cache_dir, app_path);
+    defer warm.deinit(allocator);
+    try std.testing.expect(warm.cache_hits > 0);
+    try std.testing.expectEqualSlices(u8, &cold.artifact_key, &warm.artifact_key);
+
+    // The same module name with different content must still resolve through
+    // its own import edge, including after loading the changed graph from cache.
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "workspace/app/custom1/Plugin.roc",
+        .data = "Plugin := [].{ value = 43 }\n",
+    });
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "workspace/app/main.roc",
+        .data =
+        \\app [main!] { pf: platform "./.roc_echo_platform/main.roc", custom0: "./custom0/main.roc", custom1: "./custom1/main.roc" }
+        \\import custom0.Plugin as Custom0
+        \\import custom1.Plugin as Custom1
+        \\expect Custom0.value == 42
+        \\expect Custom1.value == 43
+        \\main! = |_args| Ok({})
+        ,
+    });
+    var changed = try compileAppRootIdentity(allocator, cache_dir, app_path);
+    defer changed.deinit(allocator);
+    var changed_warm = try compileAppRootIdentity(allocator, cache_dir, app_path);
+    defer changed_warm.deinit(allocator);
+    try std.testing.expect(changed_warm.cache_hits > 0);
+    try std.testing.expectEqualSlices(u8, &changed.artifact_key, &changed_warm.artifact_key);
+    try std.testing.expect(!std.mem.eql(u8, &cold.artifact_key, &changed.artifact_key));
+}


### PR DESCRIPTION
Fixes #11065.

Importing byte-identical modules from two packages can load the same content-addressed checked cache entry twice, including its recorded package-qualified display name. Typed CIR then panicked while building an unused name-to-module index that required those names to be unique.

Remove that obsolete index and lookup API. Import edges already carry explicit resolved module indices, and cross-artifact identity uses checked content hashes. Document this graph invariant in `design.md`.

The regression compiles two packages exposing `Plugin` through separate aliases with cold and warm caches, evaluates expectations through both aliases, and finalizes executable artifacts. It then changes one package's value and checks both aliases again, including a warm-cache build.

Validation:
- Confirmed the new regression reproduces the reported duplicate-module-name panic before the fix.
- `zig build run-test-zig-module-compile -- --test-filter 'issue 11065' --test-filter 'cache-key purity' --test-filter 'issue 10897' --test-filter 'issue 10705'`
- `zig fmt` and `git diff --check`

Full MiniCI was not run, as requested.
