### PR TITLE
Raise platform package download limit to 512 MiB

### DIFF
--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -162,7 +162,8 @@ fn parseResolveLimitProblem(arg: []const u8, limits: *ResolveLimitArgs) ?ArgProb
 
 const resolve_limit_help =
     \\      --max-package-mb=<N>     Per-package decompressed size limit in MB (default: 10, 0 for unlimited)
-    \\      --max-transitive-mb=<N>  Combined size limit in MB for each direct dependency's transitive packages (default: 100, 0 for unlimited)
+    \\      --max-transitive-mb=<N>  Combined size limit in MB for each direct dependency's transitive packages
+    \\                               (defaults: packages 100, platforms 512; 0 for unlimited)
 ;
 
 /// Arguments for the default `roc` command
@@ -421,8 +422,7 @@ const main_help =
     \\      --no-cache                     Disable compilation and executable caches (useful for compiler and platform developers)
     \\      --no-color                     Do not use ANSI escape codes in CLI output
     \\  -j, --jobs=<N>                     Max worker threads for parallel compilation (default: auto-detect CPU count)
-    \\
-;
+++ "\n" ++ resolve_limit_help ++ "\n";
 
 const run_help =
     \\Run a Roc application
@@ -437,6 +437,9 @@ const run_help =
     \\Running an installed shorthand executes the optimized binary that was
     \\built at install time; no compilation or network access is needed.
     \\File and URL sources accept the same options as the default `roc` command.
+    \\Options:
+++ "\n" ++ resolve_limit_help ++ "\n" ++
+    \\  -h, --help                     Print help
     \\
 ;
 
@@ -594,8 +597,9 @@ fn parseBuild(args: []const []const u8) CliArgs {
             \\  -j, --jobs=<N>                     Max worker threads for parallel compilation (default: auto-detect CPU count)
             \\      --wasm-memory=<bytes>          Initial memory size for WASM targets in bytes (default: sized from data segments plus the stack)
             \\      --wasm-stack-size=<bytes>      Stack size for WASM targets in bytes (default: 8388608 = 8MB)
-            \\      -h, --help                     Print help
-            \\
+            ++ "\n" ++ resolve_limit_help ++ "\n" ++
+                \\      -h, --help                     Print help
+                \\
             };
         } else if (mem.startsWith(u8, arg, "--max-package-mb") or mem.startsWith(u8, arg, "--max-transitive-mb")) {
             if (parseResolveLimitProblem(arg, &resolve_limits)) |problem| return CliArgs{ .problem = problem };
@@ -894,8 +898,9 @@ fn parseTest(args: []const []const u8) CliArgs {
             \\      --no-cache                      Disable compilation caching, force re-run all tests
             \\      --watch                         Re-run when source inputs change
             \\  -j, --jobs=<N>                      Max worker threads for parallel compilation (default: auto-detect CPU count)
-            \\  -h, --help                          Print help
-            \\
+            ++ "\n" ++ resolve_limit_help ++ "\n" ++
+                \\  -h, --help                          Print help
+                \\
             };
         } else if (mem.startsWith(u8, arg, "--max-package-mb") or mem.startsWith(u8, arg, "--max-transitive-mb")) {
             if (parseResolveLimitProblem(arg, &resolve_limits)) |problem| return CliArgs{ .problem = problem };
@@ -1186,8 +1191,9 @@ fn parseDocs(args: []const []const u8) CliArgs {
             \\      --time           Print timing information for each compilation phase. Will not print anything if everything is cached.
             \\      --no-cache       Disable caching
             \\      --verbose        Enable verbose output including cache statistics
-            \\  -h, --help           Print help
-            \\
+            ++ "\n" ++ resolve_limit_help ++ "\n" ++
+                \\  -h, --help           Print help
+                \\
             };
         } else if (mem.startsWith(u8, arg, "--max-package-mb") or mem.startsWith(u8, arg, "--max-transitive-mb")) {
             if (parseResolveLimitProblem(arg, &resolve_limits)) |problem| return CliArgs{ .problem = problem };
@@ -1305,6 +1311,7 @@ const bump_help =
     \\                             as the API diff requires (for release CI)
     \\      --no-cache             Disable caching
     \\      --verbose              Enable verbose output
+++ "\n" ++ resolve_limit_help ++ "\n" ++
     \\  -h, --help                 Print help
     \\
     \\Both the old and new package must compile with this compiler. Only the
@@ -2420,6 +2427,29 @@ test "roc help" {
         const result = try parse(gpa, testing.io, &[_][]const u8{ "help", "extrastuff" });
         defer result.deinit(gpa);
         try testing.expectEqual(.help, std.meta.activeTag(result));
+    }
+}
+
+test "dependency-resolving command help lists size limit flags" {
+    const gpa = testing.allocator;
+    const cases: []const []const []const u8 = &.{
+        &.{"--help"},
+        &.{ "run", "--help" },
+        &.{ "install", "--help" },
+        &.{ "check", "--help" },
+        &.{ "build", "--help" },
+        &.{ "test", "--help" },
+        &.{ "docs", "--help" },
+        &.{ "bump", "--help" },
+    };
+
+    for (cases) |args| {
+        const result = try parse(gpa, testing.io, args);
+        defer result.deinit(gpa);
+        try testing.expectEqual(.help, std.meta.activeTag(result));
+        try testing.expect(std.mem.find(u8, result.help, "--max-package-mb") != null);
+        try testing.expect(std.mem.find(u8, result.help, "--max-transitive-mb") != null);
+        try testing.expect(std.mem.find(u8, result.help, "packages 100, platforms 512") != null);
     }
 }
 

