### PR TITLE
Fix ARC residual shell liveness

### DIFF
--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -1198,7 +1198,7 @@ const ArcPlanStep = struct {
     retain_assign_ref_target: bool = true,
     take_assign_ref_target: bool = false,
     /// Absent committed field places on a same-layout representation-shell
-    /// alias, in the dismantle container's compact field-mask domain.
+    /// alias, indexed by the fields' semantic record positions.
     residual_shell_absent_mask: u64 = 0,
     residual_shell_all_rc_fields_absent: bool = false,
     retain_set_target: bool = true,
@@ -1814,8 +1814,8 @@ const Inserter = struct {
 
         var semantic_fields: [64]u32 = undefined;
         var count: usize = 0;
-        for (container.fields, 0..) |field, index| {
-            const field_mask = @as(u64, 1) << @intCast(index);
+        for (container.fields) |field| {
+            const field_mask = @as(u64, 1) << @intCast(field.field_idx);
             if ((absent_mask & field_mask) == 0) continue;
             semantic_fields[count] = field.field_idx;
             count += 1;
@@ -9984,6 +9984,48 @@ test "RC complete payload moves while parent representation has a later scalar f
     // manufacturing another unit, while the certifier keeps the shell read
     // distinct from any later RC-bearing use.
     try testing.expectEqual(@as(usize, 0), f.countRc(extracted, .incref));
+}
+
+test "RC residual shell metadata uses semantic field indices" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const record_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+        .{ .index = 0, .layout = .i64 },
+        .{ .index = 1, .layout = .i64 },
+        .{ .index = 2, .layout = .str },
+    });
+    const first_scalar = try f.local(.i64);
+    const second_scalar = try f.local(.i64);
+    const payload = try f.local(.str);
+    const record = try f.local(record_layout);
+    const taken = try f.local(.str);
+    const call_result = try f.local(.i64);
+    const shell = try f.local(record_layout);
+    const result = try f.local(.i64);
+
+    const ret = try f.ret(result);
+    const read_scalar = try f.assignRefField(result, shell, 0, ret);
+    const alias_shell = try f.assignRefLocal(shell, record, read_scalar);
+    const consume_payload = try f.assignCall(call_result, &.{taken}, alias_shell);
+    const take_payload = try f.assignRefField(taken, record, 2, consume_payload);
+    const make_record = try f.assignStruct(record, &.{ first_scalar, second_scalar, payload }, take_payload);
+    const make_payload = try f.assignStr(payload, "payload", make_record);
+    const make_second_scalar = try f.assignI64(second_scalar, 2, make_payload);
+    const body = try f.assignI64(first_scalar, 1, make_second_scalar);
+    _ = try f.addProc(&.{}, body, .i64);
+    try f.run();
+
+    var found = false;
+    for (0..f.store.cfStmtCount()) |stmt_index| {
+        const stmt = f.store.getCFStmt(@enumFromInt(@as(u32, @intCast(stmt_index))));
+        if (stmt != .assign_ref or stmt.assign_ref.target != shell) continue;
+        const absent = f.store.getU32Span(stmt.assign_ref.residual_shell_absent_fields);
+        if (absent.len == 0) continue;
+        try testing.expectEqual(@as(usize, 1), absent.len);
+        try testing.expectEqual(@as(u32, 2), GuardedList.at(absent, 0));
+        found = true;
+    }
+    try testing.expect(found);
 }
 
 test "RC early_return emits correct number of decrefs for multi-use symbol" {

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -1869,7 +1869,7 @@ const Certifier = struct {
 
         const info = self.values.items[value];
         if (info.always_live) return true;
-        if (state.balanceOf(value) > 0) return true;
+        if (state.balanceOf(value) > 0 and !try self.claimsSpendUnit(state, value)) return true;
         const holder = state.holderOf(value);
         if (holder != no_value and try self.valueIsLiveSeen(state, holder, seen)) {
             return true;
@@ -2494,7 +2494,9 @@ const Certifier = struct {
         defer seen.unset(value_index);
 
         const info = self.values.items[value];
-        if (info.always_live or state.balanceOf(value) > 0) {
+        if (info.always_live or
+            (state.balanceOf(value) > 0 and !try self.claimsSpendUnit(state, value)))
+        {
             try appendUniqueValueId(anchors, self.allocator, value);
             return true;
         }
@@ -7230,6 +7232,43 @@ test "certify preserves a holder alternative to a payload lender across a join" 
     _ = try f.addProc(&.{owner}, field_read, .i64);
 
     try f.certify();
+}
+
+test "a fully claimed holder does not keep a stale alias live across a join" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+    const holder_layout = try f.layouts.putStructFields(&.{.{ .index = 0, .layout = .str }});
+    const payload = try f.local(.str);
+    const holder = try f.local(holder_layout);
+    const taken = try f.local(.str);
+    const result = try f.local(.i64);
+
+    const ret = try f.ret(result);
+    const result_assign = try f.assignI64(result, ret);
+    const use_stale_payload = try f.store.addCFStmt(.{ .expect = .{
+        .condition = payload,
+        .next = result_assign,
+    } });
+    const join_id = f.freshJoinPointId();
+    const jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const release_taken = try f.decrefStmt(taken, .str, jump);
+    const take = try fieldReadStmt(&f, taken, holder, 0, release_taken);
+    const make_holder = try f.store.addCFStmt(.{ .assign_struct = .{
+        .target = holder,
+        .fields = try f.store.addLocalSpan(&.{payload}),
+        .next = take,
+    } });
+    const join = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = LIR.LocalSpan.empty(),
+        .body = use_stale_payload,
+        .remainder = make_holder,
+    } });
+    const body = try f.assignStr(payload, join);
+    _ = try f.addProc(&.{}, body, .i64);
+
+    try testing.expectError(error.Certification, f.certify());
+    try testing.expect(std.mem.find(u8, f.diag.message(), "unbound") != null);
 }
 
 test "certify drops a dead dormant lender from an owned join value" {

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -39,6 +39,10 @@ const UnifyFinishAction = union(enum) {
         var_: Type.TypeVarId,
         target: Type.TypeVarId,
     },
+    link_structural_to_inspectable_named: struct {
+        structural: Type.TypeVarId,
+        named: Type.TypeVarId,
+    },
     set_left_erased_link_right: struct {
         lhs: Type.TypeVarId,
         rhs: Type.TypeVarId,
@@ -1454,7 +1458,14 @@ const Solver = struct {
         defer cloner.deinit();
         const content = try cloner.lowerContent(self.lifted.types.get(leaf.id));
         self.program.types.set(root, content);
+        self.registerNamedBacking(content);
         return content;
+    }
+
+    fn registerNamedBacking(self: *Solver, content: Type.Content) void {
+        if (content == .named) {
+            if (content.named.backing) |backing| self.program.types.markNamedBacking(backing.ty);
+        }
     }
 
     fn resolvedContentAt(self: *Solver, root: Type.TypeVarId) Allocator.Error!Type.Content {
@@ -1793,11 +1804,17 @@ const Solver = struct {
         structural_ty: Type.TypeVarId,
         backing_ty: Type.TypeVarId,
     ) Allocator.Error!void {
-        try stack.append(self.allocator, .{ .process = .{
-            .lhs = structural_ty,
-            .rhs = backing_ty,
-            .structural_isolated = true,
-        } });
+        try stack.append(self.allocator, .{
+            .process = .{
+                // Keep the owned backing as the representative when the
+                // structural shapes are merged. The isolated clone may later be
+                // related to a nominal root, but a backing must never resolve to
+                // the nominal type that owns it.
+                .lhs = backing_ty,
+                .rhs = structural_ty,
+                .structural_isolated = true,
+            },
+        });
     }
 
     fn processUnifyPair(
@@ -2053,6 +2070,12 @@ const Solver = struct {
             .none => {},
             .link_rhs_to_lhs => |link| self.program.types.set(link.rhs, .{ .link = link.lhs }),
             .link_var_to_root => |link| self.program.types.set(link.var_, .{ .link = self.program.types.rootCompressed(link.target) }),
+            .link_structural_to_inspectable_named => |link| {
+                const structural_root = self.program.types.rootCompressed(link.structural);
+                const named_root = self.program.types.rootCompressed(link.named);
+                if (structural_root == named_root or self.program.types.isOwnedNamedBacking(structural_root)) return;
+                self.program.types.set(structural_root, .{ .link = named_root });
+            },
             .set_left_erased_link_right => |set| {
                 self.program.types.set(set.lhs, .{ .erased = .{
                     .source_fn_ty = set.source_fn_ty,
@@ -2179,10 +2202,12 @@ const Solver = struct {
             structural_ty
         else
             try self.program.types.add(structural_content);
-        stack.items[finish_index].finish.action = .{ .link_var_to_root = .{
-            .var_ = structural_ty,
-            .target = named_ty,
-        } };
+        if (!structural_isolated) {
+            stack.items[finish_index].finish.action = .{ .link_structural_to_inspectable_named = .{
+                .structural = structural_ty,
+                .named = named_ty,
+            } };
+        }
         try self.pushIsolatedStructuralPair(stack, working_structural, backing.ty);
         return true;
     }
@@ -3118,7 +3143,9 @@ const TypeCloner = struct {
         }
         const reserved = try self.solver.program.types.add(.unbound);
         try self.map.put(ty, reserved);
-        self.solver.program.types.set(reserved, try self.lowerContent(self.solver.lifted.types.get(ty)));
+        const lowered = try self.lowerContent(self.solver.lifted.types.get(ty));
+        self.solver.program.types.set(reserved, lowered);
+        self.solver.registerNamedBacking(lowered);
         if (shareable) try self.solver.shared_clones.put(ty, reserved);
         return reserved;
     }
@@ -3463,6 +3490,47 @@ test "inspectable backing unification isolates the structural type variable once
 
     try std.testing.expectEqual(vars_before_unify + 1, program.types.vars.items.len);
     try std.testing.expectEqual(program.types.root(outer_named), program.types.root(structural));
+    try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, try solver.shapeContent(structural));
+}
+
+test "inspectable backing unification never redirects an owned backing to its nominal type" {
+    const allocator = std.testing.allocator;
+
+    var program: Ast.Program = undefined;
+    program.types = Type.Store.init(allocator);
+    defer program.types.deinit();
+
+    const backing = try program.types.add(.{ .primitive = .u64 });
+    const named = try program.types.add(.{ .named = .{
+        .named_type = undefined,
+        .def = undefined,
+        .kind = .nominal,
+        .args = .empty(),
+        .backing = .{ .ty = backing, .use = .inspectable },
+    } });
+    const backing_representative = try program.types.add(.{ .primitive = .u64 });
+
+    var solver: Solver = undefined;
+    solver.allocator = allocator;
+    solver.program = &program;
+    solver.lifted = undefined;
+    solver.active_unifications = std.AutoHashMap(UnifyPair, void).init(allocator);
+    defer solver.active_unifications.deinit();
+    solver.unify_stack = .empty;
+    defer solver.unify_stack.deinit(allocator);
+    program.types.markNamedBacking(backing);
+    program.types.set(backing, .{ .link = backing_representative });
+    solver.solved_set_pool = collections.DenseMapPool(Type.TypeVarId, void).init(allocator);
+    defer solver.solved_set_pool.deinit();
+    solver.mono_set_pool = collections.DenseMapPool(MonoType.TypeId, void).init(allocator);
+    defer solver.mono_set_pool.deinit();
+
+    try solver.unify(backing, named);
+
+    try std.testing.expectEqual(backing_representative, program.types.root(backing));
+    try std.testing.expect(program.types.root(backing) != program.types.root(named));
+    try std.testing.expect(program.types.isOwnedNamedBacking(backing));
+    try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, program.types.rootContent(backing));
 }
 
 test "lambda solved solve declarations are referenced" {

--- a/src/postcheck/lambda_solved/type.zig
+++ b/src/postcheck/lambda_solved/type.zig
@@ -149,6 +149,7 @@ test "lambda solved named backing preserves generated-private authority" {
 pub const Store = struct {
     allocator: std.mem.Allocator,
     vars: std.ArrayList(Content),
+    owned_named_backings: std.ArrayList(bool),
     spans: std.ArrayList(TypeVarId),
     fields: std.ArrayList(Field),
     tags: std.ArrayList(Tag),
@@ -160,6 +161,7 @@ pub const Store = struct {
         return .{
             .allocator = allocator,
             .vars = .empty,
+            .owned_named_backings = .empty,
             .spans = .empty,
             .fields = .empty,
             .tags = .empty,
@@ -176,17 +178,34 @@ pub const Store = struct {
         self.tags.deinit(self.allocator);
         self.fields.deinit(self.allocator);
         self.spans.deinit(self.allocator);
+        self.owned_named_backings.deinit(self.allocator);
         self.vars.deinit(self.allocator);
     }
 
     pub fn add(self: *Store, content: Content) std.mem.Allocator.Error!TypeVarId {
         const id: TypeVarId = @enumFromInt(@as(u32, @intCast(self.vars.items.len)));
         try self.vars.append(self.allocator, content);
+        errdefer _ = self.vars.pop();
+        try self.owned_named_backings.append(self.allocator, false);
         return id;
     }
 
     pub fn set(self: *Store, id: TypeVarId, content: Content) void {
+        if (content == .link and self.owned_named_backings.items[@intFromEnum(id)]) {
+            const target = self.root(content.link);
+            self.owned_named_backings.items[@intFromEnum(target)] = true;
+        }
         self.vars.items[@intFromEnum(id)] = content;
+    }
+
+    pub fn markNamedBacking(self: *Store, id: TypeVarId) void {
+        const root_id = self.root(id);
+        self.owned_named_backings.items[@intFromEnum(root_id)] = true;
+    }
+
+    pub fn isOwnedNamedBacking(self: *const Store, id: TypeVarId) bool {
+        const root_id = self.root(id);
+        return self.owned_named_backings.items[@intFromEnum(root_id)];
     }
 
     pub fn get(self: *const Store, id: TypeVarId) Content {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -5365,6 +5365,9 @@ const Cloner = struct {
         switch (expr.data) {
             .local => |local| {
                 if (self.subst.getForClone(self.pass.program, local)) |value| {
+                    if (!sameType(self.pass.program, expr.ty, valueType(self.pass.program, value))) {
+                        return try self.wrapTypedBoundaryValue(expr.ty, value);
+                    }
                     const resolved_local = switch (value) {
                         .expr => |resolved| localExpr(self.pass.program, resolved),
                         .runtime_anchor => |anchor| localExpr(self.pass.program, anchor.runtime),
@@ -15201,7 +15204,9 @@ test "substitution resolves equivalent named types with distinct checked provena
     defer cloner.deinit();
     try cloner.subst.put(&program, first, .{ .expr = replacement_expr });
     const cloned = try cloner.cloneExpr(second_expr);
-    try std.testing.expectEqual(replacement, program.getExpr(cloned).data.local);
+    const boundary = program.getExpr(cloned).data.typed_boundary;
+    try std.testing.expectEqual(second_ty, program.getExpr(cloned).ty);
+    try std.testing.expectEqual(replacement, program.getExpr(boundary.value).data.local);
 }
 
 test "known match fold aborts on undecidable branches and trips the invariant when every branch is excluded" {

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -11359,6 +11359,7 @@ fn cloneSolvedTypeStore(allocator: std.mem.Allocator, source: *const SolvedType.
     return .{
         .allocator = allocator,
         .vars = try cloneArrayList(SolvedType.Content, allocator, &source.vars),
+        .owned_named_backings = try cloneArrayList(bool, allocator, &source.owned_named_backings),
         .spans = try cloneArrayList(SolvedType.TypeVarId, allocator, &source.spans),
         .fields = try cloneArrayList(SolvedType.Field, allocator, &source.fields),
         .tags = try cloneArrayList(SolvedType.Tag, allocator, &source.tags),


### PR DESCRIPTION
Stacked on #11216; please review that prerequisite first.

## Summary

- treat a unit whose complete field-claim set spends its sole balance as dead when computing certifier liveness and join carrier anchors
- materialize residual-shell absent-field metadata using semantic record indices, matching the dismantle mask domain
- add focused regressions for stale aliases across joins and non-compact refcounted field positions

## Root causes

A fully claimed aggregate retained a raw balance of one in certifier state. Join-summary liveness treated that raw balance as live without checking whether the complete claim set had already spent the unit, allowing a stale payload alias to acquire an impossible borrowed join state.

Separately, dismantle masks are indexed by semantic field position, but residual-shell metadata materialization tested those bits using the compact index within the refcounted-field list. A record whose only refcounted field was semantic field 2 therefore produced an empty absent-field span for mask `0x4`.

## Verification

- `zig build run-test-zig-module-lir --summary failures`
- all four previously failing CLI cases pass individually
- terrocotta `package/Layout.roc`: 97/97 tests pass
- `zig build minici`: 76/76 phases pass

The broader terrocotta `package/main.roc` proceeds past ARC with this change and currently exposes a separate Lambda Solved generated-private-evidence invariant; that is not included in this ARC fix.