### PR TITLE
Fix publication panic for abandoned associated lookups

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -15793,9 +15793,9 @@ pub const ResolvedValueRefTable = struct {
         var node_idx: u32 = 0;
         while (node_idx < module.nodeCount()) : (node_idx += 1) {
             const tag = module.nodeTag(@enumFromInt(node_idx));
-            if (tag == .expr_associated_lookup_local or tag == .expr_associated_lookup) {
-                checkedArtifactInvariant("unresolved associated lookup reached resolved value publication", .{});
-            }
+            // Checked source traversal and body copying already reject unresolved
+            // associated lookups in published expressions. Abandoned source nodes
+            // can still contain unresolved lookups and need no value reference.
             if (tag != .expr_var and
                 tag != .expr_external_lookup and
                 tag != .expr_associated_lookup_resolved and

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -168,6 +168,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11158_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11199_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11175_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11233_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11233_test.zig
+++ b/src/compile/test/issue_11233_test.zig
@@ -1,0 +1,44 @@
+//! Regression test for issue #11233: a chained range under a unary operator must
+//! report the chained-range error instead of leaving an unresolved associated
+//! lookup for checked artifact publication.
+//! repro for https://github.com/roc-lang/roc/issues/11233
+
+const std = @import("std");
+const roc_target = @import("roc_target");
+const compile_build = @import("../compile_build.zig");
+const BuildEnv = compile_build.BuildEnv;
+
+test "issue 11233: negated chained range reports rather than aborting publication" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "Repro.roc",
+        .data =
+        \\r = !1..<5..<10
+        \\
+        ,
+    });
+
+    const cwd = try tmp_dir.dir.realPathFileAlloc(io, ".", gpa);
+    defer gpa.free(cwd);
+    const module_path = try tmp_dir.dir.realPathFileAlloc(io, "Repro.roc", gpa);
+    defer gpa.free(module_path);
+
+    var build_env = try BuildEnv.init(gpa, .single_threaded, 1, roc_target.RocTarget.detectNative(), cwd, io);
+    defer build_env.deinit();
+    try build_env.build(module_path);
+
+    const drained = try build_env.drainReports();
+    defer build_env.freeDrainedReports(drained);
+
+    var found_chained_range = false;
+    for (drained) |module_reports| {
+        for (module_reports.reports) |report| {
+            if (std.mem.eql(u8, report.title, "Chained Range")) found_chained_range = true;
+        }
+    }
+    try std.testing.expect(found_chained_range);
+}


### PR DESCRIPTION
`roc check` now reports “Chained Range” for `r = !1..<5..<10` instead of panicking during checked-artifact publication. Remove an assertion that incorrectly required abandoned CIR lookups to be resolved; existing checked-source traversal and body publication still enforce resolution for expressions belonging to the checked program.

Fixes #11233.
