### PR TITLE
Let constant bounds meet at merges and keep narrowing wraps that cannot wrap

### DIFF
--- a/src/compile/test/range_prove_test.zig
+++ b/src/compile/test/range_prove_test.zig
@@ -204,6 +204,100 @@ fn arithmeticApp(comptime body: []const u8, comptime call: []const u8) []const u
         "}\n";
 }
 
+const MeetShape = struct {
+    found: bool = false,
+    is_lt: usize = 0,
+    get_unsafe: usize = 0,
+    mul_crash: usize = 0,
+    mul_proven: usize = 0,
+};
+
+const MeetSelection = enum {
+    hashed_read,
+    scaled_byte,
+};
+
+var meet_shape: MeetShape = .{};
+var meet_selection: MeetSelection = .hashed_read;
+
+fn countMeetShape(store: *const lir.LirStore, layouts: *const layout.Store) harness.LowerToLirHarnessError!void {
+    meet_shape = .{};
+    const gpa = std.testing.allocator;
+    const buf = try gpa.alloc(u8, 1 << 20);
+    defer gpa.free(buf);
+    for (0..store.getProcSpecs().len) |index| {
+        var writer = std.Io.Writer.fixed(buf);
+        try lir.DebugPrint.writeProc(gpa, store, layouts, @enumFromInt(@as(u32, @intCast(index))), &writer);
+        const text = writer.buffered();
+        if (std.mem.count(u8, text, "list_get_unsafe") == 0) continue;
+        const selected = switch (meet_selection) {
+            .hashed_read => std.mem.count(u8, text, "num_shift_right_zf_by") > 0,
+            .scaled_byte => std.mem.count(u8, text, "num_int_mul_") > 0,
+        };
+        if (!selected) continue;
+        meet_shape = .{
+            .found = true,
+            .is_lt = std.mem.count(u8, text, "num_is_lt("),
+            .get_unsafe = std.mem.count(u8, text, "list_get_unsafe"),
+            .mul_crash = std.mem.count(u8, text, "num_int_mul_crash_on_overflow"),
+            .mul_proven = std.mem.count(u8, text, "num_int_mul_proven_cannot_overflow"),
+        };
+        if (std.c.getenv("RANGE_PROVE_DUMP") != null) std.debug.print("\n===== meet proc =====\n{s}\n", .{text});
+        return;
+    }
+}
+
+test "a hash bounded by a guard on entry and a shift on the back edge proves its table read" {
+    meet_selection = .hashed_read;
+    // The loop parameter meets two different derivations of the same
+    // constant bound: the entry guard and the shift's range, whose amount
+    // is a narrowing of a literal difference.
+    try harness.expectLirInspectionWithOptions(
+        arithmeticApp(
+            "walk : List(U16), U64, List(U8), U64 -> U64\n" ++
+                "walk = |tab, h0, input, n| {\n" ++
+                "    if List.len(tab) < 256 or h0 >= 256 {\n" ++
+                "        return 0\n" ++
+                "    } else {\n" ++
+                "    }\n" ++
+                "    var $h = h0\n" ++
+                "    var $i = 0\n" ++
+                "    var $acc = 0.U64\n" ++
+                "    while $i < n {\n" ++
+                "        $acc = $acc.plus_wrap((List.get(tab, $h) ?? 0).to_u64())\n" ++
+                "        seq = U32.from_le_bytes(input, $i) ?? 0\n" ++
+                "        $h = seq.times_wrap(0x1E35A7BD).shr_zf_wrap((32.U64 - 8).to_u8_wrap()).to_u64()\n" ++
+                "        $i = $i + 1\n" ++
+                "    }\n" ++
+                "    $acc\n" ++
+                "}\n",
+            "walk([], 0, Str.to_utf8(Str.join_with(_args, \",\")), List.len(_args))",
+        ),
+        .{ .inline_mode = .wrappers, .prove_ranges = true },
+        countMeetShape,
+    );
+    try std.testing.expect(meet_shape.found);
+    try std.testing.expectEqual(@as(usize, 1), meet_shape.get_unsafe);
+    // The entry guard's length test, the loop condition, and the word read's
+    // short-input test remain; the table read's bounds test is proven away.
+    try std.testing.expectEqual(@as(usize, 3), meet_shape.is_lt);
+}
+
+test "a byte merged from a read and a literal keeps its byte range for the overflow proof" {
+    meet_selection = .scaled_byte;
+    try harness.expectLirInspectionWithOptions(
+        arithmeticApp(
+            "cost : List(U8), U64, U64 -> U64\ncost = |bits, slot, base| base + (List.get(bits, slot) ?? 0).to_u64() * 16\n",
+            "cost(Str.to_utf8(Str.join_with(_args, \",\")), List.len(_args), 3)",
+        ),
+        .{ .inline_mode = .wrappers, .prove_ranges = true },
+        countMeetShape,
+    );
+    try std.testing.expect(meet_shape.found);
+    try std.testing.expectEqual(@as(usize, 0), meet_shape.mul_crash);
+    try std.testing.expectEqual(@as(usize, 1), meet_shape.mul_proven);
+}
+
 test "checked multiply is discharged from a masked range" {
     arithmetic_selection = .masked_mul;
     try harness.expectLirInspectionWithOptions(

--- a/src/lir/range_prove.zig
+++ b/src/lir/range_prove.zig
@@ -398,6 +398,8 @@ const Pass = struct {
     value_roots: collections.DenseMap(NodeId, LocalId),
     loop_bounds: std.AutoHashMap(u64, LoopBounds),
     loop_facts: collections.DenseMap(JoinPointId, LoopFacts),
+    /// The round's shared root for constant bounds, made on first use.
+    zero_node: ?NodeId = null,
     /// Per merge head: last round's all-edge fact intersection in stable
     /// form, seeded when the merge must walk before its captures complete
     /// (a forced loop-body or cycle-interior region). Facts held by every
@@ -533,6 +535,7 @@ const Pass = struct {
 
     fn resetRound(self: *Pass) void {
         self.nodes.clearRetainingCapacity();
+        self.zero_node = null;
         self.facts.clearRetainingCapacity();
         self.no_overflow_facts.clearRetainingCapacity();
         self.global_facts.clearRetainingCapacity();
@@ -1392,8 +1395,15 @@ const Pass = struct {
             if (meet.bounds.len == 0) continue;
             // The edges bind different values, but each proves the same upper
             // bounds; a fresh value carrying those bounds preserves them.
-            const node = (try self.unknownFor(.u64)) orelse continue;
+            var hi = trackedIntMax(self.localLayout(meet.local)) orelse std.math.maxInt(u64);
             for (meet.bounds.slice()) |bound| {
+                const root = self.nodes.items[bound.root];
+                if (root.lo == root.hi) hi = @min(hi, root.lo + bound.c);
+            }
+            const node = (try self.freshRoot(0, hi)) orelse continue;
+            for (meet.bounds.slice()) |bound| {
+                const root = self.nodes.items[bound.root];
+                if (root.lo == root.hi) continue;
                 try self.addFact(.{ .a = node, .b = bound.root, .c = bound.c, .origin = .meet });
             }
             try self.bind(meet.local, .{ .node = node });
@@ -1597,7 +1607,7 @@ const Pass = struct {
     fn seedMergeEnv(self: *Pass, head: CFStmtId) ResourceError!void {
         const stored = self.merge_env.get(head) orelse return;
         for (stored.items[0..stored.len]) |entry| {
-            const node = (try self.unknownFor(self.localLayout(entry.local))) orelse continue;
+            const node = (try self.metValueNode(entry.local, entry.bounds[0..entry.len])) orelse continue;
             var used = false;
             for (entry.bounds[0..entry.len]) |bound| {
                 switch (bound.base) {
@@ -1611,15 +1621,23 @@ const Pass = struct {
                         try self.addFact(.{ .a = node, .b = self.rootOf(v), .c = bound.c + self.offHiOf(v), .origin = .meet });
                         used = true;
                     },
-                    .constant => {
-                        const const_node = (try self.constNode(bound.c)) orelse continue;
-                        try self.addFact(.{ .a = node, .b = const_node, .c = 0, .origin = .meet });
-                        used = true;
-                    },
+                    // Folded into the node's own range.
+                    .constant => used = true,
                 }
             }
             if (used) try self.bind(entry.local, .{ .node = node });
         }
+    }
+
+    /// A fresh value for a met local: its layout's range narrowed by the
+    /// constant bounds, so the static-range readers (overflow proofs among
+    /// them) see those bounds without a fact query.
+    fn metValueNode(self: *Pass, local: LocalId, bounds: []const StableBound) ResourceError!?NodeId {
+        var hi = trackedIntMax(self.localLayout(local)) orelse std.math.maxInt(u64);
+        for (bounds) |bound| {
+            if (bound.base == .constant) hi = @min(hi, bound.c);
+        }
+        return try self.freshRoot(0, hi);
     }
 
     fn persistLoopBounds(self: *Pass) ResourceError!void {
@@ -1743,7 +1761,7 @@ const Pass = struct {
             try self.seedLenInvariants(stored, local);
             return;
         }
-        const node = (try self.unknownFor(.u64)) orelse return;
+        const node = (try self.metValueNode(local, stored.items[0..stored.len])) orelse return;
         var used = false;
         for (stored.items[0..stored.len]) |bound| {
             switch (bound.base) {
@@ -1759,11 +1777,8 @@ const Pass = struct {
                     try self.addFact(.{ .a = node, .b = len_node, .c = bound.c, .origin = .meet });
                     used = true;
                 },
-                .constant => {
-                    const const_node = (try self.constNode(bound.c)) orelse continue;
-                    try self.addFact(.{ .a = node, .b = const_node, .c = 0, .origin = .meet });
-                    used = true;
-                },
+                // Folded into the node's own range.
+                .constant => used = true,
                 .value_of => |scalar_local| {
                     const v = (try self.valueOf(scalar_local)) orelse continue;
                     try self.addFact(.{ .a = node, .b = self.rootOf(v), .c = bound.c + self.offHiOf(v), .origin = .meet });
@@ -1845,7 +1860,57 @@ const Pass = struct {
                 }
             }
         }
-        return bounds;
+        return try self.normalizeUpperBounds(bounds, node);
+    }
+
+    /// Bounds against literal values are keyed by one shared constant root,
+    /// with the literal folded into `c`, so two edges that bound a value by
+    /// different constants (a guard on entry, a shift's range on the back
+    /// edge, say) still meet. A root's own static range is such a bound too.
+    fn constantRoot(self: *Pass) ResourceError!?NodeId {
+        if (self.zero_node) |id| return id;
+        const id = (try self.constNode(0)) orelse return null;
+        self.zero_node = id;
+        return id;
+    }
+
+    fn normalizeUpperBounds(self: *Pass, bounds: MeetBounds, node: Node) ResourceError!MeetBounds {
+        const zero = (try self.constantRoot()) orelse return bounds;
+        var out: MeetBounds = .{};
+        var best: ?i128 = null;
+        for (bounds.slice()) |bound| {
+            const root = self.nodes.items[bound.root];
+            if (root.lo == root.hi) {
+                const c = root.lo + bound.c;
+                if (best == null or c < best.?) best = c;
+            } else {
+                out.append(bound);
+            }
+        }
+        const root = self.nodes.items[node.root];
+        if (root.hi < std.math.maxInt(u64)) {
+            const c = root.hi + node.off_hi;
+            if (best == null or c < best.?) best = c;
+        }
+        if (best) |c| out.append(.{ .root = zero, .c = c });
+        return out;
+    }
+
+    fn normalizeLowerBounds(self: *Pass, bounds: MeetBounds) ResourceError!MeetBounds {
+        const zero = (try self.constantRoot()) orelse return bounds;
+        var out: MeetBounds = .{};
+        var best: ?i128 = null;
+        for (bounds.slice()) |bound| {
+            const root = self.nodes.items[bound.root];
+            if (root.lo == root.hi) {
+                const c = bound.c - root.lo;
+                if (best == null or c < best.?) best = c;
+            } else {
+                out.append(bound);
+            }
+        }
+        if (best) |c| out.append(.{ .root = zero, .c = c });
+        return out;
     }
 
     /// Lower bounds `root <= value(len_node) + c` provable from the current
@@ -1873,7 +1938,7 @@ const Pass = struct {
                 }
             }
         }
-        return bounds;
+        return try self.normalizeLowerBounds(bounds);
     }
 
     /// This round's length lower bounds for a local, when its value is a
@@ -2723,6 +2788,23 @@ const Pass = struct {
                 }
                 try self.bindFresh(s.target);
             },
+            .u16_to_u8_wrap, .u32_to_u8_wrap, .u32_to_u16_wrap, .u64_to_u8_wrap, .u64_to_u16_wrap, .u64_to_u32_wrap, .u128_to_u8_wrap, .u128_to_u16_wrap, .u128_to_u32_wrap, .u128_to_u64_wrap => {
+                // A narrowing that provably cannot wrap leaves the number
+                // alone as well: a shift amount computed from literals, say,
+                // stays a constant the shift rule can read.
+                if (arg_count == 1) {
+                    if (try self.valueOf(GuardedList.at(args, 0))) |node_id| {
+                        const node = self.nodes.items[node_id];
+                        const root = self.nodes.items[node.root];
+                        const max = trackedIntMax(self.localLayout(s.target));
+                        if (max != null and root.hi + node.off_hi <= max.? and root.lo + node.off_lo >= 0) {
+                            try self.bind(s.target, .{ .node = node_id });
+                            return;
+                        }
+                    }
+                }
+                try self.bindFresh(s.target);
+            },
             .u8_to_u16, .u8_to_u32, .u8_to_u64, .u16_to_u32, .u16_to_u64, .u32_to_u64 => {
                 // A widening whose target represents every value of its source
                 // leaves the number alone, so the result is the argument: it
@@ -3067,7 +3149,6 @@ const Pass = struct {
             .u16_to_i16_wrap,
             .u16_to_i16_try,
             .u16_to_i128,
-            .u16_to_u8_wrap,
             .u16_to_u8_try,
             .u16_to_u128,
             .u16_to_f32,
@@ -3096,9 +3177,7 @@ const Pass = struct {
             .u32_to_i32_wrap,
             .u32_to_i32_try,
             .u32_to_i128,
-            .u32_to_u8_wrap,
             .u32_to_u8_try,
-            .u32_to_u16_wrap,
             .u32_to_u16_try,
             .u32_to_u128,
             .u32_to_f32,
@@ -3131,11 +3210,8 @@ const Pass = struct {
             .u64_to_i64_wrap,
             .u64_to_i64_try,
             .u64_to_i128,
-            .u64_to_u8_wrap,
             .u64_to_u8_try,
-            .u64_to_u16_wrap,
             .u64_to_u16_try,
-            .u64_to_u32_wrap,
             .u64_to_u32_try,
             .u64_to_u128,
             .u64_to_f32,
@@ -3171,13 +3247,9 @@ const Pass = struct {
             .u128_to_i64_try,
             .u128_to_i128_wrap,
             .u128_to_i128_try,
-            .u128_to_u8_wrap,
             .u128_to_u8_try,
-            .u128_to_u16_wrap,
             .u128_to_u16_try,
-            .u128_to_u32_wrap,
             .u128_to_u32_try,
-            .u128_to_u64_wrap,
             .u128_to_u64_try,
             .u128_to_f32,
             .u128_to_f64,


### PR DESCRIPTION
A loop parameter bounded by a literal on entry and by a shift's range on the back edge never met in the range prover, because every constant is its own node and the merge matches bounds by root, so a loop-carried hash table index stayed bounds-checked on every access even when the code established both bounds. Bounds against literals are now keyed by one shared constant root with the literal folded into the offset, and a value's own static range counts as such a bound, so the two edges agree. When a met value is seeded for the next round, constant bounds narrow its fresh root's range instead of hanging off it as facts, because the overflow proofs read ranges rather than facts. A narrowing wrap conversion whose argument provably fits keeps the argument, so a shift amount computed from literals stays a constant the shift rule can read.

The second commit fixes the other half of the same problem: a loop's entry facts and a merge's all-edge facts were intersected by node id, but edges arriving from different walk regions hold different nodes for the same value, so a guard established before a search never reached a loop nested after an earlier walk. Both meets now use the round-stable form that persistence already used, the complete-capture seeding path replays that stable meet, stable fact lists no longer accumulate duplicates, and the round backstop rises so a search lowered as several mutually jumping joins can carry a fact across all of them. Non-negative literals of signed types bind as constants and a signed-to-unsigned wrap of a provably in-range value keeps the value.

The third commit fixes how persisted facts name values. Lowering binds one alias per use, so a list's length was named by whichever alias first computed it and a guard on the input's length before a loop never matched the read inside it; stable terms now name the local a chain of single-assignment aliases denotes. A single-assignment local bound to a fresh root also registers that root as its stable value, which sums of unrelated values and unproven checked operations previously lacked, so no fact about such a value could reach a loop.

On roc-deflate every existing proof is preserved and the build gains a few dozen: all four per-byte table checks in the hash-chain insert loop, every chain read in the search, and every access in the bucket matchfinder's insert run. With the matching source changes that is 5-6% at level 6 on nci and xml and 7-10% at level 1 on nci and xml. Compile time is unchanged.