### PR TITLE
Prevent nominal backing cycles in Lambda Solved

### DIFF
--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -39,6 +39,10 @@ const UnifyFinishAction = union(enum) {
         var_: Type.TypeVarId,
         target: Type.TypeVarId,
     },
+    link_structural_to_inspectable_named: struct {
+        structural: Type.TypeVarId,
+        named: Type.TypeVarId,
+    },
     set_left_erased_link_right: struct {
         lhs: Type.TypeVarId,
         rhs: Type.TypeVarId,
@@ -1454,7 +1458,14 @@ const Solver = struct {
         defer cloner.deinit();
         const content = try cloner.lowerContent(self.lifted.types.get(leaf.id));
         self.program.types.set(root, content);
+        self.registerNamedBacking(content);
         return content;
+    }
+
+    fn registerNamedBacking(self: *Solver, content: Type.Content) void {
+        if (content == .named) {
+            if (content.named.backing) |backing| self.program.types.markNamedBacking(backing.ty);
+        }
     }
 
     fn resolvedContentAt(self: *Solver, root: Type.TypeVarId) Allocator.Error!Type.Content {
@@ -1793,11 +1804,17 @@ const Solver = struct {
         structural_ty: Type.TypeVarId,
         backing_ty: Type.TypeVarId,
     ) Allocator.Error!void {
-        try stack.append(self.allocator, .{ .process = .{
-            .lhs = structural_ty,
-            .rhs = backing_ty,
-            .structural_isolated = true,
-        } });
+        try stack.append(self.allocator, .{
+            .process = .{
+                // Keep the owned backing as the representative when the
+                // structural shapes are merged. The isolated clone may later be
+                // related to a nominal root, but a backing must never resolve to
+                // the nominal type that owns it.
+                .lhs = backing_ty,
+                .rhs = structural_ty,
+                .structural_isolated = true,
+            },
+        });
     }
 
     fn processUnifyPair(
@@ -2053,6 +2070,12 @@ const Solver = struct {
             .none => {},
             .link_rhs_to_lhs => |link| self.program.types.set(link.rhs, .{ .link = link.lhs }),
             .link_var_to_root => |link| self.program.types.set(link.var_, .{ .link = self.program.types.rootCompressed(link.target) }),
+            .link_structural_to_inspectable_named => |link| {
+                const structural_root = self.program.types.rootCompressed(link.structural);
+                const named_root = self.program.types.rootCompressed(link.named);
+                if (structural_root == named_root or self.program.types.isOwnedNamedBacking(structural_root)) return;
+                self.program.types.set(structural_root, .{ .link = named_root });
+            },
             .set_left_erased_link_right => |set| {
                 self.program.types.set(set.lhs, .{ .erased = .{
                     .source_fn_ty = set.source_fn_ty,
@@ -2179,10 +2202,12 @@ const Solver = struct {
             structural_ty
         else
             try self.program.types.add(structural_content);
-        stack.items[finish_index].finish.action = .{ .link_var_to_root = .{
-            .var_ = structural_ty,
-            .target = named_ty,
-        } };
+        if (!structural_isolated) {
+            stack.items[finish_index].finish.action = .{ .link_structural_to_inspectable_named = .{
+                .structural = structural_ty,
+                .named = named_ty,
+            } };
+        }
         try self.pushIsolatedStructuralPair(stack, working_structural, backing.ty);
         return true;
     }
@@ -3118,7 +3143,9 @@ const TypeCloner = struct {
         }
         const reserved = try self.solver.program.types.add(.unbound);
         try self.map.put(ty, reserved);
-        self.solver.program.types.set(reserved, try self.lowerContent(self.solver.lifted.types.get(ty)));
+        const lowered = try self.lowerContent(self.solver.lifted.types.get(ty));
+        self.solver.program.types.set(reserved, lowered);
+        self.solver.registerNamedBacking(lowered);
         if (shareable) try self.solver.shared_clones.put(ty, reserved);
         return reserved;
     }
@@ -3463,6 +3490,47 @@ test "inspectable backing unification isolates the structural type variable once
 
     try std.testing.expectEqual(vars_before_unify + 1, program.types.vars.items.len);
     try std.testing.expectEqual(program.types.root(outer_named), program.types.root(structural));
+    try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, try solver.shapeContent(structural));
+}
+
+test "inspectable backing unification never redirects an owned backing to its nominal type" {
+    const allocator = std.testing.allocator;
+
+    var program: Ast.Program = undefined;
+    program.types = Type.Store.init(allocator);
+    defer program.types.deinit();
+
+    const backing = try program.types.add(.{ .primitive = .u64 });
+    const named = try program.types.add(.{ .named = .{
+        .named_type = undefined,
+        .def = undefined,
+        .kind = .nominal,
+        .args = .empty(),
+        .backing = .{ .ty = backing, .use = .inspectable },
+    } });
+    const backing_representative = try program.types.add(.{ .primitive = .u64 });
+
+    var solver: Solver = undefined;
+    solver.allocator = allocator;
+    solver.program = &program;
+    solver.lifted = undefined;
+    solver.active_unifications = std.AutoHashMap(UnifyPair, void).init(allocator);
+    defer solver.active_unifications.deinit();
+    solver.unify_stack = .empty;
+    defer solver.unify_stack.deinit(allocator);
+    program.types.markNamedBacking(backing);
+    program.types.set(backing, .{ .link = backing_representative });
+    solver.solved_set_pool = collections.DenseMapPool(Type.TypeVarId, void).init(allocator);
+    defer solver.solved_set_pool.deinit();
+    solver.mono_set_pool = collections.DenseMapPool(MonoType.TypeId, void).init(allocator);
+    defer solver.mono_set_pool.deinit();
+
+    try solver.unify(backing, named);
+
+    try std.testing.expectEqual(backing_representative, program.types.root(backing));
+    try std.testing.expect(program.types.root(backing) != program.types.root(named));
+    try std.testing.expect(program.types.isOwnedNamedBacking(backing));
+    try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, program.types.rootContent(backing));
 }
 
 test "lambda solved solve declarations are referenced" {

--- a/src/postcheck/lambda_solved/type.zig
+++ b/src/postcheck/lambda_solved/type.zig
@@ -149,6 +149,7 @@ test "lambda solved named backing preserves generated-private authority" {
 pub const Store = struct {
     allocator: std.mem.Allocator,
     vars: std.ArrayList(Content),
+    owned_named_backings: std.ArrayList(bool),
     spans: std.ArrayList(TypeVarId),
     fields: std.ArrayList(Field),
     tags: std.ArrayList(Tag),
@@ -160,6 +161,7 @@ pub const Store = struct {
         return .{
             .allocator = allocator,
             .vars = .empty,
+            .owned_named_backings = .empty,
             .spans = .empty,
             .fields = .empty,
             .tags = .empty,
@@ -176,17 +178,34 @@ pub const Store = struct {
         self.tags.deinit(self.allocator);
         self.fields.deinit(self.allocator);
         self.spans.deinit(self.allocator);
+        self.owned_named_backings.deinit(self.allocator);
         self.vars.deinit(self.allocator);
     }
 
     pub fn add(self: *Store, content: Content) std.mem.Allocator.Error!TypeVarId {
         const id: TypeVarId = @enumFromInt(@as(u32, @intCast(self.vars.items.len)));
         try self.vars.append(self.allocator, content);
+        errdefer _ = self.vars.pop();
+        try self.owned_named_backings.append(self.allocator, false);
         return id;
     }
 
     pub fn set(self: *Store, id: TypeVarId, content: Content) void {
+        if (content == .link and self.owned_named_backings.items[@intFromEnum(id)]) {
+            const target = self.root(content.link);
+            self.owned_named_backings.items[@intFromEnum(target)] = true;
+        }
         self.vars.items[@intFromEnum(id)] = content;
+    }
+
+    pub fn markNamedBacking(self: *Store, id: TypeVarId) void {
+        const root_id = self.root(id);
+        self.owned_named_backings.items[@intFromEnum(root_id)] = true;
+    }
+
+    pub fn isOwnedNamedBacking(self: *const Store, id: TypeVarId) bool {
+        const root_id = self.root(id);
+        return self.owned_named_backings.items[@intFromEnum(root_id)];
     }
 
     pub fn get(self: *const Store, id: TypeVarId) Content {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -5365,6 +5365,9 @@ const Cloner = struct {
         switch (expr.data) {
             .local => |local| {
                 if (self.subst.getForClone(self.pass.program, local)) |value| {
+                    if (!sameType(self.pass.program, expr.ty, valueType(self.pass.program, value))) {
+                        return try self.wrapTypedBoundaryValue(expr.ty, value);
+                    }
                     const resolved_local = switch (value) {
                         .expr => |resolved| localExpr(self.pass.program, resolved),
                         .runtime_anchor => |anchor| localExpr(self.pass.program, anchor.runtime),
@@ -15201,7 +15204,9 @@ test "substitution resolves equivalent named types with distinct checked provena
     defer cloner.deinit();
     try cloner.subst.put(&program, first, .{ .expr = replacement_expr });
     const cloned = try cloner.cloneExpr(second_expr);
-    try std.testing.expectEqual(replacement, program.getExpr(cloned).data.local);
+    const boundary = program.getExpr(cloned).data.typed_boundary;
+    try std.testing.expectEqual(second_ty, program.getExpr(cloned).ty);
+    try std.testing.expectEqual(replacement, program.getExpr(boundary.value).data.local);
 }
 
 test "known match fold aborts on undecidable branches and trips the invariant when every branch is excluded" {

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -11359,6 +11359,7 @@ fn cloneSolvedTypeStore(allocator: std.mem.Allocator, source: *const SolvedType.
     return .{
         .allocator = allocator,
         .vars = try cloneArrayList(SolvedType.Content, allocator, &source.vars),
+        .owned_named_backings = try cloneArrayList(bool, allocator, &source.owned_named_backings),
         .spans = try cloneArrayList(SolvedType.TypeVarId, allocator, &source.spans),
         .fields = try cloneArrayList(SolvedType.Field, allocator, &source.fields),
         .tags = try cloneArrayList(SolvedType.Tag, allocator, &source.tags),


### PR DESCRIPTION
Fixes the compiler spin reported in #11215.

SpecConstr can substitute a value whose checked type is semantically equivalent but whose exact Monotype representation differs. Preserve that exact boundary explicitly instead of letting the substituted expression silently acquire the consumer type.

Lambda Solved now tracks which union-find classes are owned named backings. Inspectable named/structural relations use a dedicated deferred action that re-resolves roots after child unification and never redirects an owned backing into a nominal root. This prevents graphs such as `Pos -> backing -> Pos`, while preserving the existing nominal redirect for ordinary structural values. The ownership bit follows union-find links and is registered for both eager and lazy Monotype materialization.

Verification:
- `zig build run-test-zig-module-postcheck --summary failures`
- `zig build minici` (76/76 phases passed; an initial timing-sensitive issue-11133 failure passed when rerun, followed by a fully green MiniCI rerun)
- terrocotta reduced `Layout.roc` reproducer: 50/50 tests pass in ~6.6s with the debug compiler
- `roc check` passes for terrocotta `package/Layout.roc` and the counter, floating, image, scrollable, text_wrap, and widgets examples

The full terrocotta test module now gets beyond the former Lambda Solved spin and reaches a separate ARC certification failure (`borrowed local ... crossed a join without a live owner local`). Screwbot also has independent roc-ray rc5 API migration errors; neither is treated as fixed by this compiler PR.