### PR TITLE
Fix cached imports of same-named modules across packages

### DIFF
--- a/src/check/typed_cir.zig
+++ b/src/check/typed_cir.zig
@@ -79,10 +79,11 @@ const ModuleData = struct {
 };
 
 /// Owned collection of typed CIR modules used by later lowering stages.
+/// Modules are addressed by their explicit indices. Display names need not be
+/// unique: imports from different packages can share a checked cache entry.
 pub const Modules = struct {
     allocator: Allocator,
     modules: []ModuleData,
-    module_idxs_by_name: std.StringHashMapUnmanaged(u32),
 
     /// Ways to provide a checked module env to typed CIR.
     pub const SourceModule = union(enum) {
@@ -151,22 +152,12 @@ pub const Modules = struct {
             modules[i] = try source_module.initModuleData(allocator);
         }
 
-        var module_idxs_by_name: std.StringHashMapUnmanaged(u32) = .{};
-        errdefer module_idxs_by_name.deinit(allocator);
-
         for (modules, 0..) |*module_data, i| {
             const module_ = Module{
                 .allocator = allocator,
                 .module_idx = @intCast(i),
                 .data_store = module_data,
             };
-            const module_name = module_.name();
-            const module_result = try module_idxs_by_name.getOrPut(allocator, module_name);
-            if (module_result.found_existing) {
-                std.debug.panic("typed_cir invariant violated: duplicate module name {s}", .{module_name});
-            }
-            module_result.value_ptr.* = @intCast(i);
-
             for (module_.moduleEnvConst().store.sliceDefs(module_.moduleEnvConst().top_level_value_defs)) |def_idx| {
                 const def = module_.def(def_idx);
                 if (def.data.kind != .let) continue;
@@ -182,13 +173,11 @@ pub const Modules = struct {
         return .{
             .allocator = allocator,
             .modules = modules,
-            .module_idxs_by_name = module_idxs_by_name,
         };
     }
 
     pub fn deinit(self: *Modules) void {
         for (self.modules) |*module_data| module_data.deinit(self.allocator);
-        self.module_idxs_by_name.deinit(self.allocator);
         self.allocator.free(self.modules);
     }
 
@@ -202,10 +191,6 @@ pub const Modules = struct {
             .module_idx = module_idx,
             .data_store = @constCast(&self.modules[module_idx]),
         };
-    }
-
-    pub fn moduleIdxByName(self: @This(), target_name: []const u8) ?u32 {
-        return self.module_idxs_by_name.get(target_name);
     }
 };
 

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -416,6 +416,7 @@ const CustomCase = enum {
     cache_passing_results,
     cache_failing_results,
     cache_invalidated_by_source_change,
+    issue_11065_duplicate_module_name_across_packages,
     cache_ignores_optimized_mode,
     cache_replays_optimized_dbg_transcript,
     cache_replays_dbg_transcript_across_backends,
@@ -1030,6 +1031,7 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "issue 10704: erroneous checked type in declaration reports without postcheck panic", .body = .{ .command = .{ .args = &.{"--no-cache"}, .roc_file = "test/cli/issue_10704_erroneous_checked_type_statement.roc", .exit = .not_panic, .contains = &.{.{ .stream = .stderr, .text = "type mismatch" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "erroneous checked type reached Monotype instantiation" }, .{ .stream = .stderr, .text = "postcheck invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "reassignment type error under a platform target reports without postcheck panic", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/reassign_type_error_platform_root/app.roc", .exit = .failure, .contains = &.{.{ .stream = .stderr, .text = "type mismatch" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "erroneous checked type reached Monotype instantiation" }, .{ .stream = .stderr, .text = "postcheck invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "issue 10705: app imports two nested types from one platform module", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10705_two_nested_platform_exposes/app.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{ .{ .stream = .stderr, .text = "module not found" }, .{ .stream = .stderr, .text = "type not exposed" }, .{ .stream = .stderr, .text = "duplicate module name" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 11065: app imports a same-named module from two packages", .body = .{ .custom = .issue_11065_duplicate_module_name_across_packages } },
     .{ .id = 0, .suite = .subcommands, .name = "issue 10728: value cycle through from_numeral is a circular value definition", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10728_from_numeral_value_cycle.roc", .exit = .{ .code = 1 }, .contains = &.{.{ .stream = .stderr, .text = "circular value definition" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "overflowed its stack" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check reports the body error of an unannotated associated method that is dispatched on", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/DispatchOnUnannotatedErrorBodyMethod.roc", .exit = .{ .code = 1 }, .contains = &.{ .{ .stream = .stderr, .text = "does not exist" }, .{ .stream = .stderr, .text = "Bool.true" } }, .not_contains = &.{ .{ .stream = .stderr, .text = "publication could not resolve a checked dispatch target" }, .{ .stream = .stderr, .text = "panic" } } } } },
     // Repro for https://github.com/roc-lang/roc/issues/10369: associated items
@@ -2907,6 +2909,7 @@ fn runCustomCase(
         .cache_passing_results => customCachePassingResults(io, allocator, &env, &timer, timeout_ms, spec.backend orelse .interpreter),
         .cache_failing_results => customCacheFailingResults(io, allocator, &env, &timer, timeout_ms, spec.backend orelse .interpreter),
         .cache_invalidated_by_source_change => customCacheInvalidated(io, allocator, &env, &timer, timeout_ms, spec.backend orelse .interpreter),
+        .issue_11065_duplicate_module_name_across_packages => customIssue11065DuplicateModuleNameAcrossPackages(io, allocator, &env, &timer, timeout_ms),
         .cache_ignores_optimized_mode => customCacheIgnoresOptimizedMode(io, allocator, &env, &timer, timeout_ms),
         .cache_replays_optimized_dbg_transcript => customCacheReplaysOptimizedDbgTranscript(io, allocator, &env, &timer, timeout_ms),
         .cache_replays_dbg_transcript_across_backends => customCacheReplaysDbgTranscriptAcrossBackends(io, allocator, &env, &timer, timeout_ms),
@@ -6474,6 +6477,25 @@ fn customCacheInvalidated(io: std.Io, allocator: Allocator, env: *const CaseEnv,
     std.Io.Dir.cwd().writeFile(io, .{ .sub_path = file_path, .data = updated_content }) catch |err|
         return customInfraFailure(allocator, timer, "failed to update cache test file: {}", .{err});
     if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{ .args = &.{ "test", opt_arg }, .roc_file = file_path, .not_contains = &.{.{ .stream = .stdout, .text = "(cached)" }} })) |failure| return failure;
+    return null;
+}
+
+// Identical modules from separate packages share a checked-module cache entry.
+// Both a cold check and a warm check must accept their imports.
+fn customIssue11065DuplicateModuleNameAcrossPackages(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
+    const check_app = CommandCase{
+        .args = &.{"check"},
+        .roc_file = "test/cli/issue_11065_duplicate_module_name_across_packages/app.roc",
+        .exit = .success,
+        .contains_any = &.{.{ .needles = &no_errors_needles }},
+        .not_contains = &.{
+            .{ .stream = .stderr, .text = "duplicate module name" },
+            .{ .stream = .stderr, .text = "invariant violated" },
+            .{ .stream = .stderr, .text = "panic" },
+        },
+    };
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, check_app)) |failure| return failure;
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, check_app)) |failure| return failure;
     return null;
 }
 

--- a/test/cli/issue_11065_duplicate_module_name_across_packages/app.roc
+++ b/test/cli/issue_11065_duplicate_module_name_across_packages/app.roc
@@ -1,0 +1,9 @@
+app [main!] { pf: platform "../../fx/platform/main.roc", custom0: "custom0/main.roc", custom1: "custom1/main.roc" }
+
+# Repro for https://github.com/roc-lang/roc/issues/11065: both packages ship
+# identical Plugin modules, so a warm check loads the same cached module twice.
+import custom0.Plugin as Custom0
+import custom1.Plugin as Custom1
+import pf.Stdout
+
+main! = || Stdout.line!("${Custom0.name()} ${Custom1.name()}")

--- a/test/cli/issue_11065_duplicate_module_name_across_packages/custom0/Plugin.roc
+++ b/test/cli/issue_11065_duplicate_module_name_across_packages/custom0/Plugin.roc
@@ -1,0 +1,4 @@
+Plugin := [].{
+    name : () -> Str
+    name = || "plugin"
+}

--- a/test/cli/issue_11065_duplicate_module_name_across_packages/custom0/main.roc
+++ b/test/cli/issue_11065_duplicate_module_name_across_packages/custom0/main.roc
@@ -1,0 +1,1 @@
+package [Plugin] {}

--- a/test/cli/issue_11065_duplicate_module_name_across_packages/custom1/Plugin.roc
+++ b/test/cli/issue_11065_duplicate_module_name_across_packages/custom1/Plugin.roc
@@ -1,0 +1,4 @@
+Plugin := [].{
+    name : () -> Str
+    name = || "plugin"
+}

--- a/test/cli/issue_11065_duplicate_module_name_across_packages/custom1/main.roc
+++ b/test/cli/issue_11065_duplicate_module_name_across_packages/custom1/main.roc
@@ -1,0 +1,1 @@
+package [Plugin] {}


### PR DESCRIPTION
Identical modules imported from different packages intentionally share a checked-module cache entry, but restoring that entry gives both environments the same qualified name and triggers an obsolete uniqueness check. Remove the unused name-to-module map so these imports compile successfully with a warm cache, while also eliminating its allocations and string hashing.

Fixes #11065.
