### PR TITLE
Fix Zig glue identifiers for keyword tag names

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -456,6 +456,7 @@ const CustomCase = enum {
     glue_rust_box_payload_alignment,
     glue_rust_returned_list_elements,
     glue_zig_bang_record_fields,
+    glue_zig_keyword_tag_names,
     glue_package_nominal_api_alias,
     glue_nominal_canonical_field,
     glue_unlisted_hosted_declaration,
@@ -927,6 +928,7 @@ const glue_cases = [_]CliCase{
     .{ .id = 0, .suite = .glue, .name = "glue regression: RustGlue decrefs non-refcounted boxed payloads with payload alignment", .body = .{ .custom = .glue_rust_box_payload_alignment } },
     .{ .id = 0, .suite = .glue, .name = "issue 10451: RustGlue releases list elements returned from a provided entrypoint", .body = .{ .custom = .glue_rust_returned_list_elements } },
     .{ .id = 0, .suite = .glue, .name = "glue regression: ZigGlue quotes bang record fields", .body = .{ .custom = .glue_zig_bang_record_fields } },
+    .{ .id = 0, .suite = .glue, .name = "issue 11196: ZigGlue emits parseable Zig for tags named after Zig keywords", .body = .{ .custom = .glue_zig_keyword_tag_names } },
     .{ .id = 0, .suite = .glue, .name = "issue 9865: RustGlue does not panic for package nominal record API alias", .body = .{ .custom = .glue_package_nominal_api_alias } },
     .{ .id = 0, .suite = .glue, .name = "glue regression: nominal scalar field resolves canonical backing", .body = .{ .custom = .glue_nominal_canonical_field } },
     .{ .id = 0, .suite = .glue, .name = "glue regression: platform hosted declaration missing from the hosted section stops without panic", .body = .{ .custom = .glue_unlisted_hosted_declaration } },
@@ -2958,6 +2960,7 @@ fn runCustomCase(
         .glue_rust_box_payload_alignment => customGlueRustBoxPayloadAlignment(io, allocator, &env, &timer, timeout_ms),
         .glue_rust_returned_list_elements => customGlueRustReturnedListElements(io, allocator, &env, &timer, timeout_ms),
         .glue_zig_bang_record_fields => customGlueZigBangRecordFieldNames(io, allocator, &env, &timer, timeout_ms),
+        .glue_zig_keyword_tag_names => customGlueZigKeywordTagNames(io, allocator, &env, &timer, timeout_ms),
         .glue_package_nominal_api_alias => customGluePackageNominalApiAlias(io, allocator, &env, &timer, timeout_ms),
         .glue_nominal_canonical_field => customGlueNominalCanonicalField(io, allocator, &env, &timer, timeout_ms),
         .glue_unlisted_hosted_declaration => customGlueUnlistedHostedDeclaration(io, allocator, &env, &timer, timeout_ms),
@@ -9277,7 +9280,7 @@ fn customGlueTryBoxModelUnknownPayload(io: std.Io, allocator: Allocator, env: *c
     // generated comptime checks. A zero-sized unknown payload would collapse the
     // tag offset to 0 at both widths, so these needles pin the fix in place.
     for ([_][]const u8{
-        "        ok: RocBox,",
+        "        @\"ok\": RocBox,",
         "if (@sizeOf(Init_for_hostResult) != 16) @compileError",
         "if (@offsetOf(Init_for_hostResult, \"tag\") != 8) @compileError",
         "if (@sizeOf(Init_for_hostResult) != 8) @compileError",
@@ -10085,6 +10088,30 @@ fn customGlueZigBangRecordFieldNames(io: std.Io, allocator: Allocator, env: *con
         return customInfraFailure(allocator, timer, "failed to allocate emit flag: {}", .{err});
 
     if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{ "zig", "build-obj", generated_path, emit_flag }, project_root_path, .{ .args = &.{} })) |failure| return failure;
+    return null;
+}
+
+fn customGlueZigKeywordTagNames(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
+    const output_dir = createWorkSubdir(io, allocator, env, "glue-keyword-tags-out") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create glue output dir: {}", .{err});
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "glue", "src/glue/src/ZigGlue.roc", output_dir, "test/glue/zig-keyword-tags/main.roc" },
+        .not_contains = &.{ .{ .stream = .stderr, .text = "panic" }, .{ .stream = .stderr, .text = "invariant violated" } },
+    })) |failure| return failure;
+
+    const generated_path = std.fs.path.join(allocator, &.{ output_dir, "roc_platform_abi.zig" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate generated Zig path: {}", .{err});
+    const abi_module_arg = std.fmt.allocPrint(allocator, "-Mabi={s}", .{generated_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate generated Zig ABI module arg: {}", .{err});
+
+    // Exports force analysis of accessor bodies, including the native union
+    // representation and the 32-bit byte-storage representation.
+    for ([_][]const u8{ "x86_64-linux-musl", "wasm32-freestanding" }) |target| {
+        if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
+            "zig",   "build-obj", "-fno-emit-bin",                                      "-target",      target,
+            "--dep", "abi",       "-Mroot=test/glue/zig_keyword_tags_compile_lock.zig", abi_module_arg,
+        }, project_root_path, .{ .args = &.{} })) |failure| return failure;
+    }
     return null;
 }
 

--- a/src/glue/src/ZigGlue.roc
+++ b/src/glue/src/ZigGlue.roc
@@ -972,8 +972,8 @@ generate_single_tag_union = |type_table, duplicate_tag_names, preferred_names, t
 		var $variants = ""
 		var $idx = 0
 		for tag in tu.tags {
-			snake = to_lower_snake_case(tag.name)
-			$variants = Str.concat($variants, "    ${snake} = ${U64.to_str($idx)},\n")
+			variant_ident = name_to_zig_quoted_ident(to_lower_snake_case(tag.name))
+			$variants = Str.concat($variants, "    ${variant_ident} = ${U64.to_str($idx)},\n")
 			$idx = $idx + 1
 		}
 
@@ -997,7 +997,8 @@ generate_single_tag_union = |type_table, duplicate_tag_names, preferred_names, t
 		var $enum_variants = ""
 		var $idx = 0
 		for enum_tag in tu.tags {
-			$enum_variants = Str.concat($enum_variants, "    ${enum_tag.name} = ${U64.to_str($idx)},\n")
+			variant_ident = name_to_zig_quoted_ident(enum_tag.name)
+			$enum_variants = Str.concat($enum_variants, "    ${variant_ident} = ${U64.to_str($idx)},\n")
 			$idx = $idx + 1
 		}
 
@@ -1011,9 +1012,10 @@ generate_single_tag_union = |type_table, duplicate_tag_names, preferred_names, t
 		for union_tag in tu.tags {
 			tag_layout = abi_tag_at(abi_tags, $union_tag_idx)
 			snake = to_lower_snake_case(union_tag.name)
+			field_ident = name_to_zig_quoted_ident(snake)
 			if !(abi_tag_has_payload(tag_layout)) {
 				# No-payload variant: use [0]u8 (Zig extern unions can't have void)
-				$union_fields = Str.concat($union_fields, "        ${snake}: [0]u8,\n")
+				$union_fields = Str.concat($union_fields, "        ${field_ident}: [0]u8,\n")
 			} else if List.len(union_tag.payload) == 1 {
 				zig_type = match List.first(union_tag.payload) {
 					Ok(pid) => type_id_to_zig(type_table, duplicate_tag_names, preferred_names, pid)
@@ -1021,13 +1023,13 @@ generate_single_tag_union = |type_table, duplicate_tag_names, preferred_names, t
 						crash "glue invariant violated: single-payload tag had no payload"
 					}
 				}
-				$union_fields = Str.concat($union_fields, "        ${snake}: ${zig_type},\n")
-				$accessors64 = Str.concat($accessors64, "    pub fn payload_${snake}(self: *const @This()) ${zig_type} {\n        return self.payload.${snake};\n    }\n")
+				$union_fields = Str.concat($union_fields, "        ${field_ident}: ${zig_type},\n")
+				$accessors64 = Str.concat($accessors64, "    pub fn payload_${snake}(self: *const @This()) ${zig_type} {\n        return self.payload.${field_ident};\n    }\n")
 				$accessors32 = Str.concat($accessors32, "    pub fn payload_${snake}(self: *const @This()) ${zig_type} {\n        const ptr: *const ${zig_type} = @ptrCast(@alignCast(&self.payload));\n        return ptr.*;\n    }\n")
 			} else {
 				tuple_name = "${struct_name}${capitalize_first(union_tag.name)}Payload"
-				$union_fields = Str.concat($union_fields, "        ${snake}: ${tuple_name},\n")
-				$accessors64 = Str.concat($accessors64, "    pub fn payload_${snake}(self: *const @This()) ${tuple_name} {\n        return self.payload.${snake};\n    }\n")
+				$union_fields = Str.concat($union_fields, "        ${field_ident}: ${tuple_name},\n")
+				$accessors64 = Str.concat($accessors64, "    pub fn payload_${snake}(self: *const @This()) ${tuple_name} {\n        return self.payload.${field_ident};\n    }\n")
 				$accessors32 = Str.concat($accessors32, "    pub fn payload_${snake}(self: *const @This()) ${tuple_name} {\n        const ptr: *const ${tuple_name} = @ptrCast(@alignCast(&self.payload));\n        return ptr.*;\n    }\n")
 			}
 			$union_tag_idx = $union_tag_idx + 1
@@ -1168,7 +1170,7 @@ release_policy_for_type_id = |type_table, duplicate_tag_names, preferred_names, 
 					} else {
 						"${tag_union_struct_name(preferred_names, duplicate_tag_names, type_id, tu)}Release"
 					}
