### PR TITLE
Relate generated-private evidence through nominal backings

### DIFF
--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -1198,7 +1198,7 @@ const ArcPlanStep = struct {
     retain_assign_ref_target: bool = true,
     take_assign_ref_target: bool = false,
     /// Absent committed field places on a same-layout representation-shell
-    /// alias, in the dismantle container's compact field-mask domain.
+    /// alias, indexed by the fields' semantic record positions.
     residual_shell_absent_mask: u64 = 0,
     residual_shell_all_rc_fields_absent: bool = false,
     retain_set_target: bool = true,
@@ -1814,8 +1814,8 @@ const Inserter = struct {
 
         var semantic_fields: [64]u32 = undefined;
         var count: usize = 0;
-        for (container.fields, 0..) |field, index| {
-            const field_mask = @as(u64, 1) << @intCast(index);
+        for (container.fields) |field| {
+            const field_mask = @as(u64, 1) << @intCast(field.field_idx);
             if ((absent_mask & field_mask) == 0) continue;
             semantic_fields[count] = field.field_idx;
             count += 1;
@@ -9984,6 +9984,48 @@ test "RC complete payload moves while parent representation has a later scalar f
     // manufacturing another unit, while the certifier keeps the shell read
     // distinct from any later RC-bearing use.
     try testing.expectEqual(@as(usize, 0), f.countRc(extracted, .incref));
+}
+
+test "RC residual shell metadata uses semantic field indices" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const record_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+        .{ .index = 0, .layout = .i64 },
+        .{ .index = 1, .layout = .i64 },
+        .{ .index = 2, .layout = .str },
+    });
+    const first_scalar = try f.local(.i64);
+    const second_scalar = try f.local(.i64);
+    const payload = try f.local(.str);
+    const record = try f.local(record_layout);
+    const taken = try f.local(.str);
+    const call_result = try f.local(.i64);
+    const shell = try f.local(record_layout);
+    const result = try f.local(.i64);
+
+    const ret = try f.ret(result);
+    const read_scalar = try f.assignRefField(result, shell, 0, ret);
+    const alias_shell = try f.assignRefLocal(shell, record, read_scalar);
+    const consume_payload = try f.assignCall(call_result, &.{taken}, alias_shell);
+    const take_payload = try f.assignRefField(taken, record, 2, consume_payload);
+    const make_record = try f.assignStruct(record, &.{ first_scalar, second_scalar, payload }, take_payload);
+    const make_payload = try f.assignStr(payload, "payload", make_record);
+    const make_second_scalar = try f.assignI64(second_scalar, 2, make_payload);
+    const body = try f.assignI64(first_scalar, 1, make_second_scalar);
+    _ = try f.addProc(&.{}, body, .i64);
+    try f.run();
+
+    var found = false;
+    for (0..f.store.cfStmtCount()) |stmt_index| {
+        const stmt = f.store.getCFStmt(@enumFromInt(@as(u32, @intCast(stmt_index))));
+        if (stmt != .assign_ref or stmt.assign_ref.target != shell) continue;
+        const absent = f.store.getU32Span(stmt.assign_ref.residual_shell_absent_fields);
+        if (absent.len == 0) continue;
+        try testing.expectEqual(@as(usize, 1), absent.len);
+        try testing.expectEqual(@as(u32, 2), GuardedList.at(absent, 0));
+        found = true;
+    }
+    try testing.expect(found);
 }
 
 test "RC early_return emits correct number of decrefs for multi-use symbol" {

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -1869,7 +1869,7 @@ const Certifier = struct {
 
         const info = self.values.items[value];
         if (info.always_live) return true;
-        if (state.balanceOf(value) > 0) return true;
+        if (state.balanceOf(value) > 0 and !try self.claimsSpendUnit(state, value)) return true;
         const holder = state.holderOf(value);
         if (holder != no_value and try self.valueIsLiveSeen(state, holder, seen)) {
             return true;
@@ -2494,7 +2494,9 @@ const Certifier = struct {
         defer seen.unset(value_index);
 
         const info = self.values.items[value];
-        if (info.always_live or state.balanceOf(value) > 0) {
+        if (info.always_live or
+            (state.balanceOf(value) > 0 and !try self.claimsSpendUnit(state, value)))
+        {
             try appendUniqueValueId(anchors, self.allocator, value);
             return true;
         }
@@ -7230,6 +7232,43 @@ test "certify preserves a holder alternative to a payload lender across a join" 
     _ = try f.addProc(&.{owner}, field_read, .i64);
 
     try f.certify();
+}
+
+test "a fully claimed holder does not keep a stale alias live across a join" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+    const holder_layout = try f.layouts.putStructFields(&.{.{ .index = 0, .layout = .str }});
+    const payload = try f.local(.str);
+    const holder = try f.local(holder_layout);
+    const taken = try f.local(.str);
+    const result = try f.local(.i64);
+
+    const ret = try f.ret(result);
+    const result_assign = try f.assignI64(result, ret);
+    const use_stale_payload = try f.store.addCFStmt(.{ .expect = .{
+        .condition = payload,
+        .next = result_assign,
+    } });
+    const join_id = f.freshJoinPointId();
+    const jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const release_taken = try f.decrefStmt(taken, .str, jump);
+    const take = try fieldReadStmt(&f, taken, holder, 0, release_taken);
+    const make_holder = try f.store.addCFStmt(.{ .assign_struct = .{
+        .target = holder,
+        .fields = try f.store.addLocalSpan(&.{payload}),
+        .next = take,
+    } });
+    const join = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = LIR.LocalSpan.empty(),
+        .body = use_stale_payload,
+        .remainder = make_holder,
+    } });
+    const body = try f.assignStr(payload, join);
+    _ = try f.addProc(&.{}, body, .i64);
+
+    try testing.expectError(error.Certification, f.certify());
+    try testing.expect(std.mem.find(u8, f.diag.message(), "unbound") != null);
 }
 
 test "certify drops a dead dormant lender from an owned join value" {

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -2330,7 +2330,9 @@ const Solver = struct {
     /// shape into its producer-authored generated-private representation.
     /// Monotype has already sealed both representations, so this relation
     /// deliberately preserves every composite and named root. Only callable
-    /// slots (and still-open Lambda Solved slots) are unified.
+    /// slots (and still-open Lambda Solved slots) are unified. A checked-public
+    /// inspectable named type may correspond to its structural backing in the
+    /// private witness; walk through that backing without linking either root.
     fn relateGeneratedPrivateEvidence(
         self: *Solver,
         public_ty: Type.TypeVarId,
@@ -2445,7 +2447,15 @@ const Solver = struct {
                 try self.relateGeneratedPrivateEvidence(public_fn.ret, private_fn.ret);
             },
             .named => |public_named| {
-                if (private_content_tag != .named) Common.invariant("generated-private evidence relation received different type structure");
+                if (private_content_tag != .named) {
+                    const public_backing = public_named.backing orelse
+                        Common.invariant("generated-private evidence relation could not traverse a public named type without backing");
+                    if (public_backing.authority != .checked_public or public_backing.use != .inspectable) {
+                        Common.invariant("generated-private evidence relation could not traverse an opaque public named type");
+                    }
+                    try self.relateGeneratedPrivateEvidence(public_backing.ty, private_root);
+                    return;
+                }
                 const private_named = private.named;
                 const same_identity = public_named.kind == private_named.kind and
                     std.meta.eql(public_named.def, private_named.def) and
@@ -3531,6 +3541,60 @@ test "inspectable backing unification never redirects an owned backing to its no
     try std.testing.expect(program.types.root(backing) != program.types.root(named));
     try std.testing.expect(program.types.isOwnedNamedBacking(backing));
     try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, program.types.rootContent(backing));
+}
+
+test "generated-private evidence traverses a public inspectable named backing" {
+    const allocator = std.testing.allocator;
+    var lifted = emptyLiftedProgramForTest(allocator);
+    var program = Ast.Program.init(allocator, lifted);
+    lifted = undefined;
+    defer program.deinit();
+
+    const field_name = try program.lifted.names.internRecordFieldLabel("step");
+    const ret_ty = try program.types.add(.zst);
+    const public_callable = try program.types.add(.unbound);
+    const private_callable = try program.types.add(.{ .lambda_set = try program.types.addMembers(&.{.{
+        .lambda = @enumFromInt(1),
+        .captures = .empty(),
+    }}) });
+    const public_fn = try program.types.add(.{ .func = .{
+        .args = .empty(),
+        .callable = public_callable,
+        .ret = ret_ty,
+    } });
+    const private_fn = try program.types.add(.{ .func = .{
+        .args = .empty(),
+        .callable = private_callable,
+        .ret = ret_ty,
+    } });
+    const public_backing = try program.types.add(.{ .record = try program.types.addFields(&.{.{
+        .name = field_name,
+        .ty = public_fn,
+        .default = null,
+    }}) });
+    const private_record = try program.types.add(.{ .record = try program.types.addFields(&.{.{
+        .name = field_name,
+        .ty = private_fn,
+        .default = null,
+    }}) });
+    const public_named = try program.types.add(.{ .named = .{
+        .named_type = undefined,
+        .def = undefined,
+        .kind = .nominal,
+        .args = .empty(),
+        .backing = .{ .ty = public_backing, .use = .inspectable },
+    } });
+
+    var solver = try Solver.init(allocator, &program);
+    defer solver.deinit();
+    try solver.relateGeneratedPrivateEvidence(public_named, private_record);
+
+    try std.testing.expectEqual(
+        program.types.rootCompressed(public_callable),
+        program.types.rootCompressed(private_callable),
+    );
+    try std.testing.expect(program.types.rootCompressed(public_named) != program.types.rootCompressed(private_record));
+    try std.testing.expect(program.types.rootCompressed(public_backing) != program.types.rootCompressed(private_record));
 }
 
 test "lambda solved solve declarations are referenced" {


### PR DESCRIPTION
Stacked on #11218 (which is itself stacked on #11216); please review those prerequisites first.

## Summary

- allow Lambda Solved generated-private evidence transfer to cross a checked-public inspectable named backing when the private witness is already structural
- preserve both sealed nominal/structural roots while continuing the exact structure-validation walk through the public backing
- retain the existing invariant for opaque, runtime-layout-only, missing, or non-public backing boundaries
- add a focused regression proving callable evidence crosses the backing without linking either representation root

## Root cause

Terrocotta carries `LayoutTypes.Size`, an inspectable nominal record, inside generated iterator state. The public iterator backing retained the nominal `Size` node, while its exact generated-private witness carried the already-exposed record representation at the corresponding payload position. `relateGeneratedPrivateEvidence` required both sides to have the same root tag before it considered the public nominal backing, so it panicked on the valid `named -> record` visibility boundary.

The evidence relation exists to walk matching runtime structure and transfer callable/open-slot evidence without replacing sealed Monotype roots. Traversing an explicitly checked-public inspectable backing is therefore the exact missing case; ordinary opaque boundaries remain rejected.

## Verification

- focused `generated-private evidence traverses a public inspectable named backing` regression
- `zig build run-test-zig-module-postcheck --summary failures`
- terrocotta `package/main.roc`: 135/135 tests pass
- `zig build minici`: 76/76 phases pass