### PR TITLE
kcov flag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6263,8 +6263,14 @@ pub fn build(b: *std.Build) void {
     // Only supported on Linux ARM64, matching CI's coverage runner. Other local
     // targets still keep the run-coverage-parser step, but it reports unsupported
     // instead of invoking a kcov binary that cannot trace reliably on that host.
+    //
+    // Declaring these steps is also what asks zig for the lazy kcov package, so
+    // on linux-aarch64 even a build that only wants the roc binary fails without
+    // it. -Dcoverage=false skips the declaration, which is how a packager builds
+    // roc without supplying kcov at all.
+    const enable_coverage = b.option(bool, "coverage", "Declare the kcov coverage steps, which is what pulls in the kcov dependency (default: true; only has an effect on linux-aarch64)") orelse true;
     const is_linux_arm64 = target.result.os.tag == .linux and target.result.cpu.arch == .aarch64;
-    const is_coverage_supported = is_linux_arm64;
+    const is_coverage_supported = is_linux_arm64 and enable_coverage;
     if (is_coverage_supported and isNativeishOrMusl(target)) {
         // Get the kcov dependency and build it from source
         // lazyDependency returns null on first pass; Zig re-runs build() after fetching
@@ -6458,7 +6464,7 @@ pub fn build(b: *std.Build) void {
                     std.debug.print("=" ** 60 ++ "\n", .{});
                     std.debug.print("COVERAGE NOT SUPPORTED\n", .{});
                     std.debug.print("=" ** 60 ++ "\n\n", .{});
-                    std.debug.print("kcov parser coverage is currently enabled only on Linux ARM64.\n", .{});
+                    std.debug.print("kcov parser coverage is currently enabled only on Linux ARM64, and only when -Dcoverage is left on.\n", .{});
                     std.debug.print("Current platform: {s}\n\n", .{@tagName(builtin.target.os.tag)});
                     std.debug.print("=" ** 60 ++ "\n", .{});
                 }


### PR DESCRIPTION
The kcov dependency is currently required for roc binary builds on linux aarch64 but it should only be needed for CI purposes, not for every build.