-			}
+				}
 		_ => ""
 	}
 }
@@ -1193,10 +1195,10 @@ type_ident_zig = |type_table, duplicate_tag_names, preferred_names, type_id|
 				name_to_struct_name(rec.name)
 			}
 		RocTagUnion(tu) =>
-			# Mirrors `resolve_tag_union_type`, except a single-variant union
-			# resolves through its payload's fragment: that function can return
-			# a rendered type such as `RocList(RocStr)`, which is not an
-			# identifier.
+		# Mirrors `resolve_tag_union_type`, except a single-variant union
+		# resolves through its payload's fragment: that function can return
+		# a rendered type such as `RocList(RocStr)`, which is not an
+		# identifier.
 			match TypeTable.single_variant_payload(tu) {
 				SinglePayload(payload_id) => type_ident_zig(type_table, duplicate_tag_names, preferred_names, payload_id)
 				SingleNoPayload => "Type${U64.to_str(type_id)}"
@@ -1345,9 +1347,10 @@ generate_record_refcount_methods = |type_table, duplicate_tag_names, preferred_n
 generate_tag_payload_refcount_branch : TypeTable, List(Str), TypeNamePlan.PreferredNames, TagVariant, Str -> Str
 generate_tag_payload_refcount_branch = |type_table, duplicate_tag_names, preferred_names, tag, mode| {
 	snake = to_lower_snake_case(tag.name)
+	variant_ident = name_to_zig_quoted_ident(tag.name)
 
 	if List.is_empty(tag.payload) {
-		return "        .${tag.name} => {},\n"
+		return "        .${variant_ident} => {},\n"
 	}
 
 	if List.len(tag.payload) == 1 {
@@ -1365,9 +1368,9 @@ generate_tag_payload_refcount_branch = |type_table, duplicate_tag_names, preferr
 			}
 
 		if body == "" {
-			"        .${tag.name} => {},\n"
+			"        .${variant_ident} => {},\n"
 		} else {
-			"        .${tag.name} => {\n${indent_lines(body, "    ")}        },\n"
+			"        .${variant_ident} => {\n${indent_lines(body, "    ")}        },\n"
 		}
 	} else {
 		var $statements = ""
@@ -1384,9 +1387,9 @@ generate_tag_payload_refcount_branch = |type_table, duplicate_tag_names, preferr
 		}
 
 		if $statements == "" {
-			"        .${tag.name} => {},\n"
+			"        .${variant_ident} => {},\n"
 		} else {
-			"        .${tag.name} => {\n        const payload = value.payload_${snake}();\n${$statements}        },\n"
+			"        .${variant_ident} => {\n        const payload = value.payload_${snake}();\n${$statements}        },\n"
 		}
 	}
 }
