### PR TITLE
Fix nested specialization evidence and redundant lookups

### DIFF
--- a/design.md
+++ b/design.md
@@ -7480,7 +7480,11 @@ is local to the scan and uses pooled scratch, so a later lookup observes any
 intervening unions. Evidence, capture, and exact interface checks still decide
 whether a candidate may be reused. Probe work is proportional to interface
 positions plus the members of distinct classes, even when many positions share
-one class.
+one class. The index interns the exact family and evidence-digest prefix once
+per request, using an append-only index-local ID in each interface key. Growing
+the index during recursive lowering does not invalidate those IDs. Request
+kinds remain disjoint, and interning a prefix does not replace exact candidate
+validation.
 
 Type-shaped inspection that can escape relation production or become durable
 specialization identity is allowed only for a fully resolved graph node. It

--- a/design.md
+++ b/design.md
@@ -7414,6 +7414,9 @@ Entering a restored nested body recreates its lexical substitutions in that
 body's instantiation context, consuming saved callable/capture interfaces and
 retained hidden method contracts. Descendant contexts then use ordinary live
 bindings; decoding stored evidence never attaches graph cells to durable data.
+Restoring a compile-time evaluation template installs its checked scheme and
+fresh substitution in the body context even when its method evidence is already
+supplied or empty. Nested bodies consume that frame's exact type bindings.
 
 Type-only instantiation state is separate from operational body-lowering state.
 Creating a fresh checked-type instance swaps only its exact scope, checked-node

--- a/design.md
+++ b/design.md
@@ -7375,6 +7375,25 @@ strings, deriving names, inspecting layouts, or using incidental expression
 shape. It must also not attach a contextual monotype to a checked expression id
 as if that checked expression were a reusable runtime value.
 
+Nested procedure sites carry a compact checked inventory of the quantified type
+bindings their bodies consume, including use-site substitutions whose hidden
+receivers are absent from captured value types. Each binding names its checked
+type, lexical dispatch scope, and substitution slot. The existing nested-site
+walk produces this inventory from checked expression, pattern, and dispatch
+interfaces; it does not add a second body scan. Type visitation is cycle-safe,
+and nested sites propagate their required bindings to their lexical parents.
+Before instantiating a nested body, Monotype installs these exact bindings from
+its selected lexical evidence frames. Locally quantified variables consume that
+nested specialization's own substitution; they never share another request's
+cells. Construction of a new generalized scope imports only bindings owned by
+its enclosing scopes. Work at each specialization is proportional to the
+recorded bindings, not to the size of the enclosing scheme or its type-node map.
+Stored function evidence remains graph-free across root and cache boundaries.
+Entering a restored nested body recreates its lexical substitutions in that
+body's instantiation context, consuming saved callable/capture interfaces and
+retained hidden method contracts. Descendant contexts then use ordinary live
+bindings; decoding stored evidence never attaches graph cells to durable data.
+
 Type-only instantiation state is separate from operational body-lowering state.
 Creating a fresh checked-type instance swaps only its exact scope, checked-node
 cache, and nominal declaration-scope stack; it does not construct a parallel
@@ -7452,6 +7471,16 @@ final Monotype body is emitted.
 During active Monotype specialization, unresolved checked variables and row
 extensions remain instantiation graph nodes. They are not represented by
 durable Monotype `TypeId`s.
+
+Open draft specialization indexes retain permanent interface node ids. A lookup
+visits each current union-find class once and probes all its permanent members;
+repeated argument or return positions do not repeat those probes. Candidate
+inspection does not merge existing classes during this scan. Its visited set
+is local to the scan and uses pooled scratch, so a later lookup observes any
+intervening unions. Evidence, capture, and exact interface checks still decide
+whether a candidate may be reused. Probe work is proportional to interface
+positions plus the members of distinct classes, even when many positions share
+one class.
 
 Type-shaped inspection that can escape relation production or become durable
 specialization identity is allowed only for a fully resolved graph node. It

--- a/design.md
+++ b/design.md
@@ -7505,7 +7505,11 @@ one class. The index interns the exact family and evidence-digest prefix once
 per request, using an append-only index-local ID in each interface key. Growing
 the index during recursive lowering does not invalidate those IDs. Request
 kinds remain disjoint, and interning a prefix does not replace exact candidate
-validation.
+validation. Permanent-node requests use the prefix ID and node ID directly in
+a separate index; only structural type and open-shape requests carry digests.
+Each bucket stores its first candidate inline. Additional candidates occupy
+an append-only table of overflow lists, retaining insertion order and exact
+duplicate detection across index and table growth.
 
 Type-shaped inspection that can escape relation production or become durable
 specialization identity is allowed only for a fully resolved graph node. It

--- a/design.md
+++ b/design.md
@@ -7416,7 +7416,9 @@ retained hidden method contracts. Descendant contexts then use ordinary live
 bindings; decoding stored evidence never attaches graph cells to durable data.
 Restoring a compile-time evaluation template installs its checked scheme and
 fresh substitution in the body context even when its method evidence is already
-supplied or empty. Nested bodies consume that frame's exact type bindings.
+supplied or empty. Pending callable evaluation wrappers install the same frame
+before lowering their bodies, whether the requested callable type is sealed or
+still a graph node. Nested bodies consume that frame's exact type bindings.
 
 Type-only instantiation state is separate from operational body-lowering state.
 Creating a fresh checked-type instance swaps only its exact scope, checked-node

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -20142,6 +20142,14 @@ pub const NestedProcSiteOwner = union(enum) {
     default_root,
 };
 