--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -102,7 +102,7 @@ pub const default_build_opt: OptLevel = .speed;
 /// Values are in megabytes; 0 means unlimited; null uses the default.
 pub const ResolveLimitArgs = struct {
     max_package_mb: ?u32 = null, // per-package decompressed size limit (default 10)
-    max_transitive_mb: ?u32 = null, // per-direct-dependency transitive size limit (default 100)
+    max_transitive_mb: ?u32 = null, // overrides both transitive limits (defaults: packages 100, platforms 512)
 };
 
 const ResolveLimitParse = union(enum) {

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -7125,7 +7125,9 @@ fn resolutionConfigFromLimits(limits: cli_args.ResolveLimitArgs) compile.package
         config.max_package_expanded_bytes = if (mb == 0) null else @as(u64, mb) * 1024 * 1024;
     }
     if (limits.max_transitive_mb) |mb| {
-        config.max_transitive_expanded_bytes = if (mb == 0) null else @as(u64, mb) * 1024 * 1024;
+        const max_bytes = if (mb == 0) null else @as(u64, mb) * 1024 * 1024;
+        config.max_transitive_expanded_bytes = max_bytes;
+        config.max_platform_transitive_expanded_bytes = max_bytes;
     }
     return config;
 }

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -68,12 +68,16 @@ pub const Config = struct {
     /// Maximum decompressed size for any single package bundle, in bytes.
     /// Null means unlimited. Platform bundles are always exempt.
     max_package_expanded_bytes: ?u64 = default_max_package_expanded_bytes,
-    /// Maximum combined content size attributable to any single direct
-    /// dependency of the root, in bytes. Null means unlimited.
+    /// Maximum combined content size attributable to any single non-platform
+    /// direct dependency of the root, in bytes. Null means unlimited.
     max_transitive_expanded_bytes: ?u64 = default_max_transitive_expanded_bytes,
+    /// Maximum combined content size attributable to a direct platform
+    /// dependency of the root, in bytes. Null means unlimited.
+    max_platform_transitive_expanded_bytes: ?u64 = default_max_platform_transitive_expanded_bytes,
 
     pub const default_max_package_expanded_bytes: u64 = 10 * 1024 * 1024;
     pub const default_max_transitive_expanded_bytes: u64 = 100 * 1024 * 1024;
+    pub const default_max_platform_transitive_expanded_bytes: u64 = 512 * 1024 * 1024;
 };
 
 /// The kind of module header a package's root file has.
