### PR TITLE
Version promoted set loops on their owned flags

### DIFF
--- a/src/lir/body_clone.zig
+++ b/src/lir/body_clone.zig
@@ -377,6 +377,105 @@ pub fn countStmtReads(store: *const LirStore, counts: []u32, stmt: LIR.CFStmt) v
     }
 }
 
+/// Count definitions of every local reachable from `body`, walking all
+/// successor edges: statement targets, join parameters, descriptor outputs,
+/// and pattern-match captures. Operand reads are not definitions.
+pub fn countReachableDefs(store: *LirStore, body: CFStmtId) Allocator.Error!ReadCounts {
+    const counts = try store.allocator.alloc(u32, store.localCount());
+    errdefer store.allocator.free(counts);
+    @memset(counts, 0);
+
+    var work = std.ArrayList(CFStmtId).empty;
+    defer work.deinit(store.allocator);
+    var visited = collections.DenseMap(CFStmtId, void).init(store.allocator);
+    defer visited.deinit();
+
+    try work.append(store.allocator, body);
+    while (work.pop()) |stmt_id| {
+        const entry = try visited.getOrPut(stmt_id);
+        if (entry.found_existing) continue;
+
+        countStmtDefs(store, counts, store.getCFStmt(stmt_id));
+        try appendSuccessors(store, &work, stmt_id);
+    }
+
+    return .{ .allocator = store.allocator, .counts = counts };
+}
+
+/// Add this statement's definitions to an existing per-local count row.
+/// Operand reads are deliberately excluded, matching `countReachableDefs`.
+pub fn countStmtDefs(store: *const LirStore, counts: []u32, stmt: LIR.CFStmt) void {
+    switch (stmt) {
+        inline .init_uninitialized,
+        .assign_ref,
+        .assign_literal,
+        .assign_packed_erased_fn,
+        .assign_boxy_desc_ref,
+        .assign_boxy_dict_ref,
+        .assign_boxy_box,
+        .assign_boxy_reuse_box,
+        .assign_boxy_unbox,
+        .assign_boxy_adapt,
+        .assign_boxy_inspect,
+        .assign_boxy_eq,
+        .assign_boxy_tag,
+        .assign_call_dict,
+        .assign_low_level,
+        .assign_list,
+        .assign_struct,
+        .assign_tag,
+        .set_local,
+        => |s| noteRead(counts, s.target),
+        .assign_call => |s| {
+            noteRead(counts, s.target);
+            if (s.out_desc) |out_desc| noteRead(counts, out_desc);
+        },
+        .assign_call_erased => |s| {
+            noteRead(counts, s.target);
+            if (s.out_desc) |out_desc| noteRead(counts, out_desc);
+        },
+        .assign_boxy_tag_payload => |s| {
+            noteRead(counts, s.target);
+            if (s.target_desc) |target_desc| noteRead(counts, target_desc);
+        },
+        .join => |s| noteSpanReads(store, counts, s.params),
+        .str_match => |s| noteStepCaptures(store, counts, s.steps),
+        .str_match_set => |s| {
+            const arms = store.getStrMatchArms(s.arms);
+            for (0..arms.len) |index| noteStepCaptures(store, counts, GuardedList.at(arms, index).steps);
+        },
+        .store_struct,
+        .store_tag,
+        .debug,
+        .expect,
+        .expect_err,
+        .switch_stmt,
+        .switch_initialized_payload,
+        .boxy_tag_match,
+        .ret,
+        .crash,
+        .incref,
+        .decref,
+        .decref_if_initialized,
+        .free,
+        .comptime_branch_taken,
+        .jump,
+        .runtime_error,
+        .comptime_exhaustiveness_failed,
+        .loop_continue,
+        .loop_break,
+        => {},
+    }
+}
+
+fn noteStepCaptures(store: *const LirStore, counts: []u32, span: LIR.StrMatchStepSpan) void {
+    const steps = store.getStrMatchSteps(span);
+    for (0..steps.len) |index| switch (GuardedList.at(steps, index).capture) {
+        .discard => {},
+        .view => |local| noteRead(counts, local),
+    };
+}
+
 fn noteRead(counts: []u32, local: LocalId) void {
     counts[@intFromEnum(local)] += 1;
 }