@@ -1773,7 +1776,8 @@ expect name_to_camel("Echo.line!") == "echoLine"
 ## Checks `name_to_camel` for this representative case.
 expect name_to_camel("PartDef.Idx.get!") == "partDefIdxGet"
 
-## Quote a Roc record field as a Zig identifier without changing its name.
+## Quote a Roc-derived name as a Zig identifier without changing its identity.
+## Keep raw names separate when composing prefixed identifiers such as accessors.
 name_to_zig_quoted_ident : Str -> Str
 name_to_zig_quoted_ident = |name| "@\"${name}\""
 

--- a/test/glue/zig-keyword-tags/KeywordTags.roc
+++ b/test/glue/zig-keyword-tags/KeywordTags.roc
@@ -1,0 +1,5 @@
+KeywordTags := [].{
+	send! : U8 => Try({}, [TooLarge, Unreachable])
+	resolve! : U8 => Try({}, [Defer, Other(Str)])
+	payload! : U8 => [Defer, Export(U64), Struct(U64, U32)]
+}

--- a/test/glue/zig-keyword-tags/main.roc
+++ b/test/glue/zig-keyword-tags/main.roc
@@ -1,0 +1,18 @@
+platform ""
+	requires {
+		main! : () => {}
+	}
+	exposes [KeywordTags]
+	packages {}
+	provides { "roc_main": main_for_host! }
+	hosted {
+		"roc_keyword_tags_send": KeywordTags.send!,
+		"roc_keyword_tags_resolve": KeywordTags.resolve!,
+		"roc_keyword_tags_payload": KeywordTags.payload!,
+	}
+	targets: {}
+
+import KeywordTags
+
+main_for_host! : () => {}
+main_for_host! = main!