+/// A quantified checked identity used by a nested body. The lexical depth
+/// and slot address its exact specialization substitution.
+pub const NestedProcTypeBinding = struct {
+    ty: CheckedTypeId,
+    depth: u32,
+    slot: u32,
+};
+
 /// Public `NestedProcSite` declaration.
 pub const NestedProcSite = struct {
     site: canonical.NestedProcSiteId,
@@ -20153,6 +20161,8 @@ pub const NestedProcSite = struct {
     /// Exact range in `StaticDispatchPlanTable.evidence_refs` when
     /// `evidence_source == .checked_site`; empty otherwise.
     evidence: artifact_serialize.Span,
+    /// Exact used scheme slots, sorted from the innermost lexical frame out.
+    type_bindings: artifact_serialize.Span = .{},
     /// Range into the owning `NestedProcSiteTable.path_components` pool. Stored as
     /// a POD `(start,len)` (transform B) instead of an embedded slice so the
     /// element relocates with a single fixup.
@@ -20171,6 +20181,7 @@ pub const NestedProcSite = struct {
 /// Public `NestedProcSiteTable` declaration.
 pub const NestedProcSiteTable = struct {
     sites: []NestedProcSite = &.{},
+    type_bindings: []NestedProcTypeBinding = &.{},
     template_refs: []canonical.NestedProcSiteId = &.{},
     /// Flat pool of all sites' path components (transform-B side list). Each site
     /// holds a `(path_start, path_len)` range into this.
@@ -20178,6 +20189,7 @@ pub const NestedProcSiteTable = struct {
 
     pub const Serialized = extern struct {
         sites: SerializedSlice(NestedProcSite) = .{},
+        type_bindings: SerializedSlice(NestedProcTypeBinding) = .{},
         template_refs: SerializedSlice(canonical.NestedProcSiteId) = .{},
         path_components: SerializedSlice(NestedProcPathComponent) = .{},
         const Serde = artifact_serialize.SliceStoreSerde(NestedProcSiteTable, @This());
@@ -20188,6 +20200,7 @@ pub const NestedProcSiteTable = struct {
     pub fn fromTemplates(
         allocator: Allocator,
         checked_bodies: *const CheckedBodyStore,
+        checked_types: *const CheckedTypeStore,
         static_dispatch_plans: *const static_dispatch.StaticDispatchPlanTable,
         method_registry: *const static_dispatch.MethodRegistry,
         entry_wrappers: *const EntryWrapperTable,
@@ -20198,6 +20211,8 @@ pub const NestedProcSiteTable = struct {
         var builder = NestedProcSiteBuilder.init(
             allocator,
             checked_bodies,
+            checked_types,
+            templates,
             static_dispatch_plans,
             method_registry,
             templates.dispatch_scopes,
@@ -20239,8 +20254,11 @@ pub const NestedProcSiteTable = struct {
         const path_components = try builder.path_pool.toOwnedSlice(allocator);
         errdefer allocator.free(path_components);
 
+        const type_bindings = try builder.type_binding_pool.toOwnedSlice(allocator);
+        errdefer allocator.free(type_bindings);
         return .{
             .sites = sites,
+            .type_bindings = type_bindings,
             .template_refs = try builder.template_refs.toOwnedSlice(allocator),
             .path_components = path_components,
         };
@@ -20248,6 +20266,7 @@ pub const NestedProcSiteTable = struct {
 
     pub fn deinit(self: *NestedProcSiteTable, allocator: Allocator) void {
         allocator.free(self.sites);
+        allocator.free(self.type_bindings);
         allocator.free(self.template_refs);
         allocator.free(@constCast(self.path_components));
         self.* = .{};
@@ -20844,6 +20863,15 @@ fn nestedProcLexicalScope(
 const NestedProcSiteBuilder = struct {
     allocator: Allocator,
     checked_bodies: *const CheckedBodyStore,
+    checked_types: *const CheckedTypeStore,
+    templates: *const CheckedProcedureTemplateTable,
+    lexical_bindings: collections.DenseMap(CheckedTypeId, NestedProcTypeBinding),
+    binding_undo: std.ArrayList(struct { ty: CheckedTypeId, previous: ?NestedProcTypeBinding }),
+    type_binding_pool: std.ArrayList(NestedProcTypeBinding),
+    capture_frames: std.ArrayList(TypeCaptureFrame),
+    capture_depth: usize = 0,
+    evidence_depth: u32 = 0,
+
     static_dispatch_plans: *const static_dispatch.StaticDispatchPlanTable,
     method_registry: *const static_dispatch.MethodRegistry,
     dispatch_scopes: []const DispatchRefScope,
@@ -20855,9 +20883,18 @@ const NestedProcSiteBuilder = struct {
     /// Accumulated flat pool of every site's path; moved into the finished table.
     path_pool: std.ArrayList(NestedProcPathComponent),
 
+    const TypeCaptureFrame = struct {
+        site: canonical.NestedProcSiteId,
+        evidence_depth: u32 = 0,
+        visited: collections.DenseMap(CheckedTypeId, void),
+        bindings: std.ArrayList(NestedProcTypeBinding) = .empty,
+    };
+
     fn init(
         allocator: Allocator,
         checked_bodies: *const CheckedBodyStore,
+        checked_types: *const CheckedTypeStore,
+        templates: *const CheckedProcedureTemplateTable,
         static_dispatch_plans: *const static_dispatch.StaticDispatchPlanTable,
         method_registry: *const static_dispatch.MethodRegistry,
         dispatch_scopes: []const DispatchRefScope,
@@ -20866,6 +20903,12 @@ const NestedProcSiteBuilder = struct {
         return .{
             .allocator = allocator,
             .checked_bodies = checked_bodies,
+            .checked_types = checked_types,
+            .templates = templates,
+            .lexical_bindings = collections.DenseMap(CheckedTypeId, NestedProcTypeBinding).init(allocator),
+            .binding_undo = .empty,
+            .type_binding_pool = .empty,
+            .capture_frames = .empty,
             .static_dispatch_plans = static_dispatch_plans,
             .method_registry = method_registry,
             .dispatch_scopes = dispatch_scopes,
@@ -20880,41 +20923,147 @@ const NestedProcSiteBuilder = struct {
 
     fn deinitScratch(self: *NestedProcSiteBuilder) void {
         self.path.deinit(self.allocator);
+        self.lexical_bindings.deinit();
+        self.binding_undo.deinit(self.allocator);
+        for (self.capture_frames.items) |*frame| {
+            frame.visited.deinit();
+            frame.bindings.deinit(self.allocator);
+        }
+        self.capture_frames.deinit(self.allocator);
     }
 
     fn deinitAll(self: *NestedProcSiteBuilder) void {
         self.sites.deinit(self.allocator);
         self.template_refs.deinit(self.allocator);
-        self.path.deinit(self.allocator);
         self.path_pool.deinit(self.allocator);
-        self.* = NestedProcSiteBuilder.init(
+        self.type_binding_pool.deinit(self.allocator);
+    }
+
+    fn enterTypeScope(self: *NestedProcSiteBuilder, vars: []const CheckedTypeId) Allocator.Error!void {
+        for (vars, 0..) |ty, slot| {
+            const entry = try self.lexical_bindings.getOrPut(ty);
+            try self.binding_undo.append(self.allocator, .{ .ty = ty, .previous = if (entry.found_existing) entry.value_ptr.* else null });
+            entry.value_ptr.* = .{ .ty = ty, .depth = self.evidence_depth, .slot = @intCast(slot) };
+        }
+    }
+
+    fn leaveTypeScope(self: *NestedProcSiteBuilder, mark: usize) void {
+        while (self.binding_undo.items.len > mark) {
+            const undo = self.binding_undo.pop().?;
+            if (undo.previous) |previous| {
+                self.lexical_bindings.getPtr(undo.ty).?.* = previous;
+            } else {
+                _ = self.lexical_bindings.remove(undo.ty);
+            }
+        }
+    }
+
+    fn beginTypeCaptures(self: *NestedProcSiteBuilder, site: canonical.NestedProcSiteId) Allocator.Error!void {
+        if (self.capture_depth == self.capture_frames.items.len) {
+            try self.capture_frames.append(self.allocator, .{
+                .site = site,
+                .visited = collections.DenseMap(CheckedTypeId, void).init(self.allocator),
+            });
+        }
+        const frame = &self.capture_frames.items[self.capture_depth];
+        frame.site = site;
+        frame.evidence_depth = self.evidence_depth;
+        frame.visited.clearRetainingCapacity();
+        frame.bindings.clearRetainingCapacity();
+        self.capture_depth += 1;
+    }
+
+    fn finishTypeCaptures(self: *NestedProcSiteBuilder) Allocator.Error!void {
+        self.capture_depth -= 1;
+        const frame = &self.capture_frames.items[self.capture_depth];
+        for (frame.bindings.items) |*binding| binding.depth = frame.evidence_depth - binding.depth;
+        std.mem.sort(NestedProcTypeBinding, frame.bindings.items, {}, struct {
+            fn lessThan(_: void, a: NestedProcTypeBinding, b: NestedProcTypeBinding) bool {
+                return if (a.depth == b.depth) a.slot < b.slot else a.depth < b.depth;
+            }
+        }.lessThan);
+        self.sites.items[@intFromEnum(frame.site)].type_bindings = try artifact_serialize.appendSpan(
+            artifact_serialize.Span,
+            NestedProcTypeBinding,
+            &self.type_binding_pool,
             self.allocator,
-            self.checked_bodies,
-            self.static_dispatch_plans,
-            self.method_registry,
-            self.dispatch_scopes,
-            self.scope_by_checked_expr,
+            frame.bindings.items,
         );
+        // A descendant can need an enclosing binding without its parent
+        // mentioning that type in any runtime value.
+        for (frame.bindings.items) |binding| try self.captureType(binding.ty);
+    }
+
+    fn captureType(self: *NestedProcSiteBuilder, ty: CheckedTypeId) Allocator.Error!void {
+        if (self.capture_depth == 0 or !self.checked_types.rootContainsIdentityVariables(ty)) return;
+        const frame = &self.capture_frames.items[self.capture_depth - 1];
+        if ((try frame.visited.getOrPut(ty)).found_existing) return;
+        if (self.lexical_bindings.get(ty)) |binding| {
+            try frame.bindings.append(self.allocator, binding);
+            return;
+        }
+        switch (self.checked_types.payload(ty)) {
+            .pending => checkedArtifactInvariant("pending type in nested procedure binding inventory", .{}),
+            .err, .flex, .rigid, .empty_record, .empty_tag_union => {},
+            .alias => |alias| {
+                for (alias.args) |arg| try self.captureType(arg);
+                try self.captureType(alias.backing);
+            },
+            .record => |record| {
+                try self.captureFields(record.fields);
+                try self.captureType(record.ext);
+            },
+            .record_unbound => |fields| try self.captureFields(fields),
+            .tuple => |items| for (items) |item| {
+                try self.captureType(item);
+            },
+            .nominal => |nominal| for (nominal.args) |arg| {
+                try self.captureType(arg);
+            },
+            .function => |function| {
+                for (function.args) |arg| try self.captureType(arg);
+                try self.captureType(function.ret);
+            },
+            .tag_union => |tags| {
+                for (tags.tags) |tag| for (tag.argsSlice(self.checked_types)) |arg| {
+                    try self.captureType(arg);
+                };
+                try self.captureType(tags.ext);
+            },
+        }
+    }
+
+    fn captureFields(self: *NestedProcSiteBuilder, fields: []const CheckedRecordField) Allocator.Error!void {
+        for (fields) |field| {
+            if (field.kind.undeterminedVariable()) |variable| try self.captureType(variable);
+            try self.captureType(field.ty);
+        }
     }
 
     fn scanCheckedBody(
         self: *NestedProcSiteBuilder,
         body_id: CheckedBodyId,
-        _: *const CheckedProcedureTemplate,
+        template: *const CheckedProcedureTemplate,
     ) Allocator.Error!void {
         const body = self.checked_bodies.body(body_id);
         self.path.clearRetainingCapacity();
         self.current_scope = .root;
+        const mark = self.binding_undo.items.len;
+        defer self.leaveTypeScope(mark);
+        try self.enterTypeScope(self.templates.templateSchemeVars(template));
         try self.scanExpr(body.root_expr, .{ .template = body.owner_template }, true);
     }
 
     fn scanEntryWrapper(
         self: *NestedProcSiteBuilder,
         wrapper: EntryWrapper,
-        _: *const CheckedProcedureTemplate,
+        template: *const CheckedProcedureTemplate,
     ) Allocator.Error!void {
         self.path.clearRetainingCapacity();
         self.current_scope = .root;
+        const mark = self.binding_undo.items.len;
+        defer self.leaveTypeScope(mark);
+        try self.enterTypeScope(self.templates.templateSchemeVars(template));
         try self.scanExpr(wrapper.body_expr, .{ .template = wrapper.template }, false);
     }
 
@@ -20984,18 +21133,34 @@ const NestedProcSiteBuilder = struct {
             self.dispatch_scopes,
         );
         defer self.current_scope = previous_scope;
-
+        const capture_mark = self.capture_depth;
         const expr = self.checked_bodies.expr(expr_id);
+        try self.captureType(expr.ty);
+        const binding_mark = self.binding_undo.items.len;
+        const previous_evidence_depth = self.evidence_depth;
+        defer self.leaveTypeScope(binding_mark);
+        defer self.evidence_depth = previous_evidence_depth;
+        if (!std.meta.eql(self.current_scope, previous_scope)) switch (self.current_scope) {
+            .generalized => |scope| {
+                self.evidence_depth += 1;
+                try self.enterTypeScope(self.templates.scopeSchemeVars(&self.dispatch_scopes[@intFromEnum(scope)]));
+            },
+            .root => unreachable,
+        };
         switch (expr.data) {
             .closure => |closure| {
                 if (!suppress_current_site) {
                     try self.addSite(owner, .closure, expr_id, null);
+                    try self.beginTypeCaptures(@enumFromInt(@as(u32, @intCast(self.sites.items.len - 1))));
+                    try self.captureType(expr.ty);
                 }
                 try self.scanExpr(closure.lambda, owner, true);
             },
             .lambda => |lambda| {
                 if (!suppress_current_site) {
                     try self.addSite(owner, .local_function, expr_id, null);
+                    try self.beginTypeCaptures(@enumFromInt(@as(u32, @intCast(self.sites.items.len - 1))));
+                    try self.captureType(expr.ty);
                 }
                 for (lambda.args) |arg| try self.scanPattern(arg, owner);
                 try self.scanExpr(lambda.body, owner, false);
@@ -21079,17 +21244,21 @@ const NestedProcSiteBuilder = struct {
             .hosted_lambda => |hosted| {
                 if (!suppress_current_site) {
                     try self.addSite(owner, .local_function, expr_id, null);
+                    try self.beginTypeCaptures(@enumFromInt(@as(u32, @intCast(self.sites.items.len - 1))));
+                    try self.captureType(expr.ty);
                 }
                 for (hosted.args) |arg| try self.scanPattern(arg, owner);
             },
             .run_low_level => |run| {
                 for (run.args) |arg| try self.scanExpr(arg, owner, false);
             },
+            .lookup_local, .lookup_external, .lookup_required => {
+                if (self.static_dispatch_plans.siteSubstitution(expr_id)) |substitution| {
+                    for (substitution) |ty| try self.captureType(ty);
+                }
+            },
             .str_segment,
             .bytes_literal,
-            .lookup_local,
-            .lookup_external,
-            .lookup_required,
             .empty_list,
             .empty_record,
             .zero_argument_tag,
@@ -21099,6 +21268,10 @@ const NestedProcSiteBuilder = struct {
             .anno_only,
             .pending,
             => {},
+        }
+        if (self.capture_depth > capture_mark) {
+            self.leaveTypeScope(binding_mark);
+            try self.finishTypeCaptures();
         }
     }
 
@@ -21112,6 +21285,8 @@ const NestedProcSiteBuilder = struct {
             checkedArtifactInvariant("checked template static-dispatch plan id was outside the plan table", .{});
         }
         const plan = self.static_dispatch_plans.plans[raw];
+        try self.captureType(plan.dispatcher_ty);
+        try self.captureType(plan.callable_ty);
         for (plan.argsSlice(self.static_dispatch_plans)) |arg| switch (arg) {
             .checked_expr => |expr| try self.scanExpr(expr, owner, false),
             .generated_interpolation_iter => |expr| try self.scanGeneratedInterpolationIter(expr, owner),
@@ -21144,6 +21319,7 @@ const NestedProcSiteBuilder = struct {
         defer self.path.items.len -= 1;
 
         const pattern = self.checked_bodies.pattern(pattern_id);
+        try self.captureType(pattern.ty);
         switch (pattern.data) {
             .as => |as| try self.scanPattern(as.pattern, owner),
             .applied_tag => |tag| {
@@ -21264,6 +21440,51 @@ const NestedProcSiteBuilder = struct {
         }
     }
 };
+
+test "nested type bindings are sparse, lexical, transitive, and cycle safe" {
+    const allocator = std.testing.allocator;
+    var store = CheckedTypeStore{};
+    defer store.deinit(allocator);
+    var vars: [4]CheckedTypeId = undefined;
+    for (&vars, 0..) |*var_, i| {
+        var_.* = try store.reserveSyntheticTypeRoot(allocator, testCanonicalTypeKey(@intCast(i + 190)), true);
+        try store.fillSyntheticTypeRoot(allocator, var_.*, .{ .flex = .{} });
+    }
+    const cycle = try store.reserveSyntheticTypeRoot(allocator, testCanonicalTypeKey(194), true);
+    try store.fillSyntheticTypeRoot(allocator, cycle, .{ .tuple = try allocator.dupe(CheckedTypeId, &.{ vars[0], cycle }) });
+    var scopes = collections.DenseMap(CheckedExprId, DispatchScopeId).init(allocator);
+    defer scopes.deinit();
+    var builder = NestedProcSiteBuilder.init(allocator, undefined, &store, undefined, undefined, undefined, &.{}, &scopes);
+    defer builder.deinitScratch();
+    defer builder.deinitAll();
+    try builder.enterTypeScope(&vars);
+    try builder.addSite(.default_root, .local_function, null, null);
+    try builder.beginTypeCaptures(@enumFromInt(0));
+    const mark = builder.binding_undo.items.len;
+    builder.evidence_depth = 1;
+    try builder.enterTypeScope(&.{vars[1]});
+    // addSite consumes checked scope metadata, which this type-only test
+    // does not need: both sites use a root declaration for construction.
+    try builder.addSite(.default_root, .local_function, null, null);
+    try builder.beginTypeCaptures(@enumFromInt(1));
+    try builder.captureType(vars[1]);
+    try builder.captureType(cycle);
+    try builder.captureType(cycle);
+    builder.leaveTypeScope(mark);
+    builder.evidence_depth = 0;
+    try builder.finishTypeCaptures();
+    try builder.finishTypeCaptures();
+    const inner = builder.sites.items[1].type_bindings;
+    try std.testing.expectEqualSlices(NestedProcTypeBinding, &.{
+        .{ .ty = vars[1], .depth = 0, .slot = 0 },
+        .{ .ty = vars[0], .depth = 1, .slot = 0 },
+    }, builder.type_binding_pool.items[inner.start .. inner.start + inner.len]);
+    const outer = builder.sites.items[0].type_bindings;
+    try std.testing.expectEqualSlices(NestedProcTypeBinding, &.{
+        .{ .ty = vars[0], .depth = 0, .slot = 0 },
+        .{ .ty = vars[1], .depth = 0, .slot = 1 },
+    }, builder.type_binding_pool.items[outer.start .. outer.start + outer.len]);
+}
 
 /// Public `HostedProc` declaration.
 pub const HostedProc = struct {
@@ -30325,7 +30546,7 @@ pub const CheckedModuleArtifact = struct {
             // independent of stored data size. The optional-field body tables
             // add three pointers beyond the current-main count, and the
             // record-unset label pool one more.
-            std.debug.assert(artifact_serialize.relocatablePointerCount(Serialized) == 217);
+            std.debug.assert(artifact_serialize.relocatablePointerCount(Serialized) == 218);
         }
 
         /// Append every sub-store's bytes to `writer` in field order, recording
@@ -31832,6 +32053,24 @@ pub const CheckedModuleArtifact = struct {
             std.debug.assert(@intFromEnum(site.site) == i);
             std.debug.assert(site.path_len > 0);
             std.debug.assert(site.path_start + site.path_len <= self.nested_proc_sites.path_components.len);
+            const type_span = site.type_bindings;
+            std.debug.assert(type_span.start <= self.nested_proc_sites.type_bindings.len);
+            std.debug.assert(type_span.len <= self.nested_proc_sites.type_bindings.len - type_span.start);
+            var binding_scope = site.lexical_scope;
+            var binding_depth: u32 = 0;
+            for (self.nested_proc_sites.type_bindings[type_span.start .. type_span.start + type_span.len]) |binding| {
+                std.debug.assert(binding.depth >= binding_depth);
+                while (binding_depth < binding.depth) : (binding_depth += 1) {
+                    const scope = self.checked_procedure_templates.dispatch_scopes[@intFromEnum(binding_scope.generalized)];
+                    binding_scope = if (scope.parent) |parent| .{ .generalized = parent } else .root;
+                }
+                const vars = switch (binding_scope) {
+                    .root => self.checked_procedure_templates.templateSchemeVars(&self.checked_procedure_templates.templates.items[@intFromEnum(site.owner.template.template)]),
+                    .generalized => |scope| self.checked_procedure_templates.scopeSchemeVars(&self.checked_procedure_templates.dispatch_scopes[@intFromEnum(scope)]),
+                };
+                std.debug.assert(binding.slot < vars.len);
+                std.debug.assert(vars[binding.slot] == binding.ty);
+            }
             switch (site.owner) {
                 .template => |owner_template| std.debug.assert(@intFromEnum(owner_template.template) < self.checked_procedure_templates.templates.items.len),
                 // A default-root site always names its checked lambda/closure
@@ -34465,7 +34704,7 @@ pub fn publishFromTypedModule(
     );
     errdefer root_requests.deinit(allocator);
 
-    var nested_proc_sites = try NestedProcSiteTable.fromTemplates(allocator, checked_bodies, &static_dispatch_plans, &method_registry, &entry_wrappers, &checked_procedure_templates);
+    var nested_proc_sites = try NestedProcSiteTable.fromTemplates(allocator, checked_bodies, checked_types, &static_dispatch_plans, &method_registry, &entry_wrappers, &checked_procedure_templates);
     errdefer nested_proc_sites.deinit(allocator);
 
     sealConstEvalTemplatesForRoots(

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -21459,14 +21459,16 @@ test "nested type bindings are sparse, lexical, transitive, and cycle safe" {
     defer builder.deinitAll();
     try builder.enterTypeScope(&vars);
     try builder.addSite(.default_root, .local_function, null, null);
-    try builder.beginTypeCaptures(@enumFromInt(0));
+    const outer_site = builder.sites.items[builder.sites.items.len - 1].site;
+    try builder.beginTypeCaptures(outer_site);
     const mark = builder.binding_undo.items.len;
     builder.evidence_depth = 1;
     try builder.enterTypeScope(&.{vars[1]});
     // addSite consumes checked scope metadata, which this type-only test
     // does not need: both sites use a root declaration for construction.
     try builder.addSite(.default_root, .local_function, null, null);
-    try builder.beginTypeCaptures(@enumFromInt(1));
+    const inner_site = builder.sites.items[builder.sites.items.len - 1].site;
+    try builder.beginTypeCaptures(inner_site);
     try builder.captureType(vars[1]);
     try builder.captureType(cycle);
     try builder.captureType(cycle);
@@ -21474,12 +21476,12 @@ test "nested type bindings are sparse, lexical, transitive, and cycle safe" {
     builder.evidence_depth = 0;
     try builder.finishTypeCaptures();
     try builder.finishTypeCaptures();
-    const inner = builder.sites.items[1].type_bindings;
+    const inner = builder.sites.items[@intFromEnum(inner_site)].type_bindings;
     try std.testing.expectEqualSlices(NestedProcTypeBinding, &.{
         .{ .ty = vars[1], .depth = 0, .slot = 0 },
         .{ .ty = vars[0], .depth = 1, .slot = 0 },
     }, builder.type_binding_pool.items[inner.start .. inner.start + inner.len]);
-    const outer = builder.sites.items[0].type_bindings;
+    const outer = builder.sites.items[@intFromEnum(outer_site)].type_bindings;
     try std.testing.expectEqualSlices(NestedProcTypeBinding, &.{
         .{ .ty = vars[0], .depth = 0, .slot = 0 },
         .{ .ty = vars[1], .depth = 0, .slot = 1 },

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -1238,4 +1238,152 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "\"hi!\"" },
     },
+    .{
+        // https://github.com/roc-lang/roc/issues/11189
+        .name = "issue 11189: namespaced comparison helper called from a nested fold_with_index",
+        .source_kind = .module,
+        .source =
+        \\Point : { x : F64, y : F64 }
+        \\
+        \\Internals := {}.{
+        \\    proper = |a, b, c, d| {
+        \\        if a.x == b.x and c.y == d.y {
+        \\            c.x > a.x.min(b.x) and c.x < a.x.max(b.x) and a.y > c.y.min(d.y) and a.y < c.y.max(d.y)
+        \\        } else if a.y == b.y and c.x == d.x {
+        \\            a.x > c.x.min(d.x) and a.x < c.x.max(d.x) and c.y > a.y.min(b.y) and c.y < a.y.max(b.y)
+        \\        } else if a.x == b.x and c.x == d.x and a.x == c.x {
+        \\            a.y.min(b.y) < c.y.max(d.y) and a.y.max(b.y) > c.y.min(d.y)
+        \\        } else {
+        \\            False
+        \\        }
+        \\    }
+        \\
+        \\    simple = |points| points.fold_with_index(
+        \\        True,
+        \\        |simple, a, i| match points.get(i + 1) {
+        \\            Err(_) => simple
+        \\            Ok(b) => points.fold_with_index(
+        \\                simple,
+        \\                |clear, c, j| if j <= i + 1 {
+        \\                    clear
+        \\                } else {
+        \\                    match points.get(j + 1) {
+        \\                        Ok(d) => clear and !Internals.proper(a, b, c, d)
+        \\                        Err(_) => clear
+        \\                    }
+        \\                },
+        \\            )
+        \\        },
+        \\    )
+        \\}
+        \\
+        \\valid : List(Point) -> Bool
+        \\valid = |points| Internals.simple(points)
+        \\
+        \\main = valid([])
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "issue 11189: comparison branches execute at independent F64 and F32 specializations",
+        .source_kind = .module,
+        .source =
+        \\Point : { x : F64, y : F64 }
+        \\
+        \\Internals := {}.{
+        \\    proper = |a, b, c, d| {
+        \\        if a.x == b.x and c.y == d.y {
+        \\            c.x > a.x.min(b.x) and c.x < a.x.max(b.x) and a.y > c.y.min(d.y) and a.y < c.y.max(d.y)
+        \\        } else if a.y == b.y and c.x == d.x {
+        \\            a.x > c.x.min(d.x) and a.x < c.x.max(d.x) and c.y > a.y.min(b.y) and c.y < a.y.max(b.y)
+        \\        } else if a.x == b.x and c.x == d.x and a.x == c.x {
+        \\            a.y.min(b.y) < c.y.max(d.y) and a.y.max(b.y) > c.y.min(d.y)
+        \\        } else {
+        \\            False
+        \\        }
+        \\    }
+        \\
+        \\    simple = |points| points.fold_with_index(
+        \\        True,
+        \\        |simple, a, i| match points.get(i + 1) {
+        \\            Err(_) => simple
+        \\            Ok(b) => points.fold_with_index(
+        \\                simple,
+        \\                |clear, c, j| if j <= i + 1 {
+        \\                    clear
+        \\                } else {
+        \\                    match points.get(j + 1) {
+        \\                        Ok(d) => clear and !Internals.proper(a, b, c, d)
+        \\                        Err(_) => clear
+        \\                    }
+        \\                },
+        \\            )
+        \\        },
+        \\    )
+        \\}
+        \\
+        \\valid : List(Point) -> Bool
+        \\valid = |points| Internals.simple(points)
+        \\
+        \\valid32 : List({ x : F32, y : F32 }) -> Bool
+        \\valid32 = |points| Internals.simple(points)
+        \\
+        \\main = (
+        \\    valid([]),
+        \\    valid([{ x: 0, y: 0 }, { x: 0, y: 3 }, { x: 0, y: 1 }, { x: 0, y: 2 }]),
+        \\    valid32([{ x: 0, y: 0 }, { x: 0, y: 3 }, { x: 0, y: 1 }, { x: 0, y: 2 }]),
+        \\    valid([{ x: 0, y: 0 }, { x: 0, y: 2 }, { x: -1, y: 1 }, { x: 1, y: 1 }]),
+        \\    valid([{ x: 0, y: 0 }, { x: 2, y: 0 }, { x: 1, y: -1 }, { x: 1, y: 1 }]),
+        \\)
+        ,
+        .expected = .{ .inspect_str = "(True, False, False, True, True)" },
+    },
+    .{
+        .name = "issue 11189: hidden comparison receivers cross three nested folds",
+        .source_kind = .module,
+        .source =
+        \\Helpers := {}.{
+        \\    ordered = |a, b| a.min(b) <= a.max(b)
+        \\    run = |xs| xs.fold(True, |ok, a|
+        \\        xs.fold(ok, |yes, b|
+        \\            xs.fold(yes, |still, _| still and Helpers.ordered(a, b))))
+        \\}
+        \\
+        \\main = {
+        \\    xs : List(F64)
+        \\    xs = [2, 1]
+        \\    ys : List(I64)
+        \\    ys = [3, 1]
+        \\    (Helpers.run(xs), Helpers.run(ys))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(True, True)" },
+    },
+    .{
+        .name = "issue 11189: stored functions restore hidden comparison bindings independently",
+        .source_kind = .module,
+        .source =
+        \\Factory := {}.{
+        \\    ordered = |a, b| a.min(b) < a.max(b)
+        \\    make = |a, b| |{}| Factory.ordered(a, b)
+        \\}
+        \\
+        \\p : {} -> Bool
+        \\p = {
+        \\    a : F64
+        \\    a = 1
+        \\    Factory.make(a, 2)
+        \\}
+        \\
+        \\q : {} -> Bool
+        \\q = {
+        \\    a : I64
+        \\    a = 3
+        \\    Factory.make(a, 3)
+        \\}
+        \\
+        \\main = (p({}), q({}))
+        ,
+        .expected = .{ .inspect_str = "(True, False)" },
+    },
 };

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5984,13 +5984,16 @@ const Builder = struct {
         // interfaces below.
         const lookup_prefix = try source_ctx.draft.template_spec_lookup.internPrefix(family, evidence_digest.bytes);
         const resolved_lookup_address: ?DraftTemplateLookupAddress = if (resolved_request_ty) |request_fn_ty| .{
-            .prefix = lookup_prefix,
-            .request_kind = 0,
-            .request_fn_key = source_ctx.specializationTypeDigest(request_fn_ty).bytes,
+            .digest = .{
+                .prefix = lookup_prefix,
+                .kind = .closed,
+                .digest = source_ctx.specializationTypeDigest(request_fn_ty).bytes,
+            },
         } else null;
         if (resolved_lookup_address) |address| {
-            if (source_ctx.draft.template_spec_lookup.requests.get(address)) |candidates| {
-                for (candidates.items) |raw_spec| {
+            if (source_ctx.draft.template_spec_lookup.get(address)) |candidate_iterator| {
+                var candidates = candidate_iterator;
+                while (candidates.next()) |raw_spec| {
                     const spec = &source_ctx.draft.template_specs.items[raw_spec];
                     if (!specEvidenceVectorEql(spec.evidence, evidence)) continue;
                     if (!optionalTypeDigestEql(spec.lexical_context_key, lexical_context_key)) continue;
@@ -6012,12 +6015,14 @@ const Builder = struct {
                 var aliases = source_ctx.graph.classMemberIterator(interface_class);
                 while (aliases.next()) |member| {
                     const lookup_address = DraftTemplateLookupAddress{
-                        .prefix = lookup_prefix,
-                        .request_kind = 1,
-                        .request_fn_key = draftOpenRequestKey(member),
+                        .open = .{
+                            .prefix = lookup_prefix,
+                            .node = member,
+                        },
                     };
-                    if (source_ctx.draft.template_spec_lookup.requests.get(lookup_address)) |candidates| {
-                        for (candidates.items) |raw_spec| {
+                    if (source_ctx.draft.template_spec_lookup.get(lookup_address)) |candidate_iterator| {
+                        var candidates = candidate_iterator;
+                        while (candidates.next()) |raw_spec| {
                             const seen = try seen_specs.getOrPut(raw_spec);
                             if (seen.found_existing) continue;
                             const spec = &source_ctx.draft.template_specs.items[raw_spec];
@@ -6126,7 +6131,7 @@ const Builder = struct {
                     active_spec_fn_ty,
                     resolved_request_ty.?,
                 )) {
-                    try registerTemplateSpecLookup(source_ctx.draft, self.allocator, address, raw_spec);
+                    try registerTemplateSpecLookup(source_ctx.draft, address, raw_spec);
                 }
             }
             return .{ .local = .{ .draft = spec.fn_id } };
@@ -6211,7 +6216,7 @@ const Builder = struct {
             @intCast(spec_index),
         );
         if (resolved_lookup_address) |address| {
-            try registerTemplateSpecLookup(source_ctx.draft, self.allocator, address, @intCast(spec_index));
+            try registerTemplateSpecLookup(source_ctx.draft, address, @intCast(spec_index));
         }
         const owner_scope = try source_ctx.draft.enterOwner(.{ .draft_fn = fn_id });
         defer owner_scope.leave();
@@ -7959,18 +7964,22 @@ const Builder = struct {
             null;
         const lookup_prefix = try source_ctx.draft.nested_spec_lookup.internPrefix(family, evidence_digest.bytes);
         const resolved_lookup_address: ?DraftNestedLookupAddress = if (resolved_request_ty) |request_fn_ty| .{
-            .prefix = lookup_prefix,
-            .request_kind = 0,
-            .request_fn_key = source_ctx.specializationTypeDigest(request_fn_ty).bytes,
+            .digest = .{
+                .prefix = lookup_prefix,
+                .kind = .closed,
+                .digest = source_ctx.specializationTypeDigest(request_fn_ty).bytes,
+            },
         } else null;
         const open_request_shape: ?solve.OpenFunctionInterfaceShape = if (resolved_request_ty == null)
             try source_ctx.graph.openFunctionInterfaceShape(request_fn_node)
         else
             null;
         const open_shape_lookup_address: ?DraftNestedLookupAddress = if (open_request_shape) |shape| .{
-            .prefix = lookup_prefix,
-            .request_kind = 2,
-            .request_fn_key = shape.digest.bytes,
+            .digest = .{
+                .prefix = lookup_prefix,
+                .kind = .open_shape,
+                .digest = shape.digest.bytes,
+            },
         } else null;
         // Nested draft requests use the same graph-native identity discipline
         // as template requests; no resolved node becomes a durable cache key
@@ -7979,8 +7988,9 @@ const Builder = struct {
         defer seen_specs.deinit();
         var selection = DraftOpenCandidateSelection{};
         if (resolved_lookup_address) |address| {
-            if (source_ctx.draft.nested_spec_lookup.requests.get(address)) |candidates| {
-                for (candidates.items) |raw_spec| {
+            if (source_ctx.draft.nested_spec_lookup.get(address)) |candidate_iterator| {
+                var candidates = candidate_iterator;
+                while (candidates.next()) |raw_spec| {
                     self.countBodyDiagnostic("nested_lookup_probes");
                     const spec = &source_ctx.draft.nested_specs.items[raw_spec];
                     if (signature_relation == .exact_graph and
@@ -8002,8 +8012,9 @@ const Builder = struct {
         }
         if (family_exists and selection.selected() == null) {
             if (open_shape_lookup_address) |address| {
-                if (source_ctx.draft.nested_spec_lookup.requests.get(address)) |candidates| {
-                    for (candidates.items) |raw_spec| {
+                if (source_ctx.draft.nested_spec_lookup.get(address)) |candidate_iterator| {
+                    var candidates = candidate_iterator;
+                    while (candidates.next()) |raw_spec| {
                         self.countBodyDiagnostic("nested_lookup_probes");
                         const spec = &source_ctx.draft.nested_specs.items[raw_spec];
                         if (spec.state != .lowered) continue;
@@ -8032,12 +8043,14 @@ const Builder = struct {
                 while (aliases.next()) |member| {
                     self.countBodyDiagnostic("nested_lookup_probes");
                     const lookup_address = DraftNestedLookupAddress{
-                        .prefix = lookup_prefix,
-                        .request_kind = 1,
-                        .request_fn_key = draftOpenRequestKey(member),
+                        .open = .{
+                            .prefix = lookup_prefix,
+                            .node = member,
+                        },
                     };
-                    if (source_ctx.draft.nested_spec_lookup.requests.get(lookup_address)) |candidates| {
-                        for (candidates.items) |raw_spec| {
+                    if (source_ctx.draft.nested_spec_lookup.get(lookup_address)) |candidate_iterator| {
+                        var candidates = candidate_iterator;
+                        while (candidates.next()) |raw_spec| {
                             self.countBodyDiagnostic("nested_lookup_probes");
                             const seen = try seen_specs.getOrPut(raw_spec);
                             if (seen.found_existing) continue;
@@ -8192,22 +8205,21 @@ const Builder = struct {
             const indexed = try indexed_nodes.getOrPut(interface_node);
             if (indexed.found_existing) continue;
             const lookup_address = DraftNestedLookupAddress{
-                .prefix = lookup_prefix,
-                .request_kind = 1,
-                .request_fn_key = draftOpenRequestKey(interface_node),
+                .open = .{
+                    .prefix = lookup_prefix,
+                    .node = interface_node,
+                },
             };
-            const lookup_entry = try source_ctx.draft.nested_spec_lookup.requests.getOrPut(lookup_address);
-            if (!lookup_entry.found_existing) lookup_entry.value_ptr.* = .empty;
-            try lookup_entry.value_ptr.append(self.allocator, @intCast(spec_index));
+            try source_ctx.draft.nested_spec_lookup.add(lookup_address, @intCast(spec_index));
         }
         if (open_shape_lookup_address) |address| {
-            try registerNestedSpecLookup(source_ctx.draft, self.allocator, address, @intCast(spec_index));
+            try registerNestedSpecLookup(source_ctx.draft, address, @intCast(spec_index));
         }
         // A closed request has an exact interface before its body completes.
         // Index it now so recursive calls with fresh instantiation cells can
         // reuse this body through structural equality of the live interface.
         if (resolved_lookup_address) |address| {
-            try registerNestedSpecLookup(source_ctx.draft, self.allocator, address, @intCast(spec_index));
+            try registerNestedSpecLookup(source_ctx.draft, address, @intCast(spec_index));
         }
 
         const owner_scope = try source_ctx.draft.enterOwner(.{ .draft_fn = fn_id });
@@ -8274,10 +8286,12 @@ const Builder = struct {
         if (try source_ctx.graph.typeIsResolved(completed_fn_node)) {
             const completed_fn_ty = try source_ctx.activeTypeFromNode(completed_fn_node);
             source_ctx.draft.nested_specs.items[spec_index].request_fn_ty = completed_fn_ty;
-            try registerNestedSpecLookup(source_ctx.draft, self.allocator, .{
-                .prefix = lookup_prefix,
-                .request_kind = 0,
-                .request_fn_key = source_ctx.specializationTypeDigest(completed_fn_ty).bytes,
+            try registerNestedSpecLookup(source_ctx.draft, .{
+                .digest = .{
+                    .prefix = lookup_prefix,
+                    .kind = .closed,
+                    .digest = source_ctx.specializationTypeDigest(completed_fn_ty).bytes,
+                },
             }, @intCast(spec_index));
         }
         try registerNestedSpecInterfaceLookups(
@@ -12282,14 +12296,10 @@ fn draftCaptureEntryGuardsMatch(
 
 fn registerTemplateSpecLookup(
     draft: *BodyDraftStore,
-    allocator: Allocator,
     address: DraftTemplateLookupAddress,
     raw_spec: u32,
 ) Allocator.Error!void {
-    const entry = try draft.template_spec_lookup.requests.getOrPut(address);
-    if (!entry.found_existing) entry.value_ptr.* = .empty;
-    for (entry.value_ptr.items) |existing| if (existing == raw_spec) return;
-    try entry.value_ptr.append(allocator, raw_spec);
+    try draft.template_spec_lookup.add(address, raw_spec);
 }
 
 fn updateTemplateSpecInterfaceLookups(
@@ -12307,11 +12317,12 @@ fn updateTemplateSpecInterfaceLookups(
         const indexed = try indexed_nodes.getOrPut(interface_node);
         if (indexed.found_existing) continue;
         const address = DraftTemplateLookupAddress{
-            .prefix = lookup_prefix,
-            .request_kind = 1,
-            .request_fn_key = draftOpenRequestKey(interface_node),
+            .open = .{
+                .prefix = lookup_prefix,
+                .node = interface_node,
+            },
         };
-        try registerTemplateSpecLookup(draft, allocator, address, raw_spec);
+        try registerTemplateSpecLookup(draft, address, raw_spec);
     }
 }
 
@@ -12328,14 +12339,10 @@ fn draftNestedSpecRequestNode(
 
 fn registerNestedSpecLookup(
     draft: *BodyDraftStore,
-    allocator: Allocator,
     address: DraftNestedLookupAddress,
     raw_spec: u32,
 ) Allocator.Error!void {
-    const entry = try draft.nested_spec_lookup.requests.getOrPut(address);
-    if (!entry.found_existing) entry.value_ptr.* = .empty;
-    for (entry.value_ptr.items) |existing| if (existing == raw_spec) return;
-    try entry.value_ptr.append(allocator, raw_spec);
+    try draft.nested_spec_lookup.add(address, raw_spec);
 }
 
 fn registerNestedSpecInterfaceLookups(
@@ -12352,10 +12359,11 @@ fn registerNestedSpecInterfaceLookups(
     while (spec_interface.next()) |interface_node| {
         const indexed = try indexed_nodes.getOrPut(interface_node);
         if (indexed.found_existing) continue;
-        try registerNestedSpecLookup(draft, allocator, .{
-            .prefix = lookup_prefix,
-            .request_kind = 1,
-            .request_fn_key = draftOpenRequestKey(interface_node),
+        try registerNestedSpecLookup(draft, .{
+            .open = .{
+                .prefix = lookup_prefix,
+                .node = interface_node,
+            },
         }, raw_spec);
     }
 }
@@ -12537,33 +12545,115 @@ fn DraftSpecLookup(comptime Family: type) type {
             evidence_digest: [32]u8,
         };
         const PrefixId = enum(u32) { _ };
-        const Address = struct {
+        const OpenAddress = struct {
             prefix: PrefixId,
-            request_kind: u8,
-            request_fn_key: [32]u8,
+            node: NodeId,
+        };
+        const DigestAddress = struct {
+            prefix: PrefixId,
+            kind: enum { closed, open_shape },
+            digest: [32]u8,
+        };
+        const Address = union(enum) {
+            open: OpenAddress,
+            digest: DigestAddress,
+        };
+        const OverflowId = enum(u32) { none = std.math.maxInt(u32), _ };
+        const Candidates = struct {
+            first: u32,
+            overflow: OverflowId = .none,
+        };
+        const Iterator = struct {
+            first: ?u32,
+            rest: []const u32,
+
+            fn next(self: *Iterator) ?u32 {
+                if (self.first) |first| {
+                    self.first = null;
+                    return first;
+                }
+                if (self.rest.len == 0) return null;
+                const next_candidate = self.rest[0];
+                self.rest = self.rest[1..];
+                return next_candidate;
+            }
+        };
+        const Entry = struct {
+            value_ptr: *Candidates,
+            found_existing: bool,
         };
 
         allocator: Allocator,
         prefixes: std.array_hash_map.Auto(Prefix, void),
-        requests: std.AutoHashMap(Address, std.ArrayList(u32)),
+        open_requests: std.AutoHashMap(OpenAddress, Candidates),
+        digest_requests: std.AutoHashMap(DigestAddress, Candidates),
+        /// Only buckets with multiple candidates own an overflow list. Its
+        /// stable slot survives growth of both request indexes and this table.
+        overflow_lists: std.ArrayList(std.ArrayList(u32)),
 
         fn init(allocator: Allocator) Self {
             return .{
                 .allocator = allocator,
                 .prefixes = .empty,
-                .requests = std.AutoHashMap(Address, std.ArrayList(u32)).init(allocator),
+                .open_requests = std.AutoHashMap(OpenAddress, Candidates).init(allocator),
+                .digest_requests = std.AutoHashMap(DigestAddress, Candidates).init(allocator),
+                .overflow_lists = .empty,
             };
         }
 
         fn deinit(self: *Self) void {
-            var lists = self.requests.valueIterator();
-            while (lists.next()) |list| list.deinit(self.allocator);
-            self.requests.deinit();
+            self.open_requests.deinit();
+            self.digest_requests.deinit();
+            for (self.overflow_lists.items) |*list| list.deinit(self.allocator);
+            self.overflow_lists.deinit(self.allocator);
             self.prefixes.deinit(self.allocator);
         }
 
         fn isEmpty(self: *const Self) bool {
-            return self.prefixes.count() == 0 and self.requests.count() == 0;
+            return self.prefixes.count() == 0 and self.open_requests.count() == 0 and self.digest_requests.count() == 0 and self.overflow_lists.items.len == 0;
+        }
+
+        fn get(self: *const Self, address: Address) ?Iterator {
+            const candidates = switch (address) {
+                .open => |key| self.open_requests.get(key),
+                .digest => |key| self.digest_requests.get(key),
+            } orelse return null;
+            return .{
+                .first = candidates.first,
+                .rest = if (candidates.overflow == .none) &.{} else self.overflow_lists.items[@intFromEnum(candidates.overflow)].items,
+            };
+        }
+
+        fn getOrPut(self: *Self, address: Address) Allocator.Error!Entry {
+            return switch (address) {
+                inline .open, .digest => |key, tag| blk: {
+                    const map = &@field(self, @tagName(tag) ++ "_requests");
+                    const entry = try map.getOrPut(key);
+                    break :blk .{ .value_ptr = entry.value_ptr, .found_existing = entry.found_existing };
+                },
+            };
+        }
+
+        fn add(self: *Self, address: Address, raw_spec: u32) Allocator.Error!void {
+            const entry = try self.getOrPut(address);
+            if (!entry.found_existing) {
+                entry.value_ptr.* = .{ .first = raw_spec };
+                return;
+            }
+            if (entry.value_ptr.first == raw_spec) return;
+            if (entry.value_ptr.overflow != .none) {
+                const list = &self.overflow_lists.items[@intFromEnum(entry.value_ptr.overflow)];
+                for (list.items) |existing| if (existing == raw_spec) return;
+                try list.append(self.allocator, raw_spec);
+            } else {
+                if (self.overflow_lists.items.len == @intFromEnum(OverflowId.none)) return error.OutOfMemory;
+                var list: std.ArrayList(u32) = .empty;
+                errdefer list.deinit(self.allocator);
+                try list.append(self.allocator, raw_spec);
+                const overflow: OverflowId = @enumFromInt(self.overflow_lists.items.len);
+                try self.overflow_lists.append(self.allocator, list);
+                entry.value_ptr.overflow = overflow;
+            }
         }
 
         fn internPrefix(self: *Self, family: Family, evidence_digest: [32]u8) Allocator.Error!PrefixId {
@@ -12574,12 +12664,6 @@ fn DraftSpecLookup(comptime Family: type) type {
             return @enumFromInt(entry.index);
         }
     };
-}
-
-fn draftOpenRequestKey(node: NodeId) [32]u8 {
-    var bytes = [_]u8{0} ** 32;
-    std.mem.writeInt(u32, bytes[0..@sizeOf(u32)], @intFromEnum(node), .little);
-    return bytes;
 }
 
 const EagerTemplateResolution = struct {
@@ -32991,10 +33075,12 @@ const BodyContext = struct {
             completed_node,
             @intCast(spec_index),
         );
-        try registerTemplateSpecLookup(self.draft, self.allocator, .{
-            .prefix = lookup_prefix,
-            .request_kind = 0,
-            .request_fn_key = self.specializationTypeDigest(completed_ty).bytes,
+        try registerTemplateSpecLookup(self.draft, .{
+            .digest = .{
+                .prefix = lookup_prefix,
+                .kind = .closed,
+                .digest = self.specializationTypeDigest(completed_ty).bytes,
+            },
         }, raw_spec);
         return completed_node;
     }
@@ -55085,16 +55171,14 @@ test "draft specialization lookup preserves family evidence and request identity
         // The same bytes can name a structural type, a permanent graph node,
         // or an open shape. Those request domains must remain disjoint.
         const addresses = [_]Lookup.Address{
-            .{ .prefix = prefix, .request_kind = 0, .request_fn_key = @splat(0) },
-            .{ .prefix = prefix, .request_kind = 1, .request_fn_key = @splat(0) },
-            .{ .prefix = prefix, .request_kind = 2, .request_fn_key = @splat(0) },
-            .{ .prefix = prefix, .request_kind = 1, .request_fn_key = draftOpenRequestKey(@enumFromInt(1)) },
+            .{ .digest = .{ .prefix = prefix, .kind = .closed, .digest = @splat(0) } },
+            .{ .open = .{ .prefix = prefix, .node = @enumFromInt(0) } },
+            .{ .digest = .{ .prefix = prefix, .kind = .open_shape, .digest = @splat(0) } },
+            .{ .open = .{ .prefix = prefix, .node = @enumFromInt(1) } },
         };
         for (addresses, 0..) |address, raw_spec| {
-            const entry = try lookup.requests.getOrPut(address);
-            try std.testing.expect(!entry.found_existing);
-            entry.value_ptr.* = .empty;
-            try entry.value_ptr.append(allocator, @intCast(raw_spec));
+            try std.testing.expect(lookup.get(address) == null);
+            try lookup.add(address, @intCast(raw_spec));
         }
 
         // Every family qualifier and evidence byte contributes to identity.
@@ -55115,9 +55199,9 @@ test "draft specialization lookup preserves family evidence and request identity
                 const other = try lookup.internPrefix(different_family, evidence);
                 try std.testing.expect(other != prefix);
                 var address = addresses[0];
-                address.prefix = other;
-                try std.testing.expect(lookup.requests.get(address) == null);
-                try lookup.requests.put(address, .empty);
+                address.digest.prefix = other;
+                try std.testing.expect(lookup.get(address) == null);
+                try lookup.add(address, 0);
             }
         }
         for (0..evidence.len) |byte| {
@@ -55126,14 +55210,15 @@ test "draft specialization lookup preserves family evidence and request identity
             const other = try lookup.internPrefix(family, different_evidence);
             try std.testing.expect(other != prefix);
             var address = addresses[0];
-            address.prefix = other;
-            try std.testing.expect(lookup.requests.get(address) == null);
-            try lookup.requests.put(address, .empty);
+            address.digest.prefix = other;
+            try std.testing.expect(lookup.get(address) == null);
+            try lookup.add(address, 0);
         }
         try std.testing.expectEqual(prefix, try lookup.internPrefix(family, evidence));
         for (addresses, 0..) |address, raw_spec| {
-            const candidates = lookup.requests.get(address).?;
-            try std.testing.expectEqualSlices(u32, &.{@intCast(raw_spec)}, candidates.items);
+            var candidates = lookup.get(address).?;
+            try std.testing.expectEqual(@as(u32, @intCast(raw_spec)), candidates.next().?);
+            try std.testing.expect(candidates.next() == null);
         }
 
         lookup.deinit();
@@ -55141,9 +55226,61 @@ test "draft specialization lookup preserves family evidence and request identity
         try std.testing.expect(lookup.isEmpty());
         const fresh_prefix = try lookup.internPrefix(family, evidence);
         var address = addresses[0];
-        address.prefix = fresh_prefix;
-        try std.testing.expect(lookup.requests.get(address) == null);
+        address.digest.prefix = fresh_prefix;
+        try std.testing.expect(lookup.get(address) == null);
     }
+}
+
+test "draft specialization candidates retain insertion order across overflow growth and allocation failure" {
+    const Scenario = struct {
+        fn run(allocator: Allocator) !void {
+            inline for (.{ DraftTemplateFamilyAddress, DraftNestedFamilyAddress }) |Family| {
+                const Lookup = DraftSpecLookup(Family);
+                var lookup = Lookup.init(allocator);
+                defer lookup.deinit();
+                const prefix = try lookup.internPrefix(std.mem.zeroes(Family), @splat(0));
+                const addresses = [_]Lookup.Address{
+                    .{ .open = .{ .prefix = prefix, .node = @enumFromInt(0) } },
+                    .{ .digest = .{ .prefix = prefix, .kind = .closed, .digest = @splat(0) } },
+                    .{ .digest = .{ .prefix = prefix, .kind = .open_shape, .digest = @splat(0) } },
+                };
+                for (addresses) |address| {
+                    // Every u32 is a valid candidate ID, including zero and
+                    // the maximum value; neither acts as an empty marker.
+                    try lookup.add(address, std.math.maxInt(u32));
+                    for (0..20) |i| {
+                        const raw_spec: u32 = @intCast(i);
+                        try lookup.add(address, raw_spec);
+                        try lookup.add(address, raw_spec);
+                        try lookup.add(address, std.math.maxInt(u32));
+                        // Other buckets grow the indexes and overflow table
+                        // between appends to the bucket being checked.
+                        const other: Lookup.Address = .{ .open = .{
+                            .prefix = prefix,
+                            .node = @enumFromInt(i + 100),
+                        } };
+                        try lookup.add(other, raw_spec);
+                        try lookup.add(other, std.math.maxInt(u32));
+                    }
+                    var candidates = lookup.get(address).?;
+                    try std.testing.expect(candidates.next().? == std.math.maxInt(u32));
+                    for (0..20) |i| try std.testing.expect(candidates.next().? == i);
+                    try std.testing.expect(candidates.next() == null);
+                    for (0..20) |i| {
+                        var other = lookup.get(.{ .open = .{
+                            .prefix = prefix,
+                            .node = @enumFromInt(i + 100),
+                        } }).?;
+                        try std.testing.expect(other.next().? == i);
+                        try std.testing.expect(other.next().? == std.math.maxInt(u32));
+                        try std.testing.expect(other.next() == null);
+                    }
+                }
+            }
+        }
+    };
+    try Scenario.run(std.testing.allocator);
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Scenario.run, .{});
 }
 
 test "open draft recursive provenance joins fresh interface cells only while lowering" {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -23297,12 +23297,19 @@ const BodyContext = struct {
         );
 
         var body_ctx = try BodyContext.initWithMethodScope(self.allocator, self.builder, view, self.method_scope, wrapper.template, self.graph, self.draft);
-        body_ctx.evidence = rootEvidence(wrapper.template, self.restore_evidence.vector);
+        defer body_ctx.deinit();
+        const entry_template = view.templates.get(wrapper.template.template);
+        const schema = templateSchemaIn(view, &entry_template);
+        const subst = try body_ctx.substitutionFromCheckedTypes(view, schema.scheme_vars);
+        body_ctx.evidence = rootEvidenceWithSubstitution(wrapper.template, schema, .{
+            .subst = subst,
+            .vector = self.restore_evidence.vector,
+        });
+        try body_ctx.seedSubstitution(schema, subst);
         body_ctx.frozen_sealed_emission = self.frozen_sealed_emission;
         body_ctx.frozen_type_finals = self.frozen_type_finals;
         body_ctx.frozen_codec_calls = self.frozen_codec_calls;
         body_ctx.frozen_field_defaults = self.frozen_field_defaults;
-        defer body_ctx.deinit();
         const root_fn_key = Ast.fnTemplateDigest(wrapper_template, self.typeStore(), self.nameStore());
         body_ctx.owner_context_fn_key = root_fn_key;
         body_ctx.current_fn_key = root_fn_key;
@@ -23354,12 +23361,19 @@ const BodyContext = struct {
             Common.invariant("callable eval template root had no checked entry wrapper");
 
         var body_ctx = try BodyContext.initWithMethodScope(self.allocator, self.builder, view, self.method_scope, wrapper.template, self.graph, self.draft);
-        body_ctx.evidence = rootEvidence(wrapper.template, self.restore_evidence.vector);
+        defer body_ctx.deinit();
+        const entry_template = view.templates.get(wrapper.template.template);
+        const schema = templateSchemaIn(view, &entry_template);
+        const subst = try body_ctx.substitutionFromCheckedTypes(view, schema.scheme_vars);
+        body_ctx.evidence = rootEvidenceWithSubstitution(wrapper.template, schema, .{
+            .subst = subst,
+            .vector = self.restore_evidence.vector,
+        });
+        try body_ctx.seedSubstitution(schema, subst);
         body_ctx.frozen_sealed_emission = self.frozen_sealed_emission;
         body_ctx.frozen_type_finals = self.frozen_type_finals;
         body_ctx.frozen_codec_calls = self.frozen_codec_calls;
         body_ctx.frozen_field_defaults = self.frozen_field_defaults;
-        defer body_ctx.deinit();
         const root_fn_key = view.types.rootKey(wrapper.checked_fn_root);
         body_ctx.owner_context_fn_key = root_fn_key;
         body_ctx.current_fn_key = root_fn_key;

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5978,14 +5978,14 @@ const Builder = struct {
         // a repeat skips the graph-native recursive lookup below. The latter
         // view does not mutate the live request; a hit joins the live
         // interfaces below.
+        const lookup_prefix = try source_ctx.draft.template_spec_lookup.internPrefix(family, evidence_digest.bytes);
         const resolved_lookup_address: ?DraftTemplateLookupAddress = if (resolved_request_ty) |request_fn_ty| .{
-            .family = family,
-            .evidence_digest = evidence_digest.bytes,
+            .prefix = lookup_prefix,
             .request_kind = 0,
             .request_fn_key = source_ctx.specializationTypeDigest(request_fn_ty).bytes,
         } else null;
         if (resolved_lookup_address) |address| {
-            if (source_ctx.draft.template_spec_lookup.get(address)) |candidates| {
+            if (source_ctx.draft.template_spec_lookup.requests.get(address)) |candidates| {
                 for (candidates.items) |raw_spec| {
                     const spec = &source_ctx.draft.template_specs.items[raw_spec];
                     if (!specEvidenceVectorEql(spec.evidence, evidence)) continue;
@@ -6008,12 +6008,11 @@ const Builder = struct {
                 var aliases = source_ctx.graph.classMemberIterator(interface_class);
                 while (aliases.next()) |member| {
                     const lookup_address = DraftTemplateLookupAddress{
-                        .family = family,
-                        .evidence_digest = evidence_digest.bytes,
+                        .prefix = lookup_prefix,
                         .request_kind = 1,
                         .request_fn_key = draftOpenRequestKey(member),
                     };
-                    if (source_ctx.draft.template_spec_lookup.get(lookup_address)) |candidates| {
+                    if (source_ctx.draft.template_spec_lookup.requests.get(lookup_address)) |candidates| {
                         for (candidates.items) |raw_spec| {
                             const seen = try seen_specs.getOrPut(raw_spec);
                             if (seen.found_existing) continue;
@@ -6203,8 +6202,7 @@ const Builder = struct {
             source_ctx.draft,
             self.allocator,
             source_ctx.graph,
-            family,
-            evidence_digest.bytes,
+            lookup_prefix,
             request_fn_node,
             @intCast(spec_index),
         );
@@ -6306,8 +6304,7 @@ const Builder = struct {
             source_ctx.draft,
             self.allocator,
             source_ctx.graph,
-            family,
-            evidence_digest.bytes,
+            lookup_prefix,
             completed_fn_node,
             @intCast(spec_index),
         );
@@ -7954,9 +7951,9 @@ const Builder = struct {
             try source_ctx.activeTypeFromNode(request_fn_node)
         else
             null;
+        const lookup_prefix = try source_ctx.draft.nested_spec_lookup.internPrefix(family, evidence_digest.bytes);
         const resolved_lookup_address: ?DraftNestedLookupAddress = if (resolved_request_ty) |request_fn_ty| .{
-            .family = family,
-            .evidence_digest = evidence_digest.bytes,
+            .prefix = lookup_prefix,
             .request_kind = 0,
             .request_fn_key = source_ctx.specializationTypeDigest(request_fn_ty).bytes,
         } else null;
@@ -7965,8 +7962,7 @@ const Builder = struct {
         else
             null;
         const open_shape_lookup_address: ?DraftNestedLookupAddress = if (open_request_shape) |shape| .{
-            .family = family,
-            .evidence_digest = evidence_digest.bytes,
+            .prefix = lookup_prefix,
             .request_kind = 2,
             .request_fn_key = shape.digest.bytes,
         } else null;
@@ -7977,7 +7973,7 @@ const Builder = struct {
         defer seen_specs.deinit();
         var selection = DraftOpenCandidateSelection{};
         if (resolved_lookup_address) |address| {
-            if (source_ctx.draft.nested_spec_lookup.get(address)) |candidates| {
+            if (source_ctx.draft.nested_spec_lookup.requests.get(address)) |candidates| {
                 for (candidates.items) |raw_spec| {
                     const spec = &source_ctx.draft.nested_specs.items[raw_spec];
                     if (signature_relation == .exact_graph and
@@ -7999,7 +7995,7 @@ const Builder = struct {
         }
         if (selection.selected() == null) {
             if (open_shape_lookup_address) |address| {
-                if (source_ctx.draft.nested_spec_lookup.get(address)) |candidates| {
+                if (source_ctx.draft.nested_spec_lookup.requests.get(address)) |candidates| {
                     for (candidates.items) |raw_spec| {
                         const spec = &source_ctx.draft.nested_specs.items[raw_spec];
                         if (spec.state != .lowered) continue;
@@ -8027,12 +8023,11 @@ const Builder = struct {
                 var aliases = source_ctx.graph.classMemberIterator(interface_class);
                 while (aliases.next()) |member| {
                     const lookup_address = DraftNestedLookupAddress{
-                        .family = family,
-                        .evidence_digest = evidence_digest.bytes,
+                        .prefix = lookup_prefix,
                         .request_kind = 1,
                         .request_fn_key = draftOpenRequestKey(member),
                     };
-                    if (source_ctx.draft.nested_spec_lookup.get(lookup_address)) |candidates| {
+                    if (source_ctx.draft.nested_spec_lookup.requests.get(lookup_address)) |candidates| {
                         for (candidates.items) |raw_spec| {
                             const seen = try seen_specs.getOrPut(raw_spec);
                             if (seen.found_existing) continue;
@@ -8186,12 +8181,11 @@ const Builder = struct {
             const indexed = try indexed_nodes.getOrPut(interface_node);
             if (indexed.found_existing) continue;
             const lookup_address = DraftNestedLookupAddress{
-                .family = family,
-                .evidence_digest = evidence_digest.bytes,
+                .prefix = lookup_prefix,
                 .request_kind = 1,
                 .request_fn_key = draftOpenRequestKey(interface_node),
             };
-            const lookup_entry = try source_ctx.draft.nested_spec_lookup.getOrPut(lookup_address);
+            const lookup_entry = try source_ctx.draft.nested_spec_lookup.requests.getOrPut(lookup_address);
             if (!lookup_entry.found_existing) lookup_entry.value_ptr.* = .empty;
             try lookup_entry.value_ptr.append(self.allocator, @intCast(spec_index));
         }
@@ -8270,8 +8264,7 @@ const Builder = struct {
             const completed_fn_ty = try source_ctx.activeTypeFromNode(completed_fn_node);
             source_ctx.draft.nested_specs.items[spec_index].request_fn_ty = completed_fn_ty;
             try registerNestedSpecLookup(source_ctx.draft, self.allocator, .{
-                .family = family,
-                .evidence_digest = evidence_digest.bytes,
+                .prefix = lookup_prefix,
                 .request_kind = 0,
                 .request_fn_key = source_ctx.specializationTypeDigest(completed_fn_ty).bytes,
             }, @intCast(spec_index));
@@ -8280,8 +8273,7 @@ const Builder = struct {
             source_ctx.draft,
             self.allocator,
             source_ctx.graph,
-            family,
-            evidence_digest.bytes,
+            lookup_prefix,
             completed_fn_node,
             @intCast(spec_index),
         );
@@ -12268,7 +12260,7 @@ fn registerTemplateSpecLookup(
     address: DraftTemplateLookupAddress,
     raw_spec: u32,
 ) Allocator.Error!void {
-    const entry = try draft.template_spec_lookup.getOrPut(address);
+    const entry = try draft.template_spec_lookup.requests.getOrPut(address);
     if (!entry.found_existing) entry.value_ptr.* = .empty;
     for (entry.value_ptr.items) |existing| if (existing == raw_spec) return;
     try entry.value_ptr.append(allocator, raw_spec);
@@ -12278,8 +12270,7 @@ fn updateTemplateSpecInterfaceLookups(
     draft: *BodyDraftStore,
     allocator: Allocator,
     graph: *InstGraph,
-    family: DraftTemplateFamilyAddress,
-    evidence_digest: [32]u8,
+    lookup_prefix: DraftTemplateSpecLookup.PrefixId,
     request_fn_node: NodeId,
     raw_spec: u32,
 ) Allocator.Error!void {
@@ -12290,8 +12281,7 @@ fn updateTemplateSpecInterfaceLookups(
         const indexed = try indexed_nodes.getOrPut(interface_node);
         if (indexed.found_existing) continue;
         const address = DraftTemplateLookupAddress{
-            .family = family,
-            .evidence_digest = evidence_digest,
+            .prefix = lookup_prefix,
             .request_kind = 1,
             .request_fn_key = draftOpenRequestKey(interface_node),
         };
@@ -12316,7 +12306,7 @@ fn registerNestedSpecLookup(
     address: DraftNestedLookupAddress,
     raw_spec: u32,
 ) Allocator.Error!void {
-    const entry = try draft.nested_spec_lookup.getOrPut(address);
+    const entry = try draft.nested_spec_lookup.requests.getOrPut(address);
     if (!entry.found_existing) entry.value_ptr.* = .empty;
     for (entry.value_ptr.items) |existing| if (existing == raw_spec) return;
     try entry.value_ptr.append(allocator, raw_spec);
@@ -12326,8 +12316,7 @@ fn registerNestedSpecInterfaceLookups(
     draft: *BodyDraftStore,
     allocator: Allocator,
     graph: *InstGraph,
-    family: DraftNestedFamilyAddress,
-    evidence_digest: [32]u8,
+    lookup_prefix: DraftNestedSpecLookup.PrefixId,
     request_fn_node: NodeId,
     raw_spec: u32,
 ) Allocator.Error!void {
@@ -12338,8 +12327,7 @@ fn registerNestedSpecInterfaceLookups(
         const indexed = try indexed_nodes.getOrPut(interface_node);
         if (indexed.found_existing) continue;
         try registerNestedSpecLookup(draft, allocator, .{
-            .family = family,
-            .evidence_digest = evidence_digest,
+            .prefix = lookup_prefix,
             .request_kind = 1,
             .request_fn_key = draftOpenRequestKey(interface_node),
         }, raw_spec);
@@ -12505,19 +12493,62 @@ const DraftNestedFamilyAddress = struct {
     }
 };
 
-const DraftTemplateLookupAddress = struct {
-    family: DraftTemplateFamilyAddress,
-    evidence_digest: [32]u8,
-    request_kind: u8,
-    request_fn_key: [32]u8,
-};
+const DraftTemplateSpecLookup = DraftSpecLookup(DraftTemplateFamilyAddress);
+const DraftNestedSpecLookup = DraftSpecLookup(DraftNestedFamilyAddress);
+const DraftTemplateLookupAddress = DraftTemplateSpecLookup.Address;
+const DraftNestedLookupAddress = DraftNestedSpecLookup.Address;
 
-const DraftNestedLookupAddress = struct {
-    family: DraftNestedFamilyAddress,
-    evidence_digest: [32]u8,
-    request_kind: u8,
-    request_fn_key: [32]u8,
-};
+/// Intern the exact family/evidence prefix once per request, rather than
+/// hashing and storing it again for every permanent interface node. Prefix IDs
+/// are append-only and local to this index; reentrant lowering may grow the
+/// tables without invalidating an outer request's ID. Exact candidate checks
+/// remain authoritative after this index selects a bucket.
+fn DraftSpecLookup(comptime Family: type) type {
+    return struct {
+        const Self = @This();
+        const Prefix = struct {
+            family: Family,
+            evidence_digest: [32]u8,
+        };
+        const PrefixId = enum(u32) { _ };
+        const Address = struct {
+            prefix: PrefixId,
+            request_kind: u8,
+            request_fn_key: [32]u8,
+        };
+
+        allocator: Allocator,
+        prefixes: std.array_hash_map.Auto(Prefix, void),
+        requests: std.AutoHashMap(Address, std.ArrayList(u32)),
+
+        fn init(allocator: Allocator) Self {
+            return .{
+                .allocator = allocator,
+                .prefixes = .empty,
+                .requests = std.AutoHashMap(Address, std.ArrayList(u32)).init(allocator),
+            };
+        }
+
+        fn deinit(self: *Self) void {
+            var lists = self.requests.valueIterator();
+            while (lists.next()) |list| list.deinit(self.allocator);
+            self.requests.deinit();
+            self.prefixes.deinit(self.allocator);
+        }
+
+        fn isEmpty(self: *const Self) bool {
+            return self.prefixes.count() == 0 and self.requests.count() == 0;
+        }
+
+        fn internPrefix(self: *Self, family: Family, evidence_digest: [32]u8) Allocator.Error!PrefixId {
+            const entry = try self.prefixes.getOrPut(self.allocator, .{
+                .family = family,
+                .evidence_digest = evidence_digest,
+            });
+            return @enumFromInt(entry.index);
+        }
+    };
+}
 
 fn draftOpenRequestKey(node: NodeId) [32]u8 {
     var bytes = [_]u8{0} ** 32;
@@ -13572,7 +13603,7 @@ const BodyDraftStore = struct {
     template_specs: std.ArrayList(DraftTemplateSpec),
     sealed_template_specs: std.ArrayList(SealedTemplateSpec),
     template_spec_by_fn: collections.DenseMap(DraftFnId, u32),
-    template_spec_lookup: std.AutoHashMap(DraftTemplateLookupAddress, std.ArrayList(u32)),
+    template_spec_lookup: DraftTemplateSpecLookup,
     /// Exact checked identities bypass the general graph/digest lookup after
     /// the first closed direct call in this draft.
     closed_direct_specializations: std.AutoHashMap(ClosedDirectCallIdentity, ClosedDirectDraftSpecialization),
@@ -13603,7 +13634,7 @@ const BodyDraftStore = struct {
     stmt_impossibility_proofs: std.ArrayList(?RuntimeImpossibilityProofId),
     nested_specs: std.ArrayList(DraftNestedSpec),
     sealed_nested_specs: std.ArrayList(SealedNestedSpec),
-    nested_spec_lookup: std.AutoHashMap(DraftNestedLookupAddress, std.ArrayList(u32)),
+    nested_spec_lookup: DraftNestedSpecLookup,
     exprs: std.ArrayList(DraftExpr),
     pats: std.ArrayList(DraftPat),
     stmts: std.ArrayList(DraftStmt),
@@ -13684,7 +13715,7 @@ const BodyDraftStore = struct {
             .template_specs = .empty,
             .sealed_template_specs = .empty,
             .template_spec_by_fn = collections.DenseMap(DraftFnId, u32).init(allocator),
-            .template_spec_lookup = std.AutoHashMap(DraftTemplateLookupAddress, std.ArrayList(u32)).init(allocator),
+            .template_spec_lookup = DraftTemplateSpecLookup.init(allocator),
             .closed_direct_specializations = std.AutoHashMap(ClosedDirectCallIdentity, ClosedDirectDraftSpecialization).init(allocator),
             .active_callable_eval_bindings = .empty,
             .active_const_node_bindings = .empty,
@@ -13713,7 +13744,7 @@ const BodyDraftStore = struct {
             .stmt_impossibility_proofs = .empty,
             .nested_specs = .empty,
             .sealed_nested_specs = .empty,
-            .nested_spec_lookup = std.AutoHashMap(DraftNestedLookupAddress, std.ArrayList(u32)).init(allocator),
+            .nested_spec_lookup = DraftNestedSpecLookup.init(allocator),
             .exprs = .empty,
             .pats = .empty,
             .stmts = .empty,
@@ -13903,13 +13934,9 @@ const BodyDraftStore = struct {
         }
         for (self.local_proc_contexts.items) |context| self.allocator.free(context.entries);
         self.local_proc_contexts.deinit(self.allocator);
-        var template_lookup_lists = self.template_spec_lookup.valueIterator();
-        while (template_lookup_lists.next()) |list| list.deinit(self.allocator);
         self.template_spec_lookup.deinit();
         self.closed_direct_specializations.deinit();
         self.template_spec_by_fn.deinit();
-        var nested_lookup_lists = self.nested_spec_lookup.valueIterator();
-        while (nested_lookup_lists.next()) |list| list.deinit(self.allocator);
         self.nested_spec_lookup.deinit();
         self.owner_runs.deinit(self.allocator);
         self.stmt_impossibility_proofs.deinit(self.allocator);
@@ -14659,14 +14686,10 @@ const BodyDraftStore = struct {
         self.stmt_impossibility_proofs.deinit(self.allocator);
         self.stmt_impossibility_proofs = .empty;
 
-        var template_lookup_lists = self.template_spec_lookup.valueIterator();
-        while (template_lookup_lists.next()) |list| list.deinit(self.allocator);
         self.template_spec_lookup.deinit();
-        self.template_spec_lookup = std.AutoHashMap(DraftTemplateLookupAddress, std.ArrayList(u32)).init(self.allocator);
-        var nested_lookup_lists = self.nested_spec_lookup.valueIterator();
-        while (nested_lookup_lists.next()) |list| list.deinit(self.allocator);
+        self.template_spec_lookup = DraftTemplateSpecLookup.init(self.allocator);
         self.nested_spec_lookup.deinit();
-        self.nested_spec_lookup = std.AutoHashMap(DraftNestedLookupAddress, std.ArrayList(u32)).init(self.allocator);
+        self.nested_spec_lookup = DraftNestedSpecLookup.init(self.allocator);
         self.template_spec_by_fn.deinit();
         self.template_spec_by_fn = collections.DenseMap(DraftFnId, u32).init(self.allocator);
         self.closed_direct_specializations.deinit();
@@ -14694,8 +14717,8 @@ const BodyDraftStore = struct {
             self.structural_eq_method_calls.items.len != 0 or
             self.runtime_value_demands.items.len != 0 or
             self.impossibility_proofs.items.len != 0 or
-            self.template_spec_lookup.count() != 0 or
-            self.nested_spec_lookup.count() != 0 or
+            !self.template_spec_lookup.isEmpty() or
+            !self.nested_spec_lookup.isEmpty() or
             self.template_specs.items.len != 0 or
             self.nested_specs.items.len != 0 or
             self.spec_job_workspace != null or
@@ -32918,26 +32941,24 @@ const BodyContext = struct {
         self.draft.template_specs.items[spec_index].request_fn_node = completed_node;
         const completed_spec = self.draft.template_specs.items[spec_index];
         const completed_source = self.draft.fns.items[@intFromEnum(draft_fn)].source;
-        try updateTemplateSpecInterfaceLookups(
-            self.draft,
-            self.allocator,
-            self.graph,
+        const lookup_prefix = try self.draft.template_spec_lookup.internPrefix(
             DraftTemplateFamilyAddress.init(
                 completed_spec.template_ref,
                 completed_spec.method_scope,
                 completed_spec.source_fn_key,
             ),
             completed_source.evidence_digest.bytes,
+        );
+        try updateTemplateSpecInterfaceLookups(
+            self.draft,
+            self.allocator,
+            self.graph,
+            lookup_prefix,
             completed_node,
             @intCast(spec_index),
         );
         try registerTemplateSpecLookup(self.draft, self.allocator, .{
-            .family = DraftTemplateFamilyAddress.init(
-                completed_spec.template_ref,
-                completed_spec.method_scope,
-                completed_spec.source_fn_key,
-            ),
-            .evidence_digest = completed_source.evidence_digest.bytes,
+            .prefix = lookup_prefix,
             .request_kind = 0,
             .request_fn_key = self.specializationTypeDigest(completed_ty).bytes,
         }, raw_spec);
@@ -55014,6 +55035,81 @@ test "record destructure treats a scheme-interior field as required" {
         @as(?checked.CheckedFieldKind.Tag, null),
         BodyContext.recordDestructKindFromResolution(.absent),
     );
+}
+
+test "draft specialization lookup preserves family evidence and request identity" {
+    const allocator = std.testing.allocator;
+    inline for (.{ DraftTemplateFamilyAddress, DraftNestedFamilyAddress }) |Family| {
+        const Lookup = DraftSpecLookup(Family);
+        var lookup = Lookup.init(allocator);
+        defer lookup.deinit();
+        const family = std.mem.zeroes(Family);
+        const evidence = [_]u8{0} ** 32;
+        const prefix = try lookup.internPrefix(family, evidence);
+        try std.testing.expectEqual(prefix, try lookup.internPrefix(family, evidence));
+
+        // The same bytes can name a structural type, a permanent graph node,
+        // or an open shape. Those request domains must remain disjoint.
+        const addresses = [_]Lookup.Address{
+            .{ .prefix = prefix, .request_kind = 0, .request_fn_key = @splat(0) },
+            .{ .prefix = prefix, .request_kind = 1, .request_fn_key = @splat(0) },
+            .{ .prefix = prefix, .request_kind = 2, .request_fn_key = @splat(0) },
+            .{ .prefix = prefix, .request_kind = 1, .request_fn_key = draftOpenRequestKey(@enumFromInt(1)) },
+        };
+        for (addresses, 0..) |address, raw_spec| {
+            const entry = try lookup.requests.getOrPut(address);
+            try std.testing.expect(!entry.found_existing);
+            entry.value_ptr.* = .empty;
+            try entry.value_ptr.append(allocator, @intCast(raw_spec));
+        }
+
+        // Every family qualifier and evidence byte contributes to identity.
+        // Growing the prefix table must also preserve previously issued IDs.
+        inline for (std.meta.fields(Family)) |field| {
+            const changes = if (field.type == [32]u8) 32 else 1;
+            for (0..changes) |byte| {
+                var different_family = family;
+                if (field.type == [32]u8) {
+                    @field(different_family, field.name)[byte] = 1;
+                } else if (field.type == u32) {
+                    @field(different_family, field.name) = 1;
+                } else if (field.type == bool) {
+                    @field(different_family, field.name) = true;
+                } else {
+                    @compileError("unsupported specialization family qualifier");
+                }
+                const other = try lookup.internPrefix(different_family, evidence);
+                try std.testing.expect(other != prefix);
+                var address = addresses[0];
+                address.prefix = other;
+                try std.testing.expect(lookup.requests.get(address) == null);
+                try lookup.requests.put(address, .empty);
+            }
+        }
+        for (0..evidence.len) |byte| {
+            var different_evidence = evidence;
+            different_evidence[byte] = 1;
+            const other = try lookup.internPrefix(family, different_evidence);
+            try std.testing.expect(other != prefix);
+            var address = addresses[0];
+            address.prefix = other;
+            try std.testing.expect(lookup.requests.get(address) == null);
+            try lookup.requests.put(address, .empty);
+        }
+        try std.testing.expectEqual(prefix, try lookup.internPrefix(family, evidence));
+        for (addresses, 0..) |address, raw_spec| {
+            const candidates = lookup.requests.get(address).?;
+            try std.testing.expectEqualSlices(u32, &.{@intCast(raw_spec)}, candidates.items);
+        }
+
+        lookup.deinit();
+        lookup = Lookup.init(allocator);
+        try std.testing.expect(lookup.isEmpty());
+        const fresh_prefix = try lookup.internPrefix(family, evidence);
+        var address = addresses[0];
+        address.prefix = fresh_prefix;
+        try std.testing.expect(lookup.requests.get(address) == null);
+    }
 }
 
 test "open draft recursive provenance joins fresh interface cells only while lowering" {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -55159,6 +55159,14 @@ test "record destructure treats a scheme-interior field as required" {
 
 test "draft specialization lookup preserves family evidence and request identity" {
     const allocator = std.testing.allocator;
+    var type_store = Type.Store.init(allocator);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(allocator);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(allocator, &type_store, &name_store);
+    defer graph.destroy();
+    const first_node = try graph.newNode(.{ .primitive = .bool });
+    const second_node = try graph.newNode(.{ .primitive = .str });
     inline for (.{ DraftTemplateFamilyAddress, DraftNestedFamilyAddress }) |Family| {
         const Lookup = DraftSpecLookup(Family);
         var lookup = Lookup.init(allocator);
@@ -55172,9 +55180,9 @@ test "draft specialization lookup preserves family evidence and request identity
         // or an open shape. Those request domains must remain disjoint.
         const addresses = [_]Lookup.Address{
             .{ .digest = .{ .prefix = prefix, .kind = .closed, .digest = @splat(0) } },
-            .{ .open = .{ .prefix = prefix, .node = @enumFromInt(0) } },
+            .{ .open = .{ .prefix = prefix, .node = first_node } },
             .{ .digest = .{ .prefix = prefix, .kind = .open_shape, .digest = @splat(0) } },
-            .{ .open = .{ .prefix = prefix, .node = @enumFromInt(1) } },
+            .{ .open = .{ .prefix = prefix, .node = second_node } },
         };
         for (addresses, 0..) |address, raw_spec| {
             try std.testing.expect(lookup.get(address) == null);
@@ -55233,14 +55241,23 @@ test "draft specialization lookup preserves family evidence and request identity
 
 test "draft specialization candidates retain insertion order across overflow growth and allocation failure" {
     const Scenario = struct {
-        fn run(allocator: Allocator) !void {
+        fn run(allocator: Allocator) (Allocator.Error || error{TestUnexpectedResult})!void {
+            var type_store = Type.Store.init(allocator);
+            defer type_store.deinit();
+            var name_store = names.NameStore.init(allocator);
+            defer name_store.deinit();
+            const graph = try InstGraph.create(allocator, &type_store, &name_store);
+            defer graph.destroy();
+            const request_node = try graph.newNode(.{ .primitive = .bool });
+            var other_nodes: [20]NodeId = undefined;
+            for (&other_nodes) |*node| node.* = try graph.newNode(.{ .primitive = .str });
             inline for (.{ DraftTemplateFamilyAddress, DraftNestedFamilyAddress }) |Family| {
                 const Lookup = DraftSpecLookup(Family);
                 var lookup = Lookup.init(allocator);
                 defer lookup.deinit();
                 const prefix = try lookup.internPrefix(std.mem.zeroes(Family), @splat(0));
                 const addresses = [_]Lookup.Address{
-                    .{ .open = .{ .prefix = prefix, .node = @enumFromInt(0) } },
+                    .{ .open = .{ .prefix = prefix, .node = request_node } },
                     .{ .digest = .{ .prefix = prefix, .kind = .closed, .digest = @splat(0) } },
                     .{ .digest = .{ .prefix = prefix, .kind = .open_shape, .digest = @splat(0) } },
                 };
@@ -55257,7 +55274,7 @@ test "draft specialization candidates retain insertion order across overflow gro
                         // between appends to the bucket being checked.
                         const other: Lookup.Address = .{ .open = .{
                             .prefix = prefix,
-                            .node = @enumFromInt(i + 100),
+                            .node = other_nodes[i],
                         } };
                         try lookup.add(other, raw_spec);
                         try lookup.add(other, std.math.maxInt(u32));
@@ -55269,7 +55286,7 @@ test "draft specialization candidates retain insertion order across overflow gro
                     for (0..20) |i| {
                         var other = lookup.get(.{ .open = .{
                             .prefix = prefix,
-                            .node = @enumFromInt(i + 100),
+                            .node = other_nodes[i],
                         } }).?;
                         try std.testing.expect(other.next().? == i);
                         try std.testing.expect(other.next().? == std.math.maxInt(u32));

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -953,6 +953,9 @@ const EvidenceScope = struct {
 
 const EvidenceChain = struct {
     scope: EvidenceScope,
+    /// Stored evidence is graph-free until a nested body creates its own
+    /// instantiation context. It must remain graph-free across root requests.
+    origin: enum { specialization, stored_function } = .specialization,
     vector: []const SpecEvidence = &.{},
     /// The scheme this frame's vector answers for, and the substitution the
     /// vector was derived from. A body lowered inside this frame forwards an
@@ -5999,9 +6002,10 @@ const Builder = struct {
         if (selection.selected() == null) {
             var seen_specs = std.AutoHashMap(u32, void).init(self.allocator);
             defer seen_specs.deinit();
-            var interface = try source_ctx.graph.functionInterfaceIterator(request_fn_node);
-            while (interface.next()) |interface_node| {
-                var aliases = source_ctx.graph.classMemberIterator(interface_node);
+            var interface = try source_ctx.graph.functionInterfaceClassIterator(request_fn_node);
+            defer interface.deinit();
+            while (try interface.next()) |interface_class| {
+                var aliases = source_ctx.graph.classMemberIterator(interface_class);
                 while (aliases.next()) |member| {
                     const lookup_address = DraftTemplateLookupAddress{
                         .family = family,
@@ -8016,10 +8020,11 @@ const Builder = struct {
                 }
             }
         }
-        var interface = try source_ctx.graph.functionInterfaceIterator(request_fn_node);
         if (selection.selected() == null) {
-            while (interface.next()) |interface_node| {
-                var aliases = source_ctx.graph.classMemberIterator(interface_node);
+            var interface = try source_ctx.graph.functionInterfaceClassIterator(request_fn_node);
+            defer interface.deinit();
+            while (try interface.next()) |interface_class| {
+                var aliases = source_ctx.graph.classMemberIterator(interface_class);
                 while (aliases.next()) |member| {
                     const lookup_address = DraftNestedLookupAddress{
                         .family = family,
@@ -8203,9 +8208,8 @@ const Builder = struct {
         const owner_scope = try source_ctx.draft.enterOwner(.{ .draft_fn = fn_id });
         defer owner_scope.leave();
 
-        var nested_ctx = try source_ctx.nestedInstantiationContext(source_fn_key);
+        var nested_ctx = try source_ctx.nestedInstantiationContext(source_fn_key, nested.site, requested_evidence, false);
         nested_ctx.in_deferred_body = true;
-        nested_ctx.evidence = requested_evidence;
         defer nested_ctx.deinit();
         if (codec_contract) |contract| {
             try nested_ctx.instantiateCodecContractAtCall(
@@ -18537,12 +18541,50 @@ const BodyContext = struct {
         return scope;
     }
 
-    fn nestedInstantiationContext(self: *BodyContext, current_fn_key: names.TypeDigest) Allocator.Error!BodyContext {
+    fn nestedInstantiationContext(
+        self: *BodyContext,
+        current_fn_key: names.TypeDigest,
+        site_id: names.NestedProcSiteId,
+        evidence: EvidenceChain,
+        constructing_scope: bool,
+    ) Allocator.Error!BodyContext {
         var child = try self.childContextWithTypeCells(current_fn_key, false);
         errdefer child.deinit();
+        child.evidence = switch (evidence.origin) {
+            .specialization => evidence,
+            .stored_function => try child.instantiateStoredEvidence(evidence),
+        };
         child.function_entry_demand_guards = &.{};
+        try child.bindNestedTypes(site_id, constructing_scope);
         try child.constrainCopiedBinderTypes();
         return child;
+    }
+
+    /// The checked inventory is sorted by lexical depth. Visit each frame
+    /// once, indexing its substitution directly; no enclosing type map is
+    /// copied and no checked type is searched for by identity.
+    fn bindNestedTypes(self: *BodyContext, site_id: names.NestedProcSiteId, constructing_scope: bool) Allocator.Error!void {
+        const site = self.view.nested_proc_sites.sites[@intFromEnum(site_id)];
+        const span = site.type_bindings;
+        const bindings = self.view.nested_proc_sites.type_bindings[span.start .. span.start + span.len];
+        var frame: *const EvidenceChain = &self.evidence;
+        // A scope's construction has its parent's evidence. Its own slots
+        // are fresh until the construction request determines them.
+        var depth: u32 = if (constructing_scope) 1 else 0;
+        for (bindings) |binding| {
+            if (constructing_scope and binding.depth == 0) continue;
+            while (depth < binding.depth) : (depth += 1) {
+                frame = frame.parent orelse Common.invariant("nested type binding omitted its lexical frame");
+            }
+            const schema = frame.schema orelse Common.invariant("nested type binding frame had no substitution schema");
+            if (binding.slot >= frame.subst.len or schema.scheme_vars[binding.slot] != binding.ty) {
+                Common.invariant("nested type binding differed from its checked lexical substitution");
+            }
+            switch (frame.subst[binding.slot]) {
+                .node => |node| try self.putScopedNode(self.scopedCheckedType(binding.ty), node),
+                .checked_error => {},
+            }
+        }
     }
 
     fn childContextWithTypeCells(
@@ -38161,7 +38203,7 @@ const BodyContext = struct {
                 }
                 // The construction instantiates the scope's scheme: its root
                 // related to the request binds every quantified variable.
-                var scheme_ctx = try self.nestedInstantiationContext(self.current_fn_key);
+                var scheme_ctx = try self.nestedInstantiationContext(self.current_fn_key, site.site, self.evidence, true);
                 defer scheme_ctx.deinit();
                 const scheme_root_node = try scheme_ctx.instNode(scope.scheme_root);
                 try relateFunctionRequestInterface(self.graph, scheme_root_node, request_fn_node);
@@ -39687,6 +39729,7 @@ const BodyContext = struct {
                     Common.invariant("stored function evidence did not begin at the checked root scope");
                 }
                 restored[index] = rootEvidence(owner, vector);
+                restored[index].origin = .stored_function;
                 continue;
             }
             if (scope == .root or frame.parent == null or frame.parent.? != index - 1) {
@@ -39707,6 +39750,7 @@ const BodyContext = struct {
             }
             restored[index] = .{
                 .scope = .{ .owner = owner, .lexical = scope },
+                .origin = .stored_function,
                 .vector = vector,
                 .parent = &restored[index - 1],
             };
@@ -39756,6 +39800,59 @@ const BodyContext = struct {
             Common.invariant("stored function evidence head differed from its checked nested site scope");
         }
         return restored[head];
+    }
+
+    fn instantiateStoredEvidence(self: *BodyContext, evidence: EvidenceChain) Allocator.Error!EvidenceChain {
+        var count: usize = 0;
+        var current: ?*const EvidenceChain = &evidence;
+        while (current) |frame| : (current = frame.parent) count += 1;
+        const frames = try self.builder.evidence_arena.allocator().alloc(EvidenceChain, count);
+        var index = count;
+        current = &evidence;
+        while (current) |frame| : (current = frame.parent) {
+            index -= 1;
+            frames[index] = frame.*;
+        }
+        for (frames, 0..) |*frame, i| {
+            const view = self.builder.moduleForDigest(names.procTemplateModuleDigest(frame.scope.owner));
+            frame.* = try self.restoreEvidenceFrame(view, frame.scope.owner, frame.scope.lexical, frame.vector, if (i == 0) null else &frames[i - 1]);
+        }
+        return frames[count - 1];
+    }
+
+    /// Stored functions have graph-free evidence. Recreate its lexical
+    /// substitution in the restoration context, where saved callable and
+    /// capture interfaces will constrain the same checked identities. Hidden
+    /// receivers additionally consume their retained method contracts.
+    fn restoreEvidenceFrame(
+        self: *BodyContext,
+        view: ModuleView,
+        owner: names.ProcTemplate,
+        scope: LexicalDispatchScope,
+        vector: []const SpecEvidence,
+        parent: ?*const EvidenceChain,
+    ) Allocator.Error!EvidenceChain {
+        const schema = switch (scope) {
+            .root => self.templateSchema(owner),
+            .generalized => |id| self.scopeSchema(view, id),
+        };
+        const subst = try self.substitutionFromCheckedTypes(view, schema.scheme_vars);
+        var ctx: ?BodyContext = null;
+        defer if (ctx) |*context| context.deinit();
+        for (schema.params, vector) |param, entry| {
+            if (!evidenceParamRequiresConstraintRelation(param)) continue;
+            switch (entry) {
+                .target => |target| {
+                    if (ctx == null) {
+                        ctx = try BodyContext.initWithMethodScope(self.allocator, self.builder, view, self.method_scope, owner, self.graph, self.draft);
+                        try ctx.?.seedSubstitution(schema, subst);
+                    }
+                    try self.relateTargetToConstraint(target, &ctx.?, param);
+                },
+                .structural, .from_callable, .unreachable_value, .checked_error => {},
+            }
+        }
+        return .{ .scope = .{ .owner = owner, .lexical = scope }, .schema = schema, .subst = subst, .vector = vector, .parent = parent };
     }
 
     fn materializeConstFnEvidenceVector(

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -33344,18 +33344,18 @@ const BodyContext = struct {
             self.graph,
             self.draft,
         );
-        try body_ctx.inheritActiveConstBinding(self);
-        body_ctx.evidence = rootEvidence(eval.entry_template, self.restore_evidence.vector);
-        if (self.restore_evidence.vector.len < entry_template.evidence_params.len) {
-            const root_evidence = try self.rootEdgeEvidence(store_view, eval.entry_template, entry_template);
-            body_ctx.evidence = rootEvidenceWithSubstitution(
-                eval.entry_template,
-                templateSchemaIn(store_view, &entry_template),
-                root_evidence,
-            );
-            try body_ctx.seedSubstitution(body_ctx.evidence.schema.?, root_evidence.subst);
-        }
         defer body_ctx.deinit();
+        try body_ctx.inheritActiveConstBinding(self);
+        const schema = templateSchemaIn(store_view, &entry_template);
+        const root_evidence: EdgeEvidence = if (self.restore_evidence.vector.len < entry_template.evidence_params.len)
+            try body_ctx.rootEdgeEvidence(store_view, eval.entry_template, entry_template)
+        else
+            .{
+                .subst = try body_ctx.substitutionFromCheckedTypes(store_view, schema.scheme_vars),
+                .vector = self.restore_evidence.vector,
+            };
+        body_ctx.evidence = rootEvidenceWithSubstitution(eval.entry_template, schema, root_evidence);
+        try body_ctx.seedSubstitution(schema, root_evidence.subst);
         body_ctx.source_region_override = source_region_override;
         body_ctx.current_entry_root = current_entry_root orelse .{
             .module = store_view.key,

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -3402,6 +3402,43 @@ pub const InstGraph = struct {
         return .{ .function = try self.functionNodes(node) };
     }
 
+    /// Distinct current equivalence classes in a function's explicit
+    /// interface. The caller must not merge classes during iteration; adding
+    /// independent nodes and compressing find paths does not change the set.
+    /// Each iterator owns its scratch until deinit, so overlapping
+    /// queries on the same graph cannot clear one another's visited classes.
+    pub const FunctionInterfaceClassIterator = struct {
+        graph: *InstGraph,
+        interface: FunctionInterfaceIterator,
+        seen: collections.DenseMap(NodeId, void),
+
+        pub fn deinit(self: *FunctionInterfaceClassIterator) void {
+            self.graph.node_set_pool.release(&self.seen);
+            self.* = undefined;
+        }
+
+        pub fn next(self: *FunctionInterfaceClassIterator) Allocator.Error!?NodeId {
+            while (self.interface.next()) |node| {
+                const root = self.graph.find(node);
+                if ((try self.seen.getOrPut(root)).found_existing) continue;
+                return root;
+            }
+            return null;
+        }
+    };
+
+    /// Lookup may probe each class once, but persistent indexes must retain
+    /// permanent node IDs through functionInterfaceIterator: later unions can
+    /// change which class owns an indexed node.
+    pub fn functionInterfaceClassIterator(self: *InstGraph, node: NodeId) Allocator.Error!FunctionInterfaceClassIterator {
+        const interface = try self.functionInterfaceIterator(node);
+        return .{
+            .graph = self,
+            .interface = interface,
+            .seen = self.node_set_pool.acquire(),
+        };
+    }
+
     /// Project tuple item cells without materializing a Monotype.
     pub fn tupleItemNodes(self: *InstGraph, node: NodeId) Allocator.Error![]const NodeId {
         const node_content = self.content(try self.shapeRoot(node, "tuple", .inspectable));
@@ -6845,6 +6882,65 @@ test "open draft function interfaces use related graph classes directly" {
     const other_arg = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, .empty_tag_union) });
     const other = try graph.newNode(.{ .func = .{ .args = try graph.arena().dupe(NodeId, &.{other_arg}), .ret = ret } });
     try std.testing.expect(!graph.sameFunctionInterface(left, other));
+}
+
+test "function interface classes deduplicate aliases and refresh after unions" {
+    const gpa = std.testing.allocator;
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+
+    const arg = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    const alias = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    // The same unresolved shape is a distinct class until explicitly related.
+    const other = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    const function = try graph.newNode(.{ .func = .{
+        .args = try graph.arena().dupe(NodeId, &.{ arg, arg, alias, other }),
+        .ret = alias,
+    } });
+    try graph.unify(arg, alias);
+
+    {
+        var classes = try graph.functionInterfaceClassIterator(function);
+        defer classes.deinit();
+        var members = collections.DenseMap(NodeId, void).init(gpa);
+        defer members.deinit();
+        var count: usize = 0;
+        while (try classes.next()) |class| {
+            count += 1;
+            var aliases = graph.classMemberIterator(class);
+            while (aliases.next()) |member| {
+                try std.testing.expect(!(try members.getOrPut(member)).found_existing);
+            }
+        }
+        try std.testing.expectEqual(@as(usize, 2), count);
+        try std.testing.expectEqual(@as(usize, 3), members.count());
+        try std.testing.expect(members.contains(arg));
+        try std.testing.expect(members.contains(alias));
+        try std.testing.expect(members.contains(other));
+    }
+
+    try graph.unify(alias, other);
+    // A new lookup must observe the union, with no visited state retained
+    // from the previous query. Overlapping iterators own separate scratch.
+    var classes = try graph.functionInterfaceClassIterator(function);
+    defer classes.deinit();
+    var concurrent = try graph.functionInterfaceClassIterator(function);
+    defer concurrent.deinit();
+    const root = graph.find(arg);
+    try std.testing.expectEqual(root, (try classes.next()).?);
+    try std.testing.expectEqual(root, (try concurrent.next()).?);
+    try std.testing.expectEqual(null, try classes.next());
+    try std.testing.expectEqual(null, try concurrent.next());
+
+    const nullary = try graph.newNode(.{ .func = .{ .args = &.{}, .ret = arg } });
+    var return_only = try graph.functionInterfaceClassIterator(nullary);
+    defer return_only.deinit();
+    try std.testing.expectEqual(root, (try return_only.next()).?);
+    try std.testing.expectEqual(null, try return_only.next());
 }
 
 test "open function interface shape snapshot alpha-normalizes variables and survives refinement" {

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -740,8 +740,8 @@ test "Monotype open specialization lookup covers the complete function interface
         "fn lowerExprAtTypeCell(",
     );
     inline for (.{ template_source, nested_source }) |lookup_source| {
-        try expectContains(lookup_source, "functionInterfaceIterator(request_fn_node)");
-        try expectContains(lookup_source, "classMemberIterator(interface_node)");
+        try expectContains(lookup_source, "functionInterfaceClassIterator(request_fn_node)");
+        try expectContains(lookup_source, "classMemberIterator(interface_class)");
         try expectContains(lookup_source, "seen_specs.getOrPut(raw_spec)");
         try expectContains(lookup_source, "draftOpenCandidateQualifies(");
         try expectContains(lookup_source, "spec.runtime_demand_guard_frames");

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -760,7 +760,7 @@ test "Monotype open specialization lookup covers the complete function interface
         "fn draftNestedSpecRequestNode(",
     );
     try expectContains(interface_registration, "indexed_nodes.getOrPut(interface_node)");
-    try expectContains(interface_registration, "draftOpenRequestKey(interface_node)");
+    try expectContains(interface_registration, ".node = interface_node");
     try expectContains(nested_source, "std.meta.eql(spec.lexical_owner, source_ctx.draft.current_owner)");
 }
 


### PR DESCRIPTION
Nested procedures now receive explicit lexical type bindings from checked metadata, including hidden comparison receivers. Stored function evidence restores these bindings within each instantiation context, fixing the panic when a namespaced comparison helper is called from nested folds.

Specialization lookup visits each equivalence class once, interns shared prefixes, and stores compact node keys and inline candidates while preserving permanent node identities and exact reuse checks.

Fixes #11189.
