### PR TITLE
Fix ARC certification of wide aggregate field transfers

### DIFF
--- a/design.md
+++ b/design.md
@@ -11379,6 +11379,15 @@ tag-payload field is that payload struct's sole refcounted field. The tag read's
 variant and discriminant metadata is the explicit proof of the active shape;
 no layout shape is treated as evidence that a variant is active.
 
+Certification tracks field claims over the full committed semantic field-index
+domain. Scalar and padding fields contribute no ownership obligations, regardless
+of their indices. The required claim set is derived once per queried layout from
+its committed RC fields. Path states keep the first word inline and share sparse
+persistent words for higher indices; forks and outcome-restitution receipts retain
+exact prior sets. Join comparison and memo hashing use field-set contents rather
+than snapshot addresses. A container's unit is spent only when its claims equal
+the complete required set, with every field claim validated against that set.
+
 Ownership-complete aggregate reads and borrowed pure aliases form explicit
 ownership places. The place graph is solved to a fixpoint, so a nested read
 chain such as tag payload to struct field keeps the root aggregate's unit key.

--- a/design.md
+++ b/design.md
@@ -11379,8 +11379,8 @@ tag-payload field is that payload struct's sole refcounted field. The tag read's
 variant and discriminant metadata is the explicit proof of the active shape;
 no layout shape is treated as evidence that a variant is active.
 
