### PR TITLE
Fix codec evidence for platform entrypoints

### DIFF
--- a/design.md
+++ b/design.md
@@ -7762,6 +7762,9 @@ Entering a restored nested body recreates its lexical substitutions in that
 body's instantiation context, consuming saved callable/capture interfaces and
 retained hidden method contracts. Descendant contexts then use ordinary live
 bindings; decoding stored evidence never attaches graph cells to durable data.
+An initializer template with no requirements derives no method evidence. A use
+of its returned value can still carry a checked recipe for a callable stored
+inside that value; that recipe is separate from the initializer edge.
 Restoring a compile-time evaluation template installs its checked scheme and
 fresh substitution in the body context even when its method evidence is already
 supplied or empty. Pending callable evaluation wrappers install the same frame

--- a/design.md
+++ b/design.md
@@ -2368,6 +2368,14 @@ or checked-error. `platformRequirementSolutionTableFromInputs` and
 `EvidencePass.run` consume that verdict directly; they never infer success by
 inspecting solved type shape or by comparing the eventual runtime value kind.
 
+A procedure requirement's root evidence follows the complete scheme of its
+recorded app definition, including captured codec requirements. The copied
+platform requirement type supplies the solved interface, not the scheme's
+evidence identity. Checked output validates a direct procedure's root vector
+against the app template's parameter count. Monotype selects this root evidence
+before materializing an edge for a direct call, procedure value, or interface
+relation; downstream specialization receives only that selected edge.
+
 A platform `provides` declaration must name a top-level value defined in the
 platform module. It cannot name a value from `requires` directly; a platform
 that wants to expose an app-provided value to its host defines an explicit

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -17870,7 +17870,9 @@ const EvidencePass = struct {
             if (!solution.is_function) continue;
 
             params.clearRetainingCapacity();
-            try self.enumerateParams(solution.solved_var, &params);
+            // The app definition owns the complete scheme, including captured
+            // codec requirements absent from the platform's copied type root.
+            try self.enumerateParams(ModuleEnv.varFrom(solution.def), &params);
             var entries = std.ArrayListUnmanaged(static_dispatch.CheckedEvidence).empty;
             defer entries.deinit(self.allocator);
             try entries.ensureTotalCapacity(self.allocator, params.items.len);
@@ -32271,6 +32273,13 @@ pub const CheckedModuleArtifact = struct {
             if (solution.value_kind != .procedure_value) continue;
             if (@as(u64, solution.root_evidence.start) + solution.root_evidence.len > self.static_dispatch_plans.evidence_refs.len) {
                 std.debug.panic("checked artifact invariant violated: platform requirement root evidence was outside the app evidence table", .{});
+            }
+            // Direct procedures consume this vector as template arguments.
+            // Evaluated callable bindings instead retain the returned value's
+            // evidence in their compile-time root payload.
+            if (self.checked_procedure_templates.lookupByDef(solution.def)) |template_ref| {
+                const template = self.checked_procedure_templates.get(template_ref.template);
+                std.debug.assert(solution.root_evidence.len == template.evidence_params.len);
             }
         }
 

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -173,6 +173,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11233_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11217_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11236_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11249_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11249_test.zig
+++ b/src/compile/test/issue_11249_test.zig
@@ -1,0 +1,122 @@
+//! Regression tests for issue #11249.
+
+const std = @import("std");
+const harness = @import("lower_to_lir_harness.zig");
+
+test "issue 11249: a decoded value returned in main!'s Err payload lowers to Monotype" {
+    try harness.expectLowersToLirWithOptions(
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"")?
+        \\    Err(InvalidSpend(parsed))
+        \\}
+    , .{ .monotype_only = true });
+}
+
+test "issue 11249: a decoded value returned in main!'s Err payload lowers to LIR" {
+    try harness.expectLowersToLir(
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"")?
+        \\    Err(InvalidSpend(parsed))
+        \\}
+    );
+}
+
+test "issue 11249: a helper's decoded Err payload propagated through main! lowers to LIR" {
+    try harness.expectLowersToLir(
+        \\get! : {} => Try({}, _)
+        \\get! = |{}| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"")?
+        \\    Err(InvalidSpend(parsed))
+        \\}
+        \\
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    get!({})?
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "issue 11249: defaulted decoding retains platform root evidence" {
+    try harness.expectLowersToLir(
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"") ?? ""
+        \\    Err(InvalidSpend(parsed))
+        \\}
+    );
+}
+
+test "issue 11249: distinct decoded payloads retain their complete root schema" {
+    try harness.expectLowersToLir(
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    text : Str
+        \\    text = Json.parse("\"1\"")?
+        \\    record : { count : I32 }
+        \\    record = Json.parse("{\"count\":2}")?
+        \\    Err(InvalidSpend({ text, record }))
+        \\}
+    );
+}
+
+test "issue 11249: an app entrypoint alias retains the evaluated callable's evidence" {
+    try harness.expectLowersToLir(
+        \\entry! : List(Str) => Try({}, _)
+        \\entry! = |_args| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"")?
+        \\    Err(InvalidSpend(parsed))
+        \\}
+        \\
+        \\main! = entry!
+    );
+}
+
+test "issue 11249: a platform passes a constrained app procedure as a value" {
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDirPath(std.testing.io, "platform");
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\app [main!] { pf: platform "./platform/main.roc" }
+        \\
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"")?
+        \\    Err(InvalidSpend(parsed))
+        \\}
+        ,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "platform/main.roc",
+        .data =
+        \\platform ""
+        \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
+        \\    exposes []
+        \\    packages {}
+        \\    provides { "roc_main": main_for_host! }
+        \\
+        \\main_for_host! : List(Str) => I8
+        \\main_for_host! = |args| {
+        \\    run! = |entry!, argv| match entry!(argv) {
+        \\        Ok({}) => 0
+        \\        Err(Exit(code)) => code
+        \\        Err(_) => 1
+        \\    }
+        \\    run!(main!, args)
+        \\}
+        ,
+    });
+    const app_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "main.roc", std.testing.allocator);
+    defer std.testing.allocator.free(app_path);
+    try harness.expectAppPathLowersToLir(app_path);
+}