@@ -919,9 +923,11 @@ pub const Resolver = struct {
     /// package any round has ever pulled into the graph (including retracted
     /// ones, and including already-cached ones).
     fn checkTransitiveLimits(self: *Resolver, root_node: FetchedPackage) Allocator.Error!void {
-        const limit = self.config.max_transitive_expanded_bytes orelse return;
-
         for (root_node.deps) |dep| {
+            const limit = (if (dep.is_platform)
+                self.config.max_platform_transitive_expanded_bytes
+            else
+                self.config.max_transitive_expanded_bytes) orelse continue;
             const start_group = (try self.groupKeyForDep(root_node.root_dir, dep)) orelse continue;
 
             var seen_groups: std.StringHashMapUnmanaged(void) = .{};
@@ -2646,6 +2652,38 @@ test "transitive size limit counts each direct dependency's reachable packages" 
     try std.testing.expectError(error.ResolutionFailed, resolver.resolve("/app/main.roc"));
     try std.testing.expectEqualStrings("Dependency Tree Too Large", resolver.diagnostics.items[0].title);
     try std.testing.expect(std.mem.find(u8, resolver.diagnostics.items[0].message, a_url) != null);
+}
+
+test "platform dependencies have a larger transitive size limit" {
+    const gpa = std.testing.allocator;
+    var registry = TestRegistry.init(gpa);
+    defer registry.deinit();
+
+    const platform_url = "https://example.com/pf/1.0.0/hashPf.tar.zst";
+    const package_url = "https://example.com/pkg/1.0.0/hashPkg.tar.zst";
+
+    try registry.locals.put("/app/main.roc", .{
+        .kind = .app,
+        .deps = &.{
+            .{ .alias = "pf", .spec = platform_url, .is_platform = true },
+            .{ .alias = "pkg", .spec = package_url, .is_platform = false },
+        },
+    });
+    try registry.urls.put(platform_url, .{ .kind = .platform, .content_bytes = 4500 });
+    try registry.urls.put(package_url, .{ .content_bytes = 4500 });
+
+    var resolver = Resolver.init(gpa, registry.fetcher(), .{
+        .max_package_expanded_bytes = null,
+        .max_transitive_expanded_bytes = 4000,
+        .max_platform_transitive_expanded_bytes = 5000,
+    });
+    defer resolver.deinit();
+
+    try std.testing.expectError(error.ResolutionFailed, resolver.resolve("/app/main.roc"));
+    try std.testing.expectEqual(@as(usize, 1), resolver.diagnostics.items.len);
+    const diagnostic = resolver.diagnostics.items[0];
+    try std.testing.expectEqualStrings("Dependency Tree Too Large", diagnostic.title);
+    try std.testing.expect(std.mem.find(u8, diagnostic.message, package_url) != null);
 }
 
 test "per-package size limit is enforced for packages but not platforms" {

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -895,7 +895,7 @@ pub const Resolver = struct {
                     try self.addDiagnostic(
                         "Package Too Large",
                         "The package at\n\n    {s}\n\nexpands to more than the per-package limit of {d} bytes.\n\n" ++
-                            "You can raise the limit with the --max-package-bytes flag, or stop depending on this package.",
+                            "You can raise the limit with the --max-package-mb flag, or stop depending on this package.",
                         .{ task.missing.url, self.config.max_package_expanded_bytes orelse 0 },
                     );
                     continue;
@@ -979,7 +979,7 @@ pub const Resolver = struct {
                 try self.addDiagnostic(
                     "Dependency Tree Too Large",
                     "Depending on\n\n    {s}\n\nhas pulled more than {d} bytes of packages into the build ({d} bytes so far).\n\n" ++
-                        "You can raise the limit with the --max-transitive-bytes flag, or stop depending on this package.",
+                        "You can raise the limit with the --max-transitive-mb flag, or stop depending on this package.",
                     .{ dep.spec, limit, total },
                 );
             }
@@ -2652,6 +2652,7 @@ test "transitive size limit counts each direct dependency's reachable packages" 
     try std.testing.expectError(error.ResolutionFailed, resolver.resolve("/app/main.roc"));
     try std.testing.expectEqualStrings("Dependency Tree Too Large", resolver.diagnostics.items[0].title);
     try std.testing.expect(std.mem.find(u8, resolver.diagnostics.items[0].message, a_url) != null);
+    try std.testing.expect(std.mem.find(u8, resolver.diagnostics.items[0].message, "--max-transitive-mb") != null);
 }
 
 test "platform dependencies have a larger transitive size limit" {
@@ -2716,6 +2717,7 @@ test "per-package size limit is enforced for packages but not platforms" {
     const diagnostic = resolver.diagnostics.items[0];
     try std.testing.expectEqualStrings("Package Too Large", diagnostic.title);
     try std.testing.expect(std.mem.find(u8, diagnostic.message, a_url) != null);
+    try std.testing.expect(std.mem.find(u8, diagnostic.message, "--max-package-mb") != null);
 }
 
 test "platform targets must be marked and packages may not depend on apps" {


### PR DESCRIPTION
## Summary

- give root platform dependencies a 512 MiB transitive expanded-size limit
- retain the existing 100 MiB default for non-platform dependencies
- preserve `--max-transitive-mb` as an override for both limits
- select the limit using explicit `is_platform` metadata produced by header parsing and validated against the target header kind
- align size-limit diagnostics with the implemented `--max-package-mb` and `--max-transitive-mb` flags
- list both flags and the platform-specific default in every command help page that accepts them

## Testing

- `zig fmt --check src/compile/package_resolution.zig src/cli/main.zig src/cli/cli_args.zig`
- focused compile-module size-limit tests
- full compile-module unit suite
- focused CLI help test across default/run, install, check, build, test, docs, and bump
- executable-level help audit across all accepting commands
- `zig build roc`