@@ -658,10 +757,11 @@ pub fn cloneCallVariant(
 ///
 ///   * `cloneRet(self: *Rewriter, cloner: anytype, value: LocalId)`—required.
 ///     Produces the cloned tail for a source `ret value`.
-///   * `interceptStmt(self: *Rewriter, cloner: anytype, stmt: LIR.CFStmt)`—
+///   * `interceptStmt(self: *Rewriter, cloner: anytype, old_id: CFStmtId, stmt: LIR.CFStmt)`—
 ///     optional. Returns a cloned statement id to short-circuit the default
 ///     clone, letting the pass fuse a direct constructor/concat return into
-///     the tail, or `null` to fall through to the ordinary clone.
+///     the tail or rewrite statements it identified up front, or `null` to
+///     fall through to the ordinary clone.
 ///
 /// Both hooks receive the cloner and use its `mapLocal`, `mapLocalSpan`,
 /// `addTemp`, `directReturnOf`, and `store` surface to build their statements.
@@ -782,7 +882,7 @@ pub fn BodyCloner(comptime Rewriter: type) type {
 
             const stmt = self.store.getCFStmt(old_id);
             if (@hasDecl(Rewriter, "interceptStmt")) {
-                if (try self.rewriter.interceptStmt(self, stmt)) |intercepted| {
+                if (try self.rewriter.interceptStmt(self, old_id, stmt)) |intercepted| {
                     try self.stmt_map.put(old_id, intercepted);
                     return intercepted;
                 }

--- a/src/lir/loop_append_promote.zig
+++ b/src/lir/loop_append_promote.zig
@@ -39,12 +39,28 @@
 //! append through it could write into shared memory. Lowering emits one
 //! `ref.local` alias per use, so a taint lands on the single-purpose alias
 //! and leaves the chain spine clean.
+//!
+//! Element overwrites on a carried list thread an owned flag beside the
+//! limit: one once the list uniquely owns a non-slice allocation, measured on
+//! entry and re-established by every recognized operation. A set guarded by
+//! that flag still costs a branch per element and keeps a checked call in the
+//! loop body, which is enough to stop the backend from vectorizing the loop.
+//! Once the flag reaches one it never drops back, so a loop whose flags are
+//! all one is versioned: its head dispatches on the flags to a nested copy of
+//! the body in which every set whose flag is known one runs the unchecked
+//! store outright and every back edge that keeps the flags at one returns to
+//! the copy. The original body stays as the cold arm for shared entries and
+//! for edges that bring in a list of unknown ownership; those re-enter the
+//! head, which measures again. Both bodies share the loop's parameter locals,
+//! so the dispatch needs no argument copies, and the copy is lexically nested
+//! inside the head's body so every jump still targets an enclosing join.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const collections = @import("collections");
 const core = @import("lir_core");
 const layout_mod = @import("layout");
+const body_clone = @import("body_clone.zig");
 
 const LIR = core.LIR;
 const LirStore = core.LirStore;
@@ -62,8 +78,17 @@ pub fn run(store: *LirStore, layouts: *const layout_mod.Store) ResourceError!voi
         .store = store,
         .layouts = layouts,
         .append_kind = collections.DenseMap(LIR.LirProcSpecId, ?ProcKind).init(store.allocator),
+        .owned_defs = collections.DenseMap(LocalId, std.ArrayList(OwnedSource)).init(store.allocator),
+        .set_dispatches = collections.DenseMap(CFStmtId, void).init(store.allocator),
+        .loop_versions = collections.DenseMap(CFStmtId, LoopVersion).init(store.allocator),
     };
-    defer pass.append_kind.deinit();
+    defer {
+        pass.resetProcState();
+        pass.append_kind.deinit();
+        pass.owned_defs.deinit();
+        pass.set_dispatches.deinit();
+        pass.loop_versions.deinit();
+    }
 
     const proc_count = store.procSpecCount();
     var proc_index: usize = 0;
@@ -71,6 +96,33 @@ pub fn run(store: *LirStore, layouts: *const layout_mod.Store) ResourceError!voi
         try pass.transformProc(@enumFromInt(proc_index));
     }
 }
+
+/// One definition of an owned-flag local.
+const OwnedSource = union(enum) {
+    /// The literal one a rewritten site establishes.
+    one,
+    /// A `list_owned_unique` measurement of a list the chain did not carry.
+    measured,
+    /// A copy of, or a parameter write from, another owned-flag local.
+    local: LocalId,
+};
+
+/// Versioning bookkeeping for one promoted loop.
+const LoopVersion = struct {
+    /// Owned-flag parameters the loop carries, one per promoted list parameter.
+    owned_params: std.ArrayList(LocalId) = .empty,
+    /// Every jump into the loop, with the owned values written on that edge.
+    edge_values: collections.DenseMap(CFStmtId, std.ArrayList(LocalId)),
+    /// An edge's jump could not be located, so the loop keeps its flag form.
+    unresolved: bool = false,
+
+    fn deinit(self: *LoopVersion, allocator: Allocator) void {
+        self.owned_params.deinit(allocator);
+        var values = self.edge_values.valueIterator();
+        while (values.next()) |list| list.deinit(allocator);
+        self.edge_values.deinit();
+    }
+};
 
 /// What a helper proc's linear body reduces to.
 const ProcKind = enum {
@@ -110,6 +162,37 @@ const Pass = struct {
     store: *LirStore,
     layouts: *const layout_mod.Store,
     append_kind: collections.DenseMap(LIR.LirProcSpecId, ?ProcKind),
+    /// Definitions of every owned-flag local threaded in the current proc.
+    owned_defs: collections.DenseMap(LocalId, std.ArrayList(OwnedSource)),
+    /// Set-site dispatch switches of the current proc.
+    set_dispatches: collections.DenseMap(CFStmtId, void),
+    /// Promoted loops of the current proc, keyed by their join statement.
+    loop_versions: collections.DenseMap(CFStmtId, LoopVersion),
+
+    fn resetProcState(self: *Pass) void {
+        const allocator = self.store.allocator;
+        var defs = self.owned_defs.valueIterator();
+        while (defs.next()) |list| list.deinit(allocator);
+        self.owned_defs.clearRetainingCapacity();
+        self.set_dispatches.clearRetainingCapacity();
+        var versions = self.loop_versions.valueIterator();
+        while (versions.next()) |version| version.deinit(allocator);
+        self.loop_versions.clearRetainingCapacity();
+    }
+
+    fn noteOwnedDef(self: *Pass, local: LocalId, source: OwnedSource) ResourceError!void {
+        const entry = try self.owned_defs.getOrPut(local);
+        if (!entry.found_existing) entry.value_ptr.* = .empty;
+        try entry.value_ptr.append(self.store.allocator, source);
+    }
+
+    fn loopVersion(self: *Pass, loop_stmt: CFStmtId) ResourceError!*LoopVersion {
+        const entry = try self.loop_versions.getOrPut(loop_stmt);
+        if (!entry.found_existing) {
+            entry.value_ptr.* = .{ .edge_values = collections.DenseMap(CFStmtId, std.ArrayList(LocalId)).init(self.store.allocator) };
+        }
+        return entry.value_ptr;
+    }
 
     // Helper-proc classification
 
@@ -701,6 +784,7 @@ const Pass = struct {
         const proc = self.store.getProcSpec(proc_id);
         if (proc.body == null or proc.hosted != null) return;
         const allocator = self.store.allocator;
+        self.resetProcState();
 
         var proc_args = collections.DenseMap(LocalId, void).init(allocator);
         defer proc_args.deinit();
@@ -718,6 +802,7 @@ const Pass = struct {
         var attempted = collections.DenseMap(LocalId, void).init(allocator);
         defer attempted.deinit();
 
+        var max_join_id: u32 = 0;
         var promoting = true;
         while (promoting) {
             promoting = false;
@@ -730,9 +815,9 @@ const Pass = struct {
             };
             defer scan.deinit(allocator);
             try self.scanProc(self.store.getProcSpec(proc_id).body.?, &scan);
+            max_join_id = @max(max_join_id, scan.max_join_id);
             if (scan.edges.items.len == 0) break;
             try self.markLoops(&scan);
-            var max_join_id = scan.max_join_id;
             outer: for (scan.joins.items) |info| {
                 if (!info.has_back_edge) continue;
                 const join = self.store.getCFStmt(info.stmt).join;
@@ -751,6 +836,8 @@ const Pass = struct {
                 }
             }
         }
+
+        try self.versionLoops(self.store.getProcSpec(proc_id).body.?, &max_join_id, &new_locals);
 
         if (new_locals.items.len > 0) {
             const spec = self.store.getProcSpec(proc_id);
@@ -886,7 +973,7 @@ const Pass = struct {
         }
 
         // Qualified: thread the slack.
-        try self.apply(scan, &carriers, &chain_params, has_sets, max_join_id, new_locals);
+        try self.apply(scan, &carriers, &chain_params, has_sets, loop_stmt, list_param, max_join_id, new_locals);
         return true;
     }
 
@@ -939,6 +1026,8 @@ const Pass = struct {
         carriers: *collections.DenseMap(LocalId, void),
         chain_params: *collections.DenseMap(LocalId, CFStmtId),
         has_sets: bool,
+        loop_stmt: CFStmtId,
+        list_param: LocalId,
         max_join_id: *u32,
         new_locals: *std.ArrayList(LocalId),
     ) ResourceError!void {
@@ -967,6 +1056,11 @@ const Pass = struct {
                     const owned_param = try self.freshLocal(.u64, new_locals);
                     try owned_params.put(entry.key_ptr.*, owned_param);
                     try params.append(allocator, owned_param);
+                    try self.owned_defs.put(owned_param, .empty);
+                    if (entry.key_ptr.* == list_param) {
+                        const version = try self.loopVersion(loop_stmt);
+                        try version.owned_params.append(allocator, owned_param);
+                    }
                 }
                 join_ptr.params = try self.store.addLocalSpan(params.items);
             }
@@ -1016,6 +1110,7 @@ const Pass = struct {
                         const ox = try self.freshLocal(.u64, new_locals);
                         try shared_owned.put(entry.key_ptr.*, ox);
                         try owned_of.put(entry.key_ptr.*, ox);
+                        try self.owned_defs.put(ox, .empty);
                     }
                 }
             }
@@ -1041,8 +1136,10 @@ const Pass = struct {
                             const alias = self.store.getCFStmt(edge.stmt).assign_ref;
                             var next = alias.next;
                             if (has_sets) {
+                                const flag = shared_owned.get(edge.target).?;
+                                try self.noteOwnedDef(flag, .{ .local = source_owned });
                                 next = try self.store.addCFStmt(.{ .assign_ref = .{
-                                    .target = shared_owned.get(edge.target).?,
+                                    .target = flag,
                                     .op = .{ .local = source_owned },
                                     .next = next,
                                 } });
@@ -1098,6 +1195,7 @@ const Pass = struct {
                         if (try self.ownedOutFor(edge.target, has_sets, &shared_owned, new_locals)) |flag| {
                             // Every kept list operation returns a uniquely
                             // owned non-slice result.
+                            try self.noteOwnedDef(flag, .one);
                             next = try self.store.addCFStmt(.{ .assign_literal = .{
                                 .target = flag,
                                 .value = .{ .i64_literal = .{ .value = 1, .layout_idx = .u64 } },
@@ -1129,9 +1227,13 @@ const Pass = struct {
                 const slack = slack_of.get(edge.source).?;
                 var forward = try self.store.addCFStmt(.{ .set_local = original });
                 if (has_sets) {
+                    const owned_param = owned_params.get(edge.target).?;
+                    const owned = owned_of.get(edge.source).?;
+                    try self.noteOwnedDef(owned_param, .{ .local = owned });
+                    if (edge.target == list_param) try self.noteLoopEdge(loop_stmt, original.next, owned);
                     forward = try self.store.addCFStmt(.{ .set_local = .{
-                        .target = owned_params.get(edge.target).?,
-                        .value = owned_of.get(edge.source).?,
+                        .target = owned_param,
+                        .value = owned,
                         .mode = .initialize_join_param,
                         .next = forward,
                     } });
@@ -1148,8 +1250,12 @@ const Pass = struct {
                 var forward = try self.store.addCFStmt(.{ .set_local = original });
                 if (has_sets) {
                     const measured_owned = try self.freshLocal(.u64, new_locals);
+                    const owned_param = owned_params.get(edge.target).?;
+                    try self.noteOwnedDef(measured_owned, .measured);
+                    try self.noteOwnedDef(owned_param, .{ .local = measured_owned });
+                    if (edge.target == list_param) try self.noteLoopEdge(loop_stmt, original.next, measured_owned);
                     forward = try self.store.addCFStmt(.{ .set_local = .{
-                        .target = owned_params.get(edge.target).?,
+                        .target = owned_param,
                         .value = measured_owned,
                         .mode = .initialize_join_param,
                         .next = forward,
@@ -1214,6 +1320,7 @@ const Pass = struct {
             .op = .{ .local = slack_in },
             .next = call.next,
         } });
+        try self.noteOwnedDef(owned_out, .one);
         const owned_lit = try self.store.addCFStmt(.{ .assign_literal = .{
             .target = owned_out,
             .value = .{ .i64_literal = .{ .value = 1, .layout_idx = .u64 } },
@@ -1246,6 +1353,7 @@ const Pass = struct {
             .default_is_cold = true,
             .continuation = null,
         } });
+        try self.set_dispatches.put(dispatch, {});
 
         self.store.getCFStmtPtr(edge.stmt).* = .{ .join = .{
             .id = join_id,
@@ -1370,6 +1478,7 @@ const Pass = struct {
         var body = unsafe_append;
         if (owned_out) |flag| {
             // Both sides guarantee a uniquely owned non-slice list.
+            try self.noteOwnedDef(flag, .one);
             body = try self.store.addCFStmt(.{ .assign_literal = .{
                 .target = flag,
                 .value = .{ .i64_literal = .{ .value = 1, .layout_idx = .u64 } },
@@ -1512,6 +1621,7 @@ const Pass = struct {
         var body = call.next;
         if (owned_out) |flag| {
             // Both sides guarantee a uniquely owned non-slice list.
+            try self.noteOwnedDef(flag, .one);
             body = try self.store.addCFStmt(.{ .assign_literal = .{
                 .target = flag,
                 .value = .{ .i64_literal = .{ .value = 1, .layout_idx = .u64 } },
@@ -1524,6 +1634,305 @@ const Pass = struct {
             .body = body,
             .remainder = slop_lit,
         } };
+    }
+
+    // Loop versioning
+
+    /// The jump that a run of parameter writes starting at `start` ends in,
+    /// or null when control branches before reaching one.
+    fn jumpAfter(self: *Pass, start: CFStmtId) ?CFStmtId {
+        var current = start;
+        while (true) {
+            switch (self.store.getCFStmt(current)) {
+                .jump => return current,
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .store_struct, .store_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .decref_if_initialized, .free, .assign_boxy_desc_ref, .assign_boxy_dict_ref, .assign_boxy_box, .assign_boxy_reuse_box, .assign_boxy_unbox, .assign_boxy_adapt, .assign_boxy_inspect, .assign_boxy_eq, .assign_boxy_tag, .assign_boxy_tag_payload, .assign_call_dict => |s| current = s.next,
+                .switch_stmt, .switch_initialized_payload, .str_match, .str_match_set, .boxy_tag_match, .join, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => return null,
+            }
+        }
+    }
+
+    /// Record the owned value a loop's own parameter receives on the edge
+    /// whose writes begin at `start`, keyed by the jump that ends the edge.
+    fn noteLoopEdge(self: *Pass, loop_stmt: CFStmtId, start: CFStmtId, owned: LocalId) ResourceError!void {
+        const loop_id = self.store.getCFStmt(loop_stmt).join.id;
+        const version = try self.loopVersion(loop_stmt);
+        const jump = self.jumpAfter(start) orelse {
+            version.unresolved = true;
+            return;
+        };
+        if (self.store.getCFStmt(jump).jump.target != loop_id) {
+            version.unresolved = true;
+            return;
+        }
+        const entry = try version.edge_values.getOrPut(jump);
+        if (!entry.found_existing) entry.value_ptr.* = .empty;
+        try entry.value_ptr.append(self.store.allocator, owned);
+    }
+
+    /// Version every promoted loop whose edges were all traced, innermost
+    /// first so an outer loop's copy carries the already-versioned inner one.
+    fn versionLoops(self: *Pass, proc_body: CFStmtId, max_join_id: *u32, new_locals: *std.ArrayList(LocalId)) ResourceError!void {
+        const allocator = self.store.allocator;
+        const Candidate = struct { stmt: CFStmtId, size: u32 };
+        var candidates = std.ArrayList(Candidate).empty;
+        defer candidates.deinit(allocator);
+        var it = self.loop_versions.iterator();
+        while (it.next()) |entry| {
+            const version = entry.value_ptr;
+            if (version.unresolved or version.owned_params.items.len == 0) continue;
+            const join = self.store.getCFStmt(entry.key_ptr.*).join;
+            // Retained and conditionally initialized environments are
+            // released per join under conditions ARC tracks; the copy would
+            // need that environment duplicated, which is not modeled here.
+            if (self.store.getLocalSpan(join.retained).len != 0) continue;
+            if (self.store.getLocalSpan(join.maybe_uninitialized_params).len != 0) continue;
+            var stmts = try body_clone.ReachableStmts.init(self.store, join.body);
+            defer stmts.deinit();
+            var size: u32 = 0;
+            while (try stmts.next()) |_| size += 1;
+            try candidates.append(allocator, .{ .stmt = entry.key_ptr.*, .size = size });
+        }
+        // A loop nested in another's body has the smaller body.
+        std.mem.sort(Candidate, candidates.items, {}, struct {
+            fn lessThan(_: void, a: Candidate, b: Candidate) bool {
+                return a.size < b.size;
+            }
+        }.lessThan);
+        for (candidates.items) |candidate| {
+            try self.versionLoop(proc_body, candidate.stmt, max_join_id, new_locals);
+        }
+    }
+
+    fn containsLocal(locals: []const LocalId, local: LocalId) bool {
+        for (locals) |candidate| {
+            if (candidate == local) return true;
+        }
+        return false;
+    }
+
+    /// Split one promoted loop into a head that dispatches on its owned
+    /// flags and a nested unique-only copy of its body.
+    fn versionLoop(self: *Pass, proc_body: CFStmtId, loop_stmt: CFStmtId, max_join_id: *u32, new_locals: *std.ArrayList(LocalId)) ResourceError!void {
+        const allocator = self.store.allocator;
+        const join = self.store.getCFStmt(loop_stmt).join;
+        const version = self.loop_versions.getPtr(loop_stmt).?;
+        const flags = version.owned_params.items;
+
+        // Flags that may be zero inside the copy: measurements of lists the
+        // chain did not carry, and every flag fed by one, to a fixpoint. The
+        // loop's own flags are one throughout the copy, which is entered only
+        // when they are and re-entered only by edges that keep them so.
+        var non_static = collections.DenseMap(LocalId, void).init(allocator);
+        defer non_static.deinit();
+        {
+            var changed = true;
+            while (changed) {
+                changed = false;
+                var defs = self.owned_defs.iterator();
+                while (defs.next()) |entry| {
+                    const flag = entry.key_ptr.*;
+                    if (non_static.contains(flag) or containsLocal(flags, flag)) continue;
+                    for (entry.value_ptr.items) |def| {
+                        const unknown = switch (def) {
+                            .one => false,
+                            .measured => true,
+                            .local => |source| non_static.contains(source),
+                        };
+                        if (unknown) {
+                            try non_static.put(flag, {});
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        var retarget = collections.DenseMap(CFStmtId, void).init(allocator);
+        defer retarget.deinit();
+        {
+            var edges = version.edge_values.iterator();
+            while (edges.next()) |entry| {
+                var keeps_flags = entry.value_ptr.items.len == flags.len;
+                for (entry.value_ptr.items) |value| {
+                    if (non_static.contains(value)) keeps_flags = false;
+                }
+                if (keeps_flags) try retarget.put(entry.key_ptr.*, {});
+            }
+        }
+        var fold = collections.DenseMap(CFStmtId, void).init(allocator);
+        defer fold.deinit();
+        {
+            var sites = self.set_dispatches.keyIterator();
+            while (sites.next()) |site| {
+                const cond = self.store.getCFStmt(site.*).switch_stmt.cond;
+                if (!non_static.contains(cond)) try fold.put(site.*, {});
+            }
+        }
+
+        // The copy gets fresh locals for values that live entirely inside the
+        // body, so its stores and loads never share a slot with the cold
+        // arm's calls; everything else, the parameters included, is shared.
+        var body_reads = try body_clone.countReachableReads(self.store, join.body);
+        defer body_reads.deinit();
+        var body_defs = try body_clone.countReachableDefs(self.store, join.body);
+        defer body_defs.deinit();
+        var proc_reads = try body_clone.countReachableReads(self.store, proc_body);
+        defer proc_reads.deinit();
+        var proc_defs = try body_clone.countReachableDefs(self.store, proc_body);
+        defer proc_defs.deinit();
+
+        const unique_id: LIR.JoinPointId = @enumFromInt(max_join_id.*);
+        max_join_id.* += 1;
+        const rewriter = VersionRewriter{
+            .loop_id = join.id,
+            .unique_id = unique_id,
+            .retarget = &retarget,
+            .fold = &fold,
+            .join_map = collections.DenseMap(LIR.JoinPointId, LIR.JoinPointId).init(allocator),
+            .max_join_id = max_join_id,
+        };
+        var cloner = try body_clone.BodyCloner(VersionRewriter).init(self.store, rewriter);
+        defer cloner.deinit();
+        defer cloner.rewriter.join_map.deinit();
+        for (cloner.local_map, 0..) |*slot, index| {
+            const defs_inside = body_defs.counts[index];
+            const renamable = defs_inside > 0 and
+                defs_inside == proc_defs.counts[index] and
+                body_reads.counts[index] == proc_reads.counts[index];
+            if (!renamable) slot.* = @enumFromInt(index);
+        }
+        const body_copy = try cloner.cloneStmt(join.body);
+        try new_locals.appendSlice(allocator, cloner.new_locals.items);
+
+        const back = try self.store.addCFStmt(.{ .jump = .{ .target = unique_id } });
+        const unique_loop = try self.store.addCFStmt(.{ .join = .{
+            .id = unique_id,
+            .params = join.params,
+            .body = body_copy,
+            .remainder = back,
+        } });
+
+        // Dispatch on the conjunction of the flags; a shared entry takes the
+        // cold arm, which is the body as promoted.
+        var combined = std.ArrayList(LocalId).empty;
+        defer combined.deinit(allocator);
+        for (1..flags.len) |_| try combined.append(allocator, try self.freshLocal(.u64, new_locals));
+        const cond = if (combined.items.len == 0) flags[0] else combined.items[combined.items.len - 1];
+        const branches = try self.store.addCFSwitchBranches(&.{.{ .value = 1, .body = unique_loop }});
+        var head = try self.store.addCFStmt(.{ .switch_stmt = .{
+            .cond = cond,
+            .branches = branches,
+            .default_branch = join.body,
+            .default_is_cold = true,
+            .continuation = null,
+        } });
+        var index = combined.items.len;
+        while (index > 0) {
+            index -= 1;
+            const left = if (index == 0) flags[0] else combined.items[index - 1];
+            head = try self.store.addCFStmt(.{ .assign_low_level = .{
+                .target = combined.items[index],
+                .op = .num_bitwise_and,
+                .rc_effect = LowLevelOp.num_bitwise_and.rcEffect(),
+                .args = try self.store.addLocalSpan(&.{ left, flags[index + 1] }),
+                .next = head,
+            } });
+        }
+        self.store.getCFStmtPtr(loop_stmt).join.body = head;
+    }
+};
+
+/// Clones a promoted loop body into its unique-only copy: nested joins get
+/// fresh ids, back edges that keep the flags at one return to the copy, and
+/// set-site dispatches whose flag is one collapse to the unchecked store.
+const VersionRewriter = struct {
+    loop_id: LIR.JoinPointId,
+    unique_id: LIR.JoinPointId,
+    retarget: *const collections.DenseMap(CFStmtId, void),
+    fold: *const collections.DenseMap(CFStmtId, void),
+    join_map: collections.DenseMap(LIR.JoinPointId, LIR.JoinPointId),
+    max_join_id: *u32,
+
+    pub fn cloneRet(_: *VersionRewriter, cloner: anytype, value: LocalId) ResourceError!CFStmtId {
+        return try cloner.store.addCFStmt(.{ .ret = .{ .value = try cloner.mapLocal(value) } });
+    }
+
+    pub fn interceptStmt(self: *VersionRewriter, cloner: anytype, old_id: CFStmtId, stmt: LIR.CFStmt) ResourceError!?CFStmtId {
+        switch (stmt) {
+            .join => |s| {
+                const fresh: LIR.JoinPointId = @enumFromInt(self.max_join_id.*);
+                self.max_join_id.* += 1;
+                try self.join_map.put(s.id, fresh);
+                const body = try cloner.cloneStmt(s.body);
+                const remainder = try cloner.cloneStmt(s.remainder);
+                return try cloner.store.addCFStmt(.{ .join = .{
+                    .id = fresh,
+                    .params = try cloner.mapLocalSpan(s.params),
+                    .retained = try cloner.mapLocalSpan(s.retained),
+                    .maybe_uninitialized_params = try cloner.mapLocalSpan(s.maybe_uninitialized_params),
+                    .maybe_uninitialized_conditions = try cloner.mapLocalSpan(s.maybe_uninitialized_conditions),
+                    .maybe_uninitialized_condition_masks = s.maybe_uninitialized_condition_masks,
+                    .body = body,
+                    .remainder = remainder,
+                } });
+            },
+            .jump => |s| {
+                const target = if (s.target == self.loop_id)
+                    (if (self.retarget.contains(old_id)) self.unique_id else self.loop_id)
+                else
+                    (self.join_map.get(s.target) orelse s.target);
+                return try cloner.store.addCFStmt(.{ .jump = .{ .target = target } });
+            },
+            .switch_stmt => |s| {
+                if (!self.fold.contains(old_id)) return null;
+                const branches = cloner.store.getCFSwitchBranches(s.branches);
+                return try cloner.cloneStmt(GuardedList.at(branches, 0).body);
+            },
+            .init_uninitialized,
+            .assign_ref,
+            .assign_literal,
+            .assign_call,
+            .assign_call_erased,
+            .assign_packed_erased_fn,
+            .assign_low_level,
+            .assign_list,
+            .assign_struct,
+            .assign_tag,
+            .store_struct,
+            .store_tag,
+            .set_local,
+            .debug,
+            .expect,
+            .expect_err,
+            .runtime_error,
+            .comptime_exhaustiveness_failed,
+            .comptime_branch_taken,
+            .incref,
+            .decref,
+            .decref_if_initialized,
+            .free,
+            .switch_initialized_payload,
+            .str_match,
+            .str_match_set,
+            .loop_continue,
+            .loop_break,
+            .ret,
+            .crash,
+            .assign_boxy_desc_ref,
+            .assign_boxy_dict_ref,
+            .assign_boxy_box,
+            .assign_boxy_reuse_box,
+            .assign_boxy_unbox,
+            .assign_boxy_adapt,
+            .assign_boxy_inspect,
+            .assign_boxy_eq,
+            .assign_boxy_tag,
+            .assign_boxy_tag_payload,
+            .boxy_tag_match,
+            .assign_call_dict,
+            => return null,
+        }
     }
 };
 
@@ -1963,4 +2372,288 @@ test "promote ignores a join without a back edge" {
     try testing.expect(store.getCFStmt(append_call) == .assign_call);
     const unchanged = store.getCFStmt(loop).join;
     try testing.expectEqual(@as(usize, 1), store.getLocalSpan(unchanged.params).len);
+}
+
+/// What one loop body contains, for checking a versioned loop's two arms.
+const BodyShape = struct {
+    switches: u32 = 0,
+    checked_sets: u32 = 0,
+    unchecked_sets: u32 = 0,
+    jumps_to_head: u32 = 0,
+    jumps_to_copy: u32 = 0,
+};
+
+fn shapeOf(store: *LirStore, root: CFStmtId, head: LIR.JoinPointId, copy: LIR.JoinPointId) Allocator.Error!BodyShape {
+    var stmts = try body_clone.ReachableStmts.init(store, root);
+    defer stmts.deinit();
+    var shape = BodyShape{};
+    while (try stmts.next()) |id| {
+        switch (store.getCFStmt(id)) {
+            .switch_stmt => shape.switches += 1,
+            .assign_low_level => |s| {
+                if (s.op == .list_set) shape.checked_sets += 1;
+                if (s.op == .list_set_in_place_unsafe) shape.unchecked_sets += 1;
+            },
+            .jump => |s| {
+                if (s.target == head) shape.jumps_to_head += 1;
+                if (s.target == copy) shape.jumps_to_copy += 1;
+            },
+            .init_uninitialized,
+            .assign_ref,
+            .assign_literal,
+            .assign_call,
+            .assign_call_erased,
+            .assign_packed_erased_fn,
+            .assign_list,
+            .assign_struct,
+            .assign_tag,
+            .store_struct,
+            .store_tag,
+            .set_local,
+            .debug,
+            .expect,
+            .expect_err,
+            .runtime_error,
+            .comptime_exhaustiveness_failed,
+            .comptime_branch_taken,
+            .incref,
+            .decref,
+            .decref_if_initialized,
+            .free,
+            .switch_initialized_payload,
+            .str_match,
+            .str_match_set,
+            .loop_continue,
+            .loop_break,
+            .join,
+            .ret,
+            .crash,
+            .assign_boxy_desc_ref,
+            .assign_boxy_dict_ref,
+            .assign_boxy_box,
+            .assign_boxy_reuse_box,
+            .assign_boxy_unbox,
+            .assign_boxy_adapt,
+            .assign_boxy_inspect,
+            .assign_boxy_eq,
+            .assign_boxy_tag,
+            .assign_boxy_tag_payload,
+            .boxy_tag_match,
+            .assign_call_dict,
+            => {},
+        }
+    }
+    return shape;
+}
+
+/// A set site `target = list_set(list, 0, 9)` followed by `next`, returning
+/// the head statement.
+fn addSetSite(f: *PromoteTest, target: LocalId, list: LocalId, next: CFStmtId) Allocator.Error!CFStmtId {
+    const store = &f.store;
+    const idx = try store.addLocal(.{ .layout_idx = .u64 });
+    const elem = try store.addLocal(.{ .layout_idx = .u8 });
+    const set_stmt = try store.addCFStmt(.{ .assign_low_level = .{
+        .target = target,
+        .op = .list_set,
+        .rc_effect = LowLevelOp.list_set.rcEffect(),
+        .args = try store.addLocalSpan(&.{ list, idx, elem }),
+        .next = next,
+    } });
+    const elem_lit = try store.addCFStmt(.{ .assign_literal = .{
+        .target = elem,
+        .value = .{ .i64_literal = .{ .value = 9, .layout_idx = .u8 } },
+        .next = set_stmt,
+    } });
+    return try store.addCFStmt(.{ .assign_literal = .{
+        .target = idx,
+        .value = .{ .i64_literal = .{ .value = 0, .layout_idx = .u64 } },
+        .next = elem_lit,
+    } });
+}
+
+test "promote versions a set loop into a dispatching head and a unique-only copy" {
+    var f = try PromoteTest.init(testing.allocator);
+    defer f.deinit();
+    const store = &f.store;
+
+    // loop J(out):
+    //   body: a = ref out; s = list_set(a, 0, 9); b = ref s
+    //         set out := b; jump J
+    //   remainder: set out := init; jump J
+    const out = try store.addLocal(.{ .layout_idx = f.list });
+    const init_list = try store.addLocal(.{ .layout_idx = f.list });
+    const a = try store.addLocal(.{ .layout_idx = f.list });
+    const s = try store.addLocal(.{ .layout_idx = f.list });
+    const b = try store.addLocal(.{ .layout_idx = f.list });
+    const join_id = f.freshJoinPointId();
+
+    const back_jump = try store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const back_set = try store.addCFStmt(.{ .set_local = .{
+        .target = out,
+        .value = b,
+        .mode = .initialize_join_param,
+        .next = back_jump,
+    } });
+    const alias_b = try store.addCFStmt(.{ .assign_ref = .{
+        .target = b,
+        .op = .{ .local = s },
+        .next = back_set,
+    } });
+    const site = try addSetSite(&f, s, a, alias_b);
+    const alias_a = try store.addCFStmt(.{ .assign_ref = .{
+        .target = a,
+        .op = .{ .local = out },
+        .next = site,
+    } });
+
+    const entry_jump = try store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const entry_set = try store.addCFStmt(.{ .set_local = .{
+        .target = out,
+        .value = init_list,
+        .mode = .initialize_join_param,
+        .next = entry_jump,
+    } });
+    const loop = try store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = try store.addLocalSpan(&.{out}),
+        .body = alias_a,
+        .remainder = entry_set,
+    } });
+    _ = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = LIR.LocalSpan.empty(),
+        .body = loop,
+        .ret_layout = f.list,
+    });
+
+    try run(store, &f.layouts);
+
+    // The loop carries the list, its limit, and its owned flag.
+    const head = store.getCFStmt(loop).join;
+    const params = store.getLocalSpan(head.params);
+    try testing.expectEqual(@as(usize, 3), params.len);
+    const owned_param = GuardedList.at(params, 2);
+
+    // The head dispatches on the flag: the hot arm is a nested join sharing
+    // the parameters, entered directly from its remainder; the cold arm is
+    // the body as promoted.
+    const dispatch = store.getCFStmt(head.body).switch_stmt;
+    try testing.expectEqual(owned_param, dispatch.cond);
+    try testing.expect(dispatch.default_is_cold);
+    try testing.expectEqual(alias_a, dispatch.default_branch);
+    const branches = store.getCFSwitchBranches(dispatch.branches);
+    try testing.expectEqual(@as(usize, 1), branches.len);
+    try testing.expectEqual(@as(u64, 1), GuardedList.at(branches, 0).value);
+    const copy = store.getCFStmt(GuardedList.at(branches, 0).body).join;
+    try testing.expect(copy.id != head.id);
+    try testing.expectEqual(head.params, copy.params);
+    try testing.expectEqual(copy.id, store.getCFStmt(copy.remainder).jump.target);
+
+    // The copy stores in place with no dispatch and returns to itself; the
+    // cold arm keeps the guarded pair and returns to the head.
+    const hot = try shapeOf(store, copy.body, head.id, copy.id);
+    try testing.expectEqual(BodyShape{ .unchecked_sets = 1, .jumps_to_copy = 1 }, hot);
+    const cold = try shapeOf(store, alias_a, head.id, copy.id);
+    try testing.expectEqual(BodyShape{ .switches = 1, .checked_sets = 1, .unchecked_sets = 1, .jumps_to_head = 1 }, cold);
+}
+
+test "promote keeps a foreign back edge on the head inside the copy" {
+    var f = try PromoteTest.init(testing.allocator);
+    defer f.deinit();
+    const store = &f.store;
+
+    // loop J(out):
+    //   body: a = ref out; c = 1
+    //         switch c { 1: s = list_set(a, 0, 9); b = ref s; set out := b; jump J
+    //                    default: o = ref other; set out := o; jump J }
+    //   remainder: set out := init; jump J
+    // `other` is a proc argument the chain never carried, so its edge must
+    // measure ownership again and re-enter the head.
+    const out = try store.addLocal(.{ .layout_idx = f.list });
+    const init_list = try store.addLocal(.{ .layout_idx = f.list });
+    const other = try store.addLocal(.{ .layout_idx = f.list });
+    const a = try store.addLocal(.{ .layout_idx = f.list });
+    const c = try store.addLocal(.{ .layout_idx = .u8 });
+    const s = try store.addLocal(.{ .layout_idx = f.list });
+    const b = try store.addLocal(.{ .layout_idx = f.list });
+    const o = try store.addLocal(.{ .layout_idx = f.list });
+    const join_id = f.freshJoinPointId();
+
+    const set_jump = try store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const set_write = try store.addCFStmt(.{ .set_local = .{
+        .target = out,
+        .value = b,
+        .mode = .initialize_join_param,
+        .next = set_jump,
+    } });
+    const alias_b = try store.addCFStmt(.{ .assign_ref = .{
+        .target = b,
+        .op = .{ .local = s },
+        .next = set_write,
+    } });
+    const site = try addSetSite(&f, s, a, alias_b);
+
+    const foreign_jump = try store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const foreign_write = try store.addCFStmt(.{ .set_local = .{
+        .target = out,
+        .value = o,
+        .mode = .initialize_join_param,
+        .next = foreign_jump,
+    } });
+    const alias_o = try store.addCFStmt(.{ .assign_ref = .{
+        .target = o,
+        .op = .{ .local = other },
+        .next = foreign_write,
+    } });
+
+    const branch = try store.addCFStmt(.{ .switch_stmt = .{
+        .cond = c,
+        .branches = try store.addCFSwitchBranches(&.{.{ .value = 1, .body = site }}),
+        .default_branch = alias_o,
+        .continuation = null,
+    } });
+    const cond_lit = try store.addCFStmt(.{ .assign_literal = .{
+        .target = c,
+        .value = .{ .i64_literal = .{ .value = 1, .layout_idx = .u8 } },
+        .next = branch,
+    } });
+    const alias_a = try store.addCFStmt(.{ .assign_ref = .{
+        .target = a,
+        .op = .{ .local = out },
+        .next = cond_lit,
+    } });
+
+    const entry_jump = try store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const entry_set = try store.addCFStmt(.{ .set_local = .{
+        .target = out,
+        .value = init_list,
+        .mode = .initialize_join_param,
+        .next = entry_jump,
+    } });
+    const loop = try store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = try store.addLocalSpan(&.{out}),
+        .body = alias_a,
+        .remainder = entry_set,
+    } });
+    _ = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = try store.addLocalSpan(&.{other}),
+        .body = loop,
+        .ret_layout = f.list,
+    });
+
+    try run(store, &f.layouts);
+
+    const head = store.getCFStmt(loop).join;
+    const dispatch = store.getCFStmt(head.body).switch_stmt;
+    const copy = store.getCFStmt(GuardedList.at(store.getCFSwitchBranches(dispatch.branches), 0).body).join;
+
+    // Inside the copy the set edge returns to the copy while the foreign
+    // edge, whose list was measured fresh, re-enters the head. Its own
+    // condition switch survives; only the set dispatch folded.
+    const hot = try shapeOf(store, copy.body, head.id, copy.id);
+    try testing.expectEqual(BodyShape{ .switches = 1, .unchecked_sets = 1, .jumps_to_head = 1, .jumps_to_copy = 1 }, hot);
+    const cold = try shapeOf(store, alias_a, head.id, copy.id);
+    try testing.expectEqual(BodyShape{ .switches = 2, .checked_sets = 1, .unchecked_sets = 1, .jumps_to_head = 2 }, cold);
 }

--- a/src/lir/return_slot.zig
+++ b/src/lir/return_slot.zig
@@ -198,7 +198,7 @@ const ReturnSlotRewriter = struct {
         } });
     }
 
-    pub fn interceptStmt(self: *ReturnSlotRewriter, cloner: anytype, stmt: LIR.CFStmt) ResourceError!?CFStmtId {
+    pub fn interceptStmt(self: *ReturnSlotRewriter, cloner: anytype, _: CFStmtId, stmt: LIR.CFStmt) ResourceError!?CFStmtId {
         if (stmt == .assign_struct) {
             const s = stmt.assign_struct;
             if (cloner.directReturnOf(s.next, s.target)) return try self.cloneStructReturn(cloner, s);

--- a/src/lir/str_append.zig
+++ b/src/lir/str_append.zig
@@ -166,7 +166,7 @@ const AppendRewriter = struct {
         return try self.concatInto(cloner, target, self.accumulator, try cloner.mapLocal(value), ret_stmt);
     }
 
-    pub fn interceptStmt(self: *AppendRewriter, cloner: anytype, stmt: LIR.CFStmt) ResourceError!?CFStmtId {
+    pub fn interceptStmt(self: *AppendRewriter, cloner: anytype, _: CFStmtId, stmt: LIR.CFStmt) ResourceError!?CFStmtId {
         if (stmt == .assign_low_level) {
             const s = stmt.assign_low_level;
             if (s.op == .str_concat and cloner.directReturnOf(s.next, s.target)) {

--- a/src/lir/tag_case_fusion.zig
+++ b/src/lir/tag_case_fusion.zig
@@ -61,7 +61,7 @@ const BranchRewriter = struct {
         return try cloner.store.addCFStmt(.{ .ret = .{ .value = try cloner.mapLocal(value) } });
     }
 
-    pub fn interceptStmt(self: *BranchRewriter, cloner: anytype, stmt: LIR.CFStmt) ResourceError!?LIR.CFStmtId {
+    pub fn interceptStmt(self: *BranchRewriter, cloner: anytype, _: LIR.CFStmtId, stmt: LIR.CFStmt) ResourceError!?LIR.CFStmtId {
         if (stmt != .assign_ref) return null;
         const assign = stmt.assign_ref;
         if (assign.op == .tag_payload_struct) {


### PR DESCRIPTION
A loop whose carried list is overwritten element by element already threads an owned flag beside its fill limit, and each set dispatches on it between an in-place store and the checked call. That still costs a branch per element and leaves the checked call inside the loop body, which is what kept the backend from vectorizing such loops in its first pass and what forces the element to be staged in memory for the cold call. Since the flag never drops back to zero once it reaches one, the loop head can decide once instead.

After the flag threading, each promoted loop's head now dispatches on the conjunction of its owned flags to a nested copy of the body in which every set whose flag is known to be one stores in place outright and every back edge that keeps the flags at one returns to the copy. The promoted body remains as the cold arm, serving shared entries and any edge that brings in a list the chain did not carry; those edges re-enter the head, which measures ownership again. The copy shares the loop's parameter locals so the dispatch needs no argument copies, and it is nested inside the head's body so every jump still targets an enclosing join. Values that live entirely inside the body get fresh locals in the copy so the hot loop's slots are never shared with the cold arm's calls.

Which flags are known one inside the copy is a fixpoint over the flag definitions: the loop's own flags are one by construction of the dispatch, a `list_owned_unique` measurement is unknown, and any flag fed by an unknown one is unknown. Loops with retained or conditionally initialized join environments keep their flag form, as do loops with an edge whose jump could not be traced through its parameter writes. On roc-deflate every level stays byte-identical, compile time is unchanged, and the loops that spend their time in element overwrites gain a few percent (nci and xml +2-3% at levels 1 and 6, the rest within noise).