--- a/src/compile/test/issue_11249_test.zig
+++ b/src/compile/test/issue_11249_test.zig
@@ -42,6 +42,20 @@ test "issue 11249: a helper's decoded Err payload propagated through main! lower
     );
 }
 
+test "issue 11249: parallel procedure roots retain app codec evidence" {
+    try harness.expectLowersToLirWithOptions(
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    parsed : Str
+        \\    parsed = Json.parse("\"1\"")?
+        \\    Err(InvalidSpend(parsed))
+        \\}
+    , .{
+        .parallel_procedure_root_fixture = true,
+        .specialization_workers = 2,
+    });
+}
+
 test "issue 11249: defaulted decoding retains platform root evidence" {
     try harness.expectLowersToLir(
         \\main! : List(Str) => Try({}, _)

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -4180,7 +4180,7 @@ const Builder = struct {
                 var dispatch_timing_scope = ProcedureTimingScope.begin(self.timing, .dispatch_evidence);
                 defer dispatch_timing_scope.end();
                 const edge = if (request.root_evidence) |root_evidence|
-                    try ctx.checkedProcedureEdgeAtRequest(self.templateRefForProcedureUse(procedure), root_evidence, root_node, .body_lowering)
+                    try ctx.checkedProcedureEdgeAtRequest(template_ref, root_evidence, root_node, .body_lowering)
                 else
                     EdgeEvidence{ .subst = &.{}, .vector = &.{} };
                 const selected = try ctx.draftFnSlotForProcedureUseAtNode(

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -4179,13 +4179,16 @@ const Builder = struct {
             const callee, const completed_fn = dispatch: {
                 var dispatch_timing_scope = ProcedureTimingScope.begin(self.timing, .dispatch_evidence);
                 defer dispatch_timing_scope.end();
+                const edge = if (request.root_evidence) |root_evidence|
+                    try ctx.checkedProcedureEdgeAtRequest(self.templateRefForProcedureUse(procedure), root_evidence, root_node, .body_lowering)
+                else
+                    EdgeEvidence{ .subst = &.{}, .vector = &.{} };
                 const selected = try ctx.draftFnSlotForProcedureUseAtNode(
                     procedure,
                     request.checked_type,
                     procedure.source_fn_ty_template,
                     root_node,
-                    .{ .subst = &.{}, .vector = &.{} },
-                    request.root_evidence,
+                    edge,
                     false,
                 );
                 const callee_fn_node = try ctx.draftFnSlotTypeNode(selected, root_node);
@@ -20745,10 +20748,7 @@ const BodyContext = struct {
         const template_ref = self.builder.templateRefForProcedureUse(procedure);
         const callee_view = self.builder.moduleForDigest(names.procTemplateModuleDigest(template_ref));
         const template = callee_view.templates.get(template_ref.template);
-        const partial_edge = if (root_evidence) |producer_evidence|
-            try self.checkedProcedureEdgeAtRequest(template_ref, producer_evidence, request_fn_node, .specialization_interface)
-        else
-            try self.evidenceForUseSiteForPurposeAtNode(record.expr, .specialization_interface, request_fn_node);
+        const partial_edge = try self.evidenceForProcedureUseAtNode(procedure, record.expr, root_evidence, request_fn_node, .specialization_interface);
         var edge = if (partial_edge.vector.len == template.evidence_params.len)
             partial_edge
         else
@@ -31957,7 +31957,6 @@ const BodyContext = struct {
             Common.invariant("checked direct call target is outside resolved value table");
         }
         const record = self.view.resolved_refs.records[raw];
-        const evidence = try self.evidenceForUseSiteAtNode(record.expr, request_fn_node);
         return switch (record.ref) {
             .local_proc => |local| .{ .local = try self.lowerDraftLocalProcAtNode(
                 local,
@@ -31966,7 +31965,7 @@ const BodyContext = struct {
                 source_fn_ty,
                 source_fn_key,
                 request_fn_node,
-                evidence,
+                try self.evidenceForUseSiteAtNode(record.expr, request_fn_node),
                 record.recursive_reference,
                 null,
             ) },
@@ -31974,14 +31973,20 @@ const BodyContext = struct {
             .imported_proc,
             .hosted_proc,
             .promoted_top_level_proc,
-            => |proc| try self.draftFnSlotForProcedureUseAtNode(proc, source_fn_ty, source_fn_key, request_fn_node, evidence, null, record.recursive_reference),
+            => |proc| try self.draftFnSlotForProcedureUseAtNode(
+                proc,
+                source_fn_ty,
+                source_fn_key,
+                request_fn_node,
+                try self.evidenceForProcedureUseAtNode(proc, record.expr, null, request_fn_node, .body_lowering),
+                record.recursive_reference,
+            ),
             .platform_required_proc => |proc| try self.draftFnSlotForProcedureUseAtNode(
                 proc.procedure,
                 source_fn_ty,
                 source_fn_key,
                 request_fn_node,
-                evidence,
-                proc.root_evidence,
+                try self.evidenceForProcedureUseAtNode(proc.procedure, record.expr, proc.root_evidence, request_fn_node, .body_lowering),
                 record.recursive_reference,
             ),
             .local_param, .local_value, .local_mutable_version, .pattern_binder, .selected_hoisted_const, .top_level_const, .imported_const, .platform_required_declaration, .platform_required_checked_error, .platform_required_const => Common.invariant("checked direct call target was not a procedure"),
@@ -31995,21 +32000,16 @@ const BodyContext = struct {
         source_fn_key: names.TypeDigest,
         request_fn_node: NodeId,
         edge: EdgeEvidence,
-        root_evidence: ?checked.CheckedEvidenceSpan,
         recursive_reference: bool,
     ) Allocator.Error!DraftFnSlot {
         const template_ref = self.builder.templateRefForProcedureUse(proc);
-        const requested_edge = if (root_evidence) |producer_evidence|
-            try self.checkedProcedureEdgeAtRequest(template_ref, producer_evidence, request_fn_node, .body_lowering)
-        else
-            edge;
         return try self.builder.lowerDraftTemplateFromContext(
             self,
             template_ref,
             source_fn_ty,
             source_fn_key,
             request_fn_node,
-            requested_edge,
+            edge,
             if (recursive_reference) .recursive_reference else .instantiation,
             if (proc.iterator_procedure == .iter_from_step) .exact_graph else .independent_roots,
             null,
@@ -32983,7 +32983,7 @@ const BodyContext = struct {
                 edge.vector,
             );
         }
-        const edge = try self.evidenceForProcedureValueAtNode(proc, site_expr, request_fn_node);
+        const edge = try self.evidenceForProcedureUseAtNode(proc, site_expr, root_evidence, request_fn_node, .body_lowering);
         const source_fn_ty = proc.source_fn_ty_payload orelse
             Common.invariant("checked procedure value reached Monotype without a requested function type");
         const slot = try self.draftFnSlotForProcedureUseAtNode(
@@ -32992,7 +32992,6 @@ const BodyContext = struct {
             proc.source_fn_ty_template,
             request_fn_node,
             edge,
-            root_evidence,
             recursive_reference,
         );
         const fn_id = try self.requireLocalDraftSlot(slot);
@@ -40234,23 +40233,22 @@ const BodyContext = struct {
         return out;
     }
 
-    /// Materialize a procedure value's checked construction recipe together
-    /// with the exact substitution recorded for that use. Callable-reachable
-    /// entries remain symbolic until the concrete function request can resolve
-    /// their checker-authored paths.
-    fn evidenceForProcedureValueAtNode(
+    /// Select the producer-authored edge before materializing any evidence.
+    /// Platform requirements carry app-owned root evidence; ordinary procedure
+    /// uses carry their checked call-site or construction evidence. Direct calls,
+    /// procedure values, and interface specialization share this selection.
+    fn evidenceForProcedureUseAtNode(
         self: *BodyContext,
         proc: checked.ProcedureUseTemplate,
         expr: checked.CheckedExprId,
+        root_evidence: ?checked.CheckedEvidenceSpan,
         request_fn_node: NodeId,
+        purpose: EvidenceMaterializationPurpose,
     ) Allocator.Error!EdgeEvidence {
-        const edge = try self.evidenceForUseSiteAtNode(expr, request_fn_node);
-        const refs = self.view.static_dispatch_plans.siteEvidence(expr) orelse return edge;
-        const schema = self.procedureUseSchema(proc);
-        if (refs.len != schema.params.len or edge.vector.len != refs.len) {
-            Common.invariant("procedure value evidence recipe length differed from its checked scheme");
+        if (root_evidence) |evidence| {
+            return try self.checkedProcedureEdgeAtRequest(self.builder.templateRefForProcedureUse(proc), evidence, request_fn_node, purpose);
         }
-        return edge;
+        return try self.evidenceForUseSiteForPurposeAtNode(expr, purpose, request_fn_node);
     }
 
     /// Resolve every symbolic callable-path entry whose dispatcher is already
@@ -40863,10 +40861,10 @@ const BodyContext = struct {
         site_refs: ?[]const static_dispatch.CheckedEvidence,
         purpose: EvidenceMaterializationPurpose,
     ) Allocator.Error![]const SpecEvidence {
-        if (schema.params.len == 0) return &.{};
         if (site_refs) |refs| {
             if (refs.len != schema.params.len) Common.invariant("checked site evidence length differed from its scheme's requirements");
         }
+        if (schema.params.len == 0) return &.{};
         const arena = self.builder.evidence_arena.allocator();
         const out = try arena.alloc(SpecEvidence, schema.params.len);
         const derived = try self.allocator.alloc(bool, schema.params.len);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -40861,10 +40861,13 @@ const BodyContext = struct {
         site_refs: ?[]const static_dispatch.CheckedEvidence,
         purpose: EvidenceMaterializationPurpose,
     ) Allocator.Error![]const SpecEvidence {
+        // An initializer with no requirements derives no method evidence.
+        // Its value's use may still have a checked recipe for a callable
+        // stored inside that value; that recipe is not an initializer edge.
+        if (schema.params.len == 0) return &.{};
         if (site_refs) |refs| {
             if (refs.len != schema.params.len) Common.invariant("checked site evidence length differed from its scheme's requirements");
         }
-        if (schema.params.len == 0) return &.{};
         const arena = self.builder.evidence_arena.allocator();
         const out = try arena.alloc(SpecEvidence, schema.params.len);
         const derived = try self.allocator.alloc(bool, schema.params.len);


### PR DESCRIPTION
Fix a compiler crash when a `Json.parse` result escapes through an app entrypoint's error payload. Platform requirements now retain the app definition's complete codec evidence, and Monotype selects that evidence before lowering calls or procedure values. This also preserves evaluated entrypoint aliases and validates direct procedure root evidence against its target schema.

Fixes #11249.