-Certification tracks field claims over the full committed semantic field-index
-domain. Scalar and padding fields contribute no ownership obligations, regardless
+Certification tracks field claims over the full committed layout field-index
+domain. Scalar and padding fields require no RC claims, regardless
 of their indices. The required claim set is derived once per queried layout from
 its committed RC fields. Path states keep the first word inline and share sparse
 persistent words for higher indices; forks and outcome-restitution receipts retain

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -161,6 +161,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11130_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11131_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11188_test.zig"));
+    std.testing.refAllDecls(@import("test/wide_capture_arc_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11158_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));

--- a/src/compile/test/wide_capture_arc_test.zig
+++ b/src/compile/test/wide_capture_arc_test.zig
@@ -1,0 +1,19 @@
+//! Wide closure captures preserve ownership through ARC certification.
+
+const std = @import("std");
+const harness = @import("lower_to_lir_harness.zig");
+
+test "ARC wide capture: scalar captures alongside a list lower under both strategies" {
+    var source: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer source.deinit();
+    const writer = &source.writer;
+    try writer.writeAll("main! = |args| {\n");
+    for (0..128) |index| {
+        try writer.print("    salt_{d} = args.len() + {d}\n", .{ index, index });
+    }
+    try writer.writeAll("    reader = |offset| args.len() + offset");
+    for (0..128) |index| try writer.print(" + salt_{d}", .{index});
+    try writer.writeAll("\n    if reader(0) == 0 { Err(Mismatch) } else { Ok({}) }\n}\n");
+    try harness.expectLowersToLirWithOptions(source.written(), .{ .specialization_strategy = .lss });
+    try harness.expectLowersToLirWithOptions(source.written(), .{ .specialization_strategy = .boxy });
+}

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -114,6 +114,7 @@ const arc_sig = @import("arc_sig.zig");
 const arc_dismantle = @import("arc_dismantle.zig");
 const arc_solve = @import("arc_solve.zig");
 const ArcSnapshot = @import("arc_state.zig").Snapshot;
+const ClaimSet = @import("arc_claims.zig").Set;
 const debug_print = @import("debug_print.zig");
 
 const LIR = core.LIR;
@@ -213,6 +214,7 @@ fn certifyStoreWithWorkStats(
         .maybe_uninitialized = &maybe_uninitialized,
         .lender_arena = std.heap.ArenaAllocator.init(allocator),
         .state_arena = std.heap.ArenaAllocator.init(allocator),
+        .claim_arena = std.heap.ArenaAllocator.init(allocator),
         .records = collections.DenseMap(LIR.JoinPointId, JoinRecord).init(allocator),
         .memo = std.AutoHashMap(MemoEntry, void).init(allocator),
         .repr_scratch = collections.DenseMap(ValueId, u32).init(allocator),
@@ -1139,7 +1141,7 @@ const MaybeUninitializedConditions = struct {
 /// unit claimed from a nested aggregate field), not a manufactured unit.
 const OwnershipMutation = union(enum) {
     balance: struct { value: ValueId, before: i32, after: i32 },
-    claims: struct { value: ValueId, before: u64, after: u64 },
+    claims: struct { value: ValueId, before: ClaimSet, after: ClaimSet },
 };
 
 const RestitutionReceipt = struct {
@@ -1253,7 +1255,7 @@ const State = struct {
     /// takes. A claimed value's remaining unit covers only its unclaimed
     /// fields: it can no longer be released or consumed whole, and at a
     /// terminal it must be fully claimed and residual-released instead.
-    claims: ArcSnapshot(u64, 0),
+    claims: ArcSnapshot(ClaimSet, .{}),
     /// Scalar discriminant locals explicitly read from a direct call result
     /// carrying outcome-conditioned ownership.
     outcome_discriminants: ArcSnapshot(ValueId, no_value),
@@ -1289,7 +1291,7 @@ const State = struct {
             .balance = ArcSnapshot(i32, 0).init(allocator, proc_local_count),
             .holder = ArcSnapshot(ValueId, no_value).init(allocator, proc_local_count),
             .conditional = ArcSnapshot(ConditionalEntry, .{}).init(allocator, proc_local_count),
-            .claims = ArcSnapshot(u64, 0).init(allocator, proc_local_count),
+            .claims = ArcSnapshot(ClaimSet, .{}).init(allocator, proc_local_count),
             .outcome_discriminants = ArcSnapshot(ValueId, no_value).init(allocator, local_dense.len),
             .result_discriminant = no_dense,
             .maybe_uninitialized_unresolved = ArcSnapshot(bool, false).init(allocator, proc_local_count),
@@ -1315,11 +1317,11 @@ const State = struct {
         }
     }
 
-    fn claimsOf(self: *const State, value: ValueId) u64 {
+    fn claimsOf(self: *const State, value: ValueId) ClaimSet {
         return self.claims.get(value);
     }
 
-    fn setClaims(self: *State, value: ValueId, mask: u64) Allocator.Error!void {
+    fn setClaims(self: *State, value: ValueId, mask: ClaimSet) Allocator.Error!void {
         try self.put(&self.claims, value, mask);
     }
 
@@ -1544,7 +1546,7 @@ const LocalSummary = struct {
     condition_mask: u64,
     /// For owned locals: fields of the value already claimed by field takes.
     /// Set identically on every member of the alias set.
-    claims: u64 = 0,
+    claims: ClaimSet = .{},
 };
 
 const LocalClass = enum(u8) {
@@ -1700,6 +1702,9 @@ const Certifier = struct {
     value_walk_scratch: std.bit_set.DynamicBitSetUnmanaged = .{},
     diag: *Diagnostic,
     work_stats: ?*CertifierWorkStats,
+    /// Immutable layout claim sets survive per-procedure state-arena resets.
+    claim_layouts: std.AutoHashMapUnmanaged(layout_mod.Idx, ClaimSet) = .empty,
+    claim_arena: std.heap.ArenaAllocator,
     /// Proc and statement being certified; written by `certifyProc` and
     /// `runSegment` before any read.
     current_proc: LIR.LirProcSpecId = undefined,
@@ -1714,6 +1719,8 @@ const Certifier = struct {
         self.values.deinit(self.allocator);
         self.lender_arena.deinit();
         self.state_arena.deinit();
+        self.claim_layouts.deinit(self.allocator);
+        self.claim_arena.deinit();
         self.clearRecords();
         self.records.deinit();
         self.memo.deinit();
@@ -1968,7 +1975,7 @@ const Certifier = struct {
         mutations: ?*std.ArrayList(OwnershipMutation),
     ) CertifyError!void {
         if (value == no_value) return;
-        if (state.claimsOf(value) != 0 and !self.hasIntactSurplusUnit(state, value)) {
+        if (!state.claimsOf(value).isEmpty() and !try self.hasIntactSurplusUnit(state, value)) {
             return self.fail("consumed partially dismantled local {d}", .{@intFromEnum(local)});
         }
         if (state.balanceOf(value) < 1) {
@@ -2015,11 +2022,10 @@ const Certifier = struct {
         if (info.payload_projection == arc_dismantle.no_projection) return false;
         const container_origin = self.values.items[container].origin;
         const container_layout = self.layouts.getLayout(self.store.getLocal(container_origin).layout_idx);
-        const bit: u64 = switch (container_layout.tag) {
+        const field: u16 = switch (container_layout.tag) {
             .struct_ => blk: {
                 const field_idx: u16 = @intCast(info.payload_projection & 0xffff);
-                if (field_idx >= 64) return false;
-                break :blk @as(u64, 1) << @intCast(field_idx);
+                break :blk field_idx;
             },
             .tag_union => blk: {
                 if (!arc_dismantle.projectionOwnsAllRc(
@@ -2029,7 +2035,7 @@ const Certifier = struct {
                     info.origin,
                     info.payload_projection,
                 )) return false;
-                break :blk 1;
+                break :blk 0;
             },
             .scalar,
             .box,
@@ -2043,15 +2049,17 @@ const Certifier = struct {
             .ptr,
             => return false,
         };
+        const required = try self.requiredClaims(container) orelse return false;
+        if (!required.contains(field)) return false;
         const existing = state.claimsOf(container);
-        if (existing & bit != 0) {
+        if (existing.contains(field)) {
             // Only a complete projection can spend another whole unit;
             // repeating a partial field claim would lose its other fields.
-            if (self.requiredClaimMask(container) != bit) return false;
+            if (!required.isSingleton(field)) return false;
             // A second stamped take of the same projection spends that field
             // from an intact surplus aggregate unit. The first unit remains
             // represented by the existing claim set.
-            if (self.hasIntactSurplusUnit(state, container)) {
+            if (try self.hasIntactSurplusUnit(state, container)) {
                 const before = state.balanceOf(container);
                 try state.addBalance(container, -1);
                 if (mutations) |list| try list.append(self.allocator, .{ .balance = .{
@@ -2068,11 +2076,12 @@ const Certifier = struct {
             return try self.tryClaimSeen(state, container, seen, mutations);
         }
         if (!try self.ensureClaimContainerUnit(state, container, seen, mutations)) return false;
-        try state.setClaims(container, existing | bit);
+        const updated = try existing.withField(self.state_arena.allocator(), field);
+        try state.setClaims(container, updated);
         if (mutations) |list| try list.append(self.allocator, .{ .claims = .{
             .value = container,
             .before = existing,
-            .after = existing | bit,
+            .after = updated,
         } });
         return true;
     }
@@ -2104,37 +2113,37 @@ const Certifier = struct {
     /// Whether the value's single unit is fully spent by claims: every
     /// refcounted field's stored unit was taken or residually released, so
     /// no whole release is owed and none is allowed.
-    fn claimsSpendUnit(self: *Certifier, state: *const State, value: ValueId) bool {
+    fn claimsSpendUnit(self: *Certifier, state: *const State, value: ValueId) Allocator.Error!bool {
         const claims = state.claimsOf(value);
-        if (claims == 0) return false;
+        if (claims.isEmpty()) return false;
         if (state.balanceOf(value) != 1) return false;
-        const required = self.requiredClaimMask(value) orelse return false;
-        return claims == required;
+        const required = try self.requiredClaims(value) orelse return false;
+        return claims.eql(required);
     }
 
-    /// The refcounted-field mask a fully dismantled value must have claimed:
-    /// one bit per refcounted field of its struct layout. Null when the
-    /// value's layout does not support claims at all.
-    fn requiredClaimMask(self: *Certifier, value: ValueId) ?u64 {
+    /// Exact committed RC-field identities, cached once per queried layout.
+    /// Scalar siblings never contribute a stored unit or restrict the domain.
+    fn requiredClaims(self: *Certifier, value: ValueId) Allocator.Error!?ClaimSet {
         if (value >= self.values.items.len) return null;
         const origin = self.values.items[value].origin;
-        const origin_layout = self.layouts.getLayout(self.store.getLocal(origin).layout_idx);
-        return switch (origin_layout.tag) {
+        const layout_idx = self.store.getLocal(origin).layout_idx;
+        if (self.claim_layouts.get(layout_idx)) |cached| return cached;
+        const origin_layout = self.layouts.getLayout(layout_idx);
+        const required: ClaimSet = switch (origin_layout.tag) {
             .struct_ => blk: {
                 const info = self.layouts.getStructInfo(origin_layout);
-                var mask: u64 = 0;
+                var fields: ClaimSet = .{};
                 for (0..info.fields.len) |i| {
                     const field = info.fields.get(@intCast(i));
-                    if (field.index >= 64) return null;
+                    if (field.is_padding) continue;
                     if (!self.layouts.layoutContainsRefcounted(self.layouts.getLayout(field.layout))) continue;
-                    mask |= @as(u64, 1) << @intCast(field.index);
+                    fields = try fields.withField(self.claim_arena.allocator(), field.index);
                 }
-                break :blk mask;
+                break :blk fields;
             },
-            // A tag path can claim the unit only through a projection that
-            // owns every refcounted byte of the proven active payload. One
-            // such claim therefore spends the tag's whole unit.
-            .tag_union => 1,
+            // A proven complete projection spends the active tag payload's
+            // whole unit, independently of its variant or payload width.
+            .tag_union => .{ .low = 1 },
             .scalar,
             .box,
             .box_of_zst,
@@ -2145,8 +2154,10 @@ const Certifier = struct {
             .erased_callable,
             .zst,
             .ptr,
-            => null,
+            => return null,
         };
+        try self.claim_layouts.put(self.allocator, layout_idx, required);
+        return required;
     }
 
     /// Whether the value still holds an intact unit beyond the one being
@@ -2159,10 +2170,10 @@ const Certifier = struct {
     /// followed by dismantling the surplus. The claims stay outstanding
     /// against the remaining unit, so the terminal leak check still proves
     /// every stored unit was spent exactly once.
-    fn hasIntactSurplusUnit(self: *Certifier, state: *const State, value: ValueId) bool {
-        if (state.claimsOf(value) == 0) return false;
+    fn hasIntactSurplusUnit(self: *Certifier, state: *const State, value: ValueId) Allocator.Error!bool {
+        if (state.claimsOf(value).isEmpty()) return false;
         if (state.balanceOf(value) < 2) return false;
-        return self.requiredClaimMask(value) != null;
+        return try self.requiredClaims(value) != null;
     }
 
     /// Aggregate consumption: one unit moves into the holder. The emitted
@@ -2176,7 +2187,7 @@ const Certifier = struct {
         holder_value: ValueId,
     ) CertifyError!void {
         if (value == no_value) return;
-        if (state.claimsOf(value) != 0 and !self.hasIntactSurplusUnit(state, value)) {
+        if (!state.claimsOf(value).isEmpty() and !try self.hasIntactSurplusUnit(state, value)) {
             return self.fail(
                 "partially dismantled value originating at local {d} moved into an aggregate",
                 .{@intFromEnum(self.values.items[value].origin)},
@@ -2211,11 +2222,11 @@ const Certifier = struct {
         for (0..self.values.items.len) |value_index| {
             const units = state.balanceOf(@intCast(value_index));
             const claims = state.claimsOf(@intCast(value_index));
-            if (claims != 0) {
+            if (!claims.isEmpty()) {
                 // A dismantled value's own unit must still be in hand, and
                 // every refcounted field's stored unit must have been spent
                 // exactly once by a take or a residual release.
-                if (self.claimsSpendUnit(state, @intCast(value_index))) continue;
+                if (try self.claimsSpendUnit(state, @intCast(value_index))) continue;
                 const origin = self.values.items[value_index].origin;
                 self.diag.context_local = origin;
                 self.diag.context_proc = self.current_proc;
@@ -2282,7 +2293,7 @@ const Certifier = struct {
             const value = try self.requireLive(state, param);
             if (self.values.items[value].origin != param or
                 state.balanceOf(value) != 1 or
-                state.claimsOf(value) != 0 or
+                !state.claimsOf(value).isEmpty() or
                 state.holderOf(value) != no_value)
             {
                 return self.fail(
@@ -2357,7 +2368,7 @@ const Certifier = struct {
                         try state.addBalance(mutation.value, mutation.before - mutation.after);
                     },
                     .claims => |mutation| {
-                        if (state.claimsOf(mutation.value) != mutation.after) {
+                        if (!state.claimsOf(mutation.value).eql(mutation.after)) {
                             return self.fail("outcome restitution argument {d} field claims changed before refinement", .{position});
                         }
                         try state.setClaims(mutation.value, mutation.before);
@@ -2699,7 +2710,7 @@ const Certifier = struct {
             hasher.update(std.mem.asBytes(&entry.abi_live));
             hasher.update(std.mem.asBytes(&entry.condition));
             hasher.update(std.mem.asBytes(&entry.condition_mask));
-            hasher.update(std.mem.asBytes(&entry.claims));
+            entry.claims.hashInto(&hasher);
         }
         return hasher.final();
     }
@@ -2732,7 +2743,7 @@ const Certifier = struct {
                 .unbound => unreachable,
             };
             if (entry.abi_live) self.values.items[value].always_live = true;
-            if (entry.claims != 0) try state.setClaims(value, entry.claims);
+            if (!entry.claims.isEmpty()) try state.setClaims(value, entry.claims);
         }
 
         for (summary, 0..) |entry, dense| {
@@ -2904,7 +2915,7 @@ const Certifier = struct {
                 .unbound => {},
                 // Claims are per-field spend records, not attributable
                 // balances; states disagreeing on them walk separately.
-                .owned => if (ga.claims != sb.claims or
+                .owned => if (!ga.claims.eql(sb.claims) or
                     (compare and !summaryProvenanceEql(ga.provenance, sb.provenance))) return false,
                 .conditional_owned => if (ga.condition != sb.condition or
                     ga.condition_mask != sb.condition_mask or
@@ -4275,7 +4286,7 @@ const Certifier = struct {
                     (state.balanceOf(value) == 0 and !try self.valueIsLive(state, value));
                 const value_is_intact_cell = value != no_value and
                     state.balanceOf(value) == 1 and
-                    state.claimsOf(value) == 0 and
+                    state.claimsOf(value).isEmpty() and
                     state.holderOf(value) == no_value;
                 const canonicalize_conditional = declared_condition != null and
                     (declared_by_target or
@@ -4366,7 +4377,7 @@ const Certifier = struct {
         for (0..self.values.items.len) |value_index| {
             const units = state.balanceOf(@intCast(value_index));
             if (units == 0) continue;
-            if (self.claimsSpendUnit(state, @intCast(value_index))) continue;
+            if (try self.claimsSpendUnit(state, @intCast(value_index))) continue;
             const origin = self.values.items[value_index].origin;
             if (units < 0) {
                 return self.fail(
@@ -5217,14 +5228,13 @@ const Certifier = struct {
     ) CertifyError!void {
         if (state.any_negative) try self.settleNegativeClaims(state);
         const claims = state.claimsOf(container);
-        if (claims == 0) return;
+        if (claims.isEmpty()) return;
         const container_origin = self.values.items[container].origin;
         const container_layout = self.layouts.getLayout(self.store.getLocal(container_origin).layout_idx);
         const taken = switch (container_layout.tag) {
             .struct_ => blk: {
                 const field_idx: u16 = @intCast(projection & 0xffff);
-                if (field_idx >= 64) break :blk false;
-                break :blk (claims & (@as(u64, 1) << @intCast(field_idx))) != 0;
+                break :blk claims.contains(field_idx);
             },
             .tag_union => true,
             .scalar,
@@ -5239,7 +5249,7 @@ const Certifier = struct {
             .ptr,
             => false,
         };
-        if (!taken or self.hasIntactSurplusUnit(state, container)) return;
+        if (!taken or try self.hasIntactSurplusUnit(state, container)) return;
         self.diag.context_local = source;
         self.diag.context_proc = self.current_proc;
         self.diag.context_stmt = self.current_stmt;
@@ -5287,21 +5297,18 @@ const Certifier = struct {
             }
             return;
         }
-        const required = self.requiredClaimMask(source_value) orelse 0;
-        var observed: u64 = 0;
+        const required = try self.requiredClaims(source_value) orelse ClaimSet{};
+        var observed: ClaimSet = .{};
         for (0..absent_fields.len) |index| {
             const field_index = GuardedList.at(absent_fields, index);
-            if (field_index >= 64) {
-                return self.fail("residual-shell field index {d} exceeds the certified field domain", .{field_index});
-            }
-            const field_mask = @as(u64, 1) << @intCast(field_index);
-            if ((required & field_mask) == 0) {
+            if (field_index > std.math.maxInt(u16) or !required.contains(@intCast(field_index))) {
                 return self.fail("residual-shell metadata names non-RC or absent field {d}", .{field_index});
             }
-            if ((observed & field_mask) != 0) {
+            const field: u16 = @intCast(field_index);
+            if (observed.contains(field)) {
                 return self.fail("residual-shell metadata repeats field {d}", .{field_index});
             }
-            observed |= field_mask;
+            observed = try observed.withField(self.state_arena.allocator(), field);
         }
 
         // The certifier's field claims settle lazily at consumption and are
@@ -5309,7 +5316,7 @@ const Certifier = struct {
         // path-local residual snapshot attached to this particular binding;
         // ARC's solved plan is the authority for partial masks. Once the
         // whole value is dead, however, every RC field must be absent.
-        if (!try self.valueIsLive(state, source_value) and observed != required) {
+        if (!try self.valueIsLive(state, source_value) and !observed.eql(required)) {
             return self.fail("released struct representation is missing exact residual-shell metadata", .{});
         }
     }
@@ -5359,7 +5366,7 @@ const Certifier = struct {
             self.diag.context_proc = self.current_proc;
             return self.fail("release of unbound local {d}", .{@intFromEnum(local)});
         }
-        if (state.claimsOf(value) != 0 and !self.hasIntactSurplusUnit(state, value)) {
+        if (!state.claimsOf(value).isEmpty() and !try self.hasIntactSurplusUnit(state, value)) {
             self.diag.context_local = local;
             self.diag.context_proc = self.current_proc;
             return self.fail("whole release of partially dismantled local {d}", .{@intFromEnum(local)});
@@ -7933,6 +7940,157 @@ test "certify accepts a fully dismantled record via field takes" {
     const body = try fieldReadStmt(&f, first, pair, 0, read_second);
     _ = try f.addProc(&.{pair}, body, .i64);
     try f.certify();
+}
+
+test "certify accepts a complete field transfer with wide scalar siblings" {
+    for ([_]u16{ 0, 63, 64, 128 }) |rc_index| {
+        var f = try CertifyTest.init(testing.allocator);
+        defer f.deinit();
+        var fields: [129]layout_mod.StructField = undefined;
+        for (&fields, 0..) |*field, index| {
+            field.* = .{ .index = @intCast(index), .layout = if (index == rc_index) .str else .i64 };
+        }
+        const record_layout = try f.layouts.putStructFields(&fields);
+        const record = try f.local(record_layout);
+        const field = try f.local(.str);
+        const ret = try f.ret(field);
+        const body = try fieldReadStmt(&f, field, record, rc_index, ret);
+        _ = try f.addProc(&.{record}, body, .str);
+        try f.certify();
+    }
+}
+
+test "certify accounts for every stored unit beyond one word of fields" {
+    for ([_]bool{ false, true }) |leave_unspent| {
+        var f = try CertifyTest.init(testing.allocator);
+        defer f.deinit();
+        var fields: [65]layout_mod.StructField = undefined;
+        for (&fields, 0..) |*field, index| {
+            field.* = .{ .index = @intCast(index * 2), .layout = .str };
+        }
+        const record_layout = try f.layouts.putStructFields(&fields);
+        const record = try f.local(record_layout);
+        const result = try f.local(.i64);
+        var body = try f.assignI64(result, try f.ret(result));
+        for (fields) |field| {
+            if (leave_unspent and field.index == 128) continue;
+            const target = try f.local(.str);
+            const release = try f.decrefStmt(target, .str, body);
+            body = try fieldReadStmt(&f, target, record, field.index, release);
+        }
+        _ = try f.addProc(&.{record}, body, .i64);
+        if (leave_unspent) {
+            try testing.expectError(error.Certification, f.certify());
+            try testing.expect(std.mem.find(u8, f.diag.message(), "unspent") != null);
+        } else {
+            try f.certify();
+        }
+    }
+}
+
+test "certify joins equal wide claims made in different orders" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+    const record_layout = try f.layouts.putStructFields(&.{
+        .{ .index = 0, .layout = .str },
+        .{ .index = 128, .layout = .str },
+        .{ .index = 129, .layout = .str },
+    });
+    const record = try f.local(record_layout);
+    const cond = try f.local(.u8);
+    const last = try f.local(.str);
+    const result = try f.local(.i64);
+    const end = try f.assignI64(result, try f.ret(result));
+    const join_body = try fieldReadStmt(&f, last, record, 0, try f.decrefStmt(last, .str, end));
+    const join_id = f.freshJoinPointId();
+    var branches: [2]LIR.CFStmtId = undefined;
+    const orders = [_][2]u16{ .{ 128, 129 }, .{ 129, 128 } };
+    for (&branches, orders) |*branch, order| {
+        var body = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+        for (order) |index| {
+            const field = try f.local(.str);
+            body = try fieldReadStmt(&f, field, record, index, try f.decrefStmt(field, .str, body));
+        }
+        branch.* = body;
+    }
+    const choose = try f.store.addCFStmt(.{ .switch_stmt = .{
+        .cond = cond,
+        .branches = try f.store.addCFSwitchBranches(&.{.{ .value = 1, .body = branches[0] }}),
+        .default_branch = branches[1],
+    } });
+    const body = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = LIR.LocalSpan.empty(),
+        .body = join_body,
+        .remainder = choose,
+    } });
+    _ = try f.addProc(&.{ record, cond }, body, .i64);
+    try f.certify();
+}
+
+test "certify rejects repeated wide field takes and reads after a take" {
+    for ([_]bool{ false, true }) |read_after_take| {
+        var f = try CertifyTest.init(testing.allocator);
+        defer f.deinit();
+        const record_layout = try f.layouts.putStructFields(&.{
+            .{ .index = 0, .layout = .str },
+            .{ .index = 128, .layout = .str },
+        });
+        const record = try f.local(record_layout);
+        const first = try f.local(.str);
+        const again = try f.local(.str);
+        const result = try f.local(.i64);
+        const end = try f.assignI64(result, try f.ret(result));
+        const release_again = try f.decrefStmt(again, .str, end);
+        const release_first = try f.decrefStmt(first, .str, release_again);
+        const read_again = try fieldReadStmt(&f, again, record, 128, if (read_after_take) release_again else release_first);
+        const body = try fieldReadStmt(&f, first, record, 128, if (read_after_take)
+            try f.decrefStmt(first, .str, read_again)
+        else
+            read_again);
+        _ = try f.addProc(&.{record}, body, .i64);
+        try testing.expectError(error.Certification, f.certify());
+        const expected = if (read_after_take) "after the field's stored unit was taken" else "without an ownership unit";
+        try testing.expect(std.mem.find(u8, f.diag.message(), expected) != null);
+    }
+}
+
+test "certify validates wide residual shell identities across a join" {
+    const cases = [_][]const u32{ &.{128}, &.{}, &.{ 128, 128 }, &.{0}, &.{65536} };
+    for (cases, 0..) |absent, case_index| {
+        var f = try CertifyTest.init(testing.allocator);
+        defer f.deinit();
+        const record_layout = try f.layouts.putStructFields(&.{
+            .{ .index = 0, .layout = .i64 },
+            .{ .index = 128, .layout = .str },
+        });
+        const record = try f.local(record_layout);
+        const alias = try f.local(record_layout);
+        const scalar = try f.local(.i64);
+        const join_id = f.freshJoinPointId();
+        const read_scalar = try fieldReadStmt(&f, scalar, alias, 0, try f.ret(scalar));
+        const alias_shell = try f.store.addCFStmt(.{ .assign_ref = .{
+            .target = alias,
+            .op = .{ .local = record },
+            .residual_shell_absent_fields = try f.store.addU32Span(absent),
+            .next = read_scalar,
+        } });
+        const jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+        const release = try f.decrefStmt(record, record_layout, jump);
+        const body = try f.store.addCFStmt(.{ .join = .{
+            .id = join_id,
+            .params = LIR.LocalSpan.empty(),
+            .body = alias_shell,
+            .remainder = release,
+        } });
+        _ = try f.addProc(&.{record}, body, .i64);
+        if (case_index == 0) {
+            try f.certify();
+        } else {
+            try testing.expectError(error.Certification, f.certify());
+            try testing.expect(std.mem.find(u8, f.diag.message(), "residual-shell") != null);
+        }
+    }
 }
 
 test "certify flags a whole release of a partially dismantled record" {

--- a/src/lir/arc_claims.zig
+++ b/src/lir/arc_claims.zig
@@ -1,0 +1,116 @@
+//! Exact persistent sets of committed struct-field identities for certification.
+
+const std = @import("std");
+const Snapshot = @import("arc_state.zig").Snapshot;
+
+/// Ordinary records use one inline word. Higher semantic field indices use
+/// shared sparse snapshots, so a control-flow fork never copies a wide bitmap.
+pub const Set = struct {
+    low: u64 = 0,
+    high: ?*const High = null,
+
+    const High = struct {
+        words: Snapshot(u64, 0),
+        last_word: u16,
+        count: u16,
+    };
+
+    pub fn isEmpty(self: Set) bool {
+        return self.low == 0 and self.high == null;
+    }
+
+    pub fn contains(self: Set, field: u16) bool {
+        const bit = @as(u64, 1) << @as(u6, @intCast(field % 64));
+        if (field < 64) return self.low & bit != 0;
+        const high = self.high orelse return false;
+        return high.words.get(field / 64) & bit != 0;
+    }
+
+    /// Use an arena that outlives every snapshot sharing this set.
+    pub fn withField(self: Set, allocator: std.mem.Allocator, field: u16) std.mem.Allocator.Error!Set {
+        if (self.contains(field)) return self;
+        var result = self;
+        const bit = @as(u64, 1) << @as(u6, @intCast(field % 64));
+        if (field < 64) {
+            result.low |= bit;
+        } else {
+            var high: High = if (self.high) |previous| previous.* else .{
+                .words = Snapshot(u64, 0).init(allocator, @as(usize, std.math.maxInt(u16)) / 64 + 1),
+                .last_word = 0,
+                .count = 0,
+            };
+            const word = field / 64;
+            high.words.allocator = allocator;
+            try high.words.put(word, high.words.get(word) | bit);
+            high.last_word = @max(high.last_word, word);
+            high.count += 1;
+            const stored = try allocator.create(High);
+            stored.* = high;
+            result.high = stored;
+        }
+        return result;
+    }
+
+    pub fn isSingleton(self: Set, field: u16) bool {
+        const count: usize = @as(usize, @popCount(self.low)) + if (self.high) |high| high.count else @as(usize, 0);
+        return count == 1 and self.contains(field);
+    }
+
+    pub fn eql(self: Set, other: Set) bool {
+        if (self.low != other.low) return false;
+        if (self.high == other.high) return true;
+        const left = self.high orelse return false;
+        const right = other.high orelse return false;
+        return left.count == right.count and left.last_word == right.last_word and left.words.eql(&right.words);
+    }
+
+    pub fn hashInto(self: Set, hasher: *std.hash.Wyhash) void {
+        hasher.update(std.mem.asBytes(&self.low));
+        const last_word: u16 = if (self.high) |high| high.last_word else 0;
+        hasher.update(std.mem.asBytes(&last_word));
+        if (self.high) |high| {
+            for (1..@as(usize, last_word) + 1) |index| {
+                const word = high.words.get(@intCast(index));
+                hasher.update(std.mem.asBytes(&word));
+            }
+        }
+    }
+};
+
+test "field claims preserve inline and wide identities across forks" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const fields = [_]u16{ 0, 63, 64, 128, std.math.maxInt(u16) };
+    var forward: Set = .{};
+    for (fields) |field| {
+        const prior = forward;
+        forward = try forward.withField(allocator, field);
+        try std.testing.expect(!prior.contains(field));
+        try std.testing.expect(forward.contains(field));
+    }
+    var reverse: Set = .{};
+    var remaining = fields.len;
+    while (remaining != 0) {
+        remaining -= 1;
+        reverse = try reverse.withField(allocator, fields[remaining]);
+    }
+    try std.testing.expect(forward.eql(reverse));
+    var forward_hash = std.hash.Wyhash.init(0);
+    var reverse_hash = std.hash.Wyhash.init(0);
+    forward.hashInto(&forward_hash);
+    reverse.hashInto(&reverse_hash);
+    try std.testing.expectEqual(forward_hash.final(), reverse_hash.final());
+    const different = try reverse.withField(allocator, 129);
+    try std.testing.expect(!forward.eql(different));
+}
+
+test "inline field claims allocate no storage" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    var fields: Set = .{};
+    for (0..64) |index| fields = try fields.withField(failing.allocator(), @intCast(index));
+    try std.testing.expectEqual(std.math.maxInt(u64), fields.low);
+    try std.testing.expect(fields.high == null);
+    try std.testing.expectError(error.OutOfMemory, fields.withField(failing.allocator(), 64));
+    try std.testing.expect(!fields.contains(64));
+}


### PR DESCRIPTION
Fix Debug compilation aborting when Boxy closures capture wide records: ARC certification used a 64-bit field mask and rejected high field indices even when those fields owned no resources. Track exact committed field identities across ownership transfers, joins, and residual shells, keeping small sets inline and sharing sparse storage for wider sets.

Based on #11194.