--- a/test/glue/zig_keyword_tags_compile_lock.zig
+++ b/test/glue/zig_keyword_tags_compile_lock.zig
@@ -1,0 +1,31 @@
+//! Issue 11196: keyword tag declarations and accessor bodies must compile.
+const abi = @import("abi");
+
+comptime {
+    if (@intFromEnum(abi.TooLargeOrUnreachable.too_large) != 0 or
+        @intFromEnum(abi.TooLargeOrUnreachable.@"unreachable") != 1)
+        @compileError("pure enum discriminants changed");
+
+    if (!@hasField(abi.DeferOrOtherPayload, "defer") or
+        !@hasField(abi.DeferOrOtherPayload, "other") or
+        !@hasField(abi.DeferOrExportOrStructPayload, "defer") or
+        !@hasField(abi.DeferOrExportOrStructPayload, "export") or
+        !@hasField(abi.DeferOrExportOrStructPayload, "struct"))
+        @compileError("payload field names changed");
+}
+
+/// Force analysis of a keyword field access with a single payload.
+export fn keywordSinglePayload(value: *const abi.DeferOrExportOrStruct) u64 {
+    return value.payload_export();
+}
+
+/// Force analysis of a keyword field access with multiple payloads.
+export fn keywordTuplePayload(value: *const abi.DeferOrExportOrStruct) u64 {
+    const payload = value.payload_struct();
+    return payload._0 + payload._1;
+}
+
+/// Ordinary field and accessor names retain their identity.
+export fn ordinaryPayload(value: *const abi.DeferOrOther) abi.RocStr {
+    return value.payload_other();
+}


### PR DESCRIPTION
Zig glue now quotes generated tag members and their references, so Roc tags such as `Unreachable` and `Defer` generate valid Zig. The same identifier renderer handles enum members, payload fields, and field accesses while preserving generated names and ABI layouts.

Fixes #11196.
