### PR TITLE
Fix nominal record defaults through polymorphic calls

### DIFF
--- a/design.md
+++ b/design.md
@@ -6146,7 +6146,20 @@ Restrictions:
   (`Cfg.{...}`) or through an expected nominal type (`cfg : Cfg; cfg = {}`).
   Empty and nonempty literals use the same backing-row relation: omission
   validates every field and the complete extension before retaining the nominal
-  result, and records each default on its source construction. Canonicalization
+  result, and records each default on its source construction. Both nominal
+  lifting paths retain the checked representatives of the record relation,
+  alongside its original operands, so a polymorphic call's formal slot cannot
+  hide the literal that supplies it. Checking registers fresh record expressions
+  as they are checked. At settlement, before default-cycle validation, it groups
+  accepted omission decisions by solved record equality and distributes each
+  decision to every registered construction in that class that did not supply
+  the field. This consumes the unifier's explicit default identity, including
+  when later value relations normalized the field to required; it never
+  reconstructs an omission from a nominal declaration or a solved field kind.
+  Equal decisions are coalesced before visiting constructors, and only classes
+  with omissions are indexed. Type unions, instantiation, and serialized types
+  carry no additional construction state. Speculative checking rolls back
+  construction registrations with its omission decisions. Canonicalization
   analyzes cycles through explicit constructors; checking also analyzes the
   omissions determined by expected types. Derived
   codecs reach defaulted fields through the nominal's derived methods

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -234,6 +234,10 @@ optional_field_accesses: std.ArrayList(OptionalFieldAccess),
 /// `literal_field_kind_watermark` tracks the swept prefix (REPL sessions
 /// finalize repeatedly on one Check).
 literal_field_kinds: std.ArrayList(LiteralFieldKind),
+/// Fresh record expressions registered while checking their construction.
+/// Settled equality classes distribute accepted omission decisions to every
+/// contributing literal; ordinary type unions carry no construction metadata.
+record_constructions: std.ArrayList(CIR.Expr.Idx),
 literal_field_kind_watermark: usize = 0,
 /// Update-field probes are committed at their owning generalization boundary
 /// so an unresolved scheme cannot change runtime field layout per caller.
@@ -2582,6 +2586,7 @@ fn initAssumePrepared(
         .pending_default_checks = .empty,
         .optional_field_accesses = .empty,
         .literal_field_kinds = .empty,
+        .record_constructions = .empty,
         .pending_record_updates = .empty,
         .pending_record_destructs = .empty,
         .type_decl_generation_states = try initNodeSlots(TypeDeclGenerationState, gpa, node_count, .not_generated),
@@ -2788,6 +2793,7 @@ pub fn deinit(self: *Self) void {
     self.pending_default_checks.deinit(self.gpa);
     self.optional_field_accesses.deinit(self.gpa);
     self.literal_field_kinds.deinit(self.gpa);
+    self.record_constructions.deinit(self.gpa);
     self.pending_record_updates.deinit(self.gpa);
     self.pending_record_destructs.deinit(self.gpa);
     self.pending_default_seen.deinit(self.gpa);
@@ -4955,18 +4961,8 @@ fn recordAbsorbedDefaults(self: *Self, construction_var: ?Var, a: Var, b: Var) s
         const expr = mb_expr orelse
             std.debug.panic("type checker invariant violated: defaulted-field width absorption lost its source record construction", .{});
 
-        var already_recorded = false;
-        for (self.cir.record_omitted_defaults.items.items) |existing| {
-            if (existing.expr == expr and existing.field_name == absorbed.name and
-                existing.origin_module == absorbed.default.origin_module and
-                existing.default_expr_node == absorbed.default.expr_node)
-            {
-                already_recorded = true;
-                break;
-            }
-        }
-        if (already_recorded) continue;
-
+        // Settlement coalesces equal decisions before distributing them to
+        // constructions. Recording an event must not scan the module's prefix.
         _ = try self.cir.record_omitted_defaults.append(self.cir.gpa, .{
             .expr = expr,
             .field_name = absorbed.name,
@@ -18692,6 +18688,7 @@ fn checkExprWithFunctionOwner(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, ex
                 // Then unify with the actual expression
                 _ = try self.unify(record_being_updated_var, expr_var, env);
             } else {
+                try self.record_constructions.append(self.gpa, expr_idx);
                 const source_fields = self.cir.store.sliceRecordFields(e.fields);
 
                 // Build a record skeleton with one payload slot per supplied
@@ -18832,6 +18829,7 @@ fn checkExprWithFunctionOwner(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, ex
             }
         },
         .e_empty_record => {
+            try self.record_constructions.append(self.gpa, expr_idx);
             try self.unifyWith(expr_var, .{ .structure = .empty_record }, env);
         },
         // tags //
@@ -25306,6 +25304,7 @@ const Probe = struct {
     pending_generated_parser_error_mappings_len: usize,
     rejected_static_dispatches_len: usize,
     record_omitted_defaults_len: usize,
+    record_constructions_len: usize,
     accepted_nominal_constructor_backings_len: usize,
     dispatch_target_instantiations_len: usize,
     dispatch_derivations_len: usize,
@@ -25351,6 +25350,7 @@ const Probe = struct {
         // on descriptors the savepoint rollback above already restored.
         self.check.cir.rejected_static_dispatches.items.shrinkRetainingCapacity(self.rejected_static_dispatches_len);
         self.check.cir.record_omitted_defaults.items.shrinkRetainingCapacity(self.record_omitted_defaults_len);
+        self.check.record_constructions.shrinkRetainingCapacity(self.record_constructions_len);
         // Constructor relations recorded during the probe name the operand var
         // and the backing content the savepoint rollback just discarded.
         self.check.accepted_nominal_constructor_backings.shrinkRetainingCapacity(self.accepted_nominal_constructor_backings_len);
@@ -25431,6 +25431,7 @@ fn beginProbe(self: *Self, env: ?*Env) std.mem.Allocator.Error!Probe {
         .pending_generated_parser_error_mappings_len = pending_generated_parser_error_mappings_len,
         .rejected_static_dispatches_len = rejected_static_dispatches_len,
         .record_omitted_defaults_len = record_omitted_defaults_len,
+        .record_constructions_len = self.record_constructions.items.len,
         .accepted_nominal_constructor_backings_len = accepted_nominal_constructor_backings_len,
         .dispatch_target_instantiations_len = dispatch_target_instantiations_len,
         .dispatch_derivations_len = dispatch_derivations_len,
@@ -25884,6 +25885,88 @@ fn checkPendingDefaults(self: *Self, env: *Env) std.mem.Allocator.Error!void {
     // defaulting rounds and constraint validation settle the types.
 }
 
+/// An accepted omission belongs to every fresh construction of the unified
+/// record that did not supply that field. Preserve the unifier's exact default
+/// identity even if later value relations normalize its field kind to required.
+/// This pass consumes registered constructions and accepted decisions only;
+/// it never discovers defaults by reopening nominal declarations or rows.
+fn distributeRecordOmittedDefaults(self: *Self) Allocator.Error!void {
+    const entries = self.cir.record_omitted_defaults.items.items;
+    if (entries.len == 0) return;
+
+    const Decision = struct {
+        root: Var,
+        omission: ModuleEnv.RecordOmittedDefault,
+
+        fn lessThan(_: void, a: @This(), b: @This()) bool {
+            if (a.root != b.root) return @intFromEnum(a.root) < @intFromEnum(b.root);
+            if (a.omission.field_name != b.omission.field_name)
+                return @as(u32, @bitCast(a.omission.field_name)) < @as(u32, @bitCast(b.omission.field_name));
+            if (a.omission.origin_module != b.omission.origin_module)
+                return @intFromEnum(a.omission.origin_module) < @intFromEnum(b.omission.origin_module);
+            return a.omission.default_expr_node < b.omission.default_expr_node;
+        }
+    };
+    const decisions = try self.gpa.alloc(Decision, entries.len);
+    defer self.gpa.free(decisions);
+    for (entries, decisions) |entry, *decision| {
+        decision.* = .{
+            .root = self.types.resolveVar(ModuleEnv.varFrom(entry.expr)).var_,
+            .omission = entry,
+        };
+    }
+    std.mem.sort(Decision, decisions, {}, Decision.lessThan);
+
+    // Index only classes with accepted defaults. Identical decisions from
+    // already-guided sibling literals are visited once per construction.
+    const Range = struct { start: usize, end: usize };
+    var by_root = collections.DenseMap(Var, Range).init(self.gpa);
+    defer by_root.deinit();
+    var unique_len: usize = 0;
+    for (decisions) |decision| {
+        if (unique_len > 0 and !Decision.lessThan({}, decisions[unique_len - 1], decision)) continue;
+        decisions[unique_len] = decision;
+        const group = try by_root.getOrPut(decision.root);
+        if (!group.found_existing) group.value_ptr.* = .{ .start = unique_len, .end = unique_len };
+        unique_len += 1;
+        group.value_ptr.end = unique_len;
+    }
+
+    var emitted = collections.DenseMap(CIR.Expr.Idx, void).init(self.gpa);
+    defer emitted.deinit();
+    var output = try ModuleEnv.RecordOmittedDefault.SafeList.initCapacity(self.cir.gpa, @intCast(entries.len));
+    errdefer output.deinit(self.cir.gpa);
+    for (self.record_constructions.items) |expr_idx| {
+        if (self.hoistExprInvalidated(expr_idx) or self.erroneous_value_exprs.contains(expr_idx)) continue;
+        const resolved = self.types.resolveVar(ModuleEnv.varFrom(expr_idx));
+        if (resolved.desc.content == .err) continue;
+        const group = by_root.get(resolved.var_) orelse continue;
+        const seen = try emitted.getOrPut(expr_idx);
+        if (seen.found_existing) continue;
+        const expr = self.cir.store.getExpr(expr_idx);
+        const supplied_fields = fields: {
+            if (expr == .e_empty_record) break :fields &.{};
+            std.debug.assert(expr == .e_record and expr.e_record.ext == null);
+            break :fields self.cir.store.sliceRecordFields(expr.e_record.fields);
+        };
+        for (decisions[group.start..group.end]) |decision| {
+            const supplied = supplied: {
+                for (supplied_fields) |field_idx| {
+                    if (self.cir.store.getRecordField(field_idx).name == decision.omission.field_name)
+                        break :supplied true;
+                }
+                break :supplied false;
+            };
+            if (supplied) continue;
+            var omission = decision.omission;
+            omission.expr = expr_idx;
+            _ = try output.append(self.cir.gpa, omission);
+        }
+    }
+    self.cir.record_omitted_defaults.deinit(self.cir.gpa);
+    self.cir.record_omitted_defaults = output;
+}
+
 /// Post-settlement cycle residue on defaults (design.md "Defaulted Fields"):
 /// canonicalization's end-of-module pass already rejected every
 /// name-resolvable materialization cycle (and dropped those defaults, so
@@ -25894,6 +25977,7 @@ fn checkPendingDefaults(self: *Self, env: *Env) std.mem.Allocator.Error!void {
 /// defaults materialize per specialization, so a parametric field lowers its
 /// default at each site's monotype.)
 fn checkDefaultRestrictions(self: *Self) std.mem.Allocator.Error!void {
+    try self.distributeRecordOmittedDefaults();
     // Every judgment and retirement below is per pending default, so a
     // module with none has nothing to build or sweep: gating here keeps the
     // evidence indexes (and `dispatch_scheme_uses`' loud release-mode

--- a/src/check/test/repros_test.zig
+++ b/src/check/test/repros_test.zig
@@ -935,6 +935,100 @@ test "check - repro - issue 11024 - empty record literal satisfies an all-defaul
     try test_env.assertDefType("y", "Foo");
 }
 
+test "check - issue 11271 - polymorphic calls retain every omitted-default construction" {
+    const cases = [_]struct { expression: []const u8, owners: usize, fields_per_owner: usize = 2, empty: bool = true }{
+        .{ .expression = "List.repeat({}, 2)", .owners = 1 },
+        .{ .expression = "List.map([1, 2], |_| {})", .owners = 1 },
+        .{ .expression = "id([{}, {}])", .owners = 2 },
+        .{ .expression = "id([id({}), id({})])", .owners = 2 },
+        .{ .expression = "id(if True [{}, {}] else [{}, {}])", .owners = 4 },
+        .{ .expression = "List.map([True, False], |flag| if flag {} else {})", .owners = 2 },
+        .{ .expression = "id([{ count: 1 }, { count: 2 }])", .owners = 2, .fields_per_owner = 1, .empty = false },
+    };
+    for (cases) |case| {
+        const source = try std.fmt.allocPrint(std.testing.allocator,
+            \\Config := {{ count : U8 ?? 10, other : U8 ?? 20 }}
+            \\id : a -> a
+            \\id = |x| x
+            \\xs : List(Config)
+            \\xs = {s}
+        , .{case.expression});
+        defer std.testing.allocator.free(source);
+        var env = try TestEnv.init("Test", source);
+        defer env.deinit();
+        try env.assertDefType("xs", "List(Config)");
+        const omissions = env.module_env.record_omitted_defaults.items.items;
+        try std.testing.expectEqual(case.fields_per_owner * case.owners, omissions.len);
+        for (omissions) |omission| {
+            const expr = env.module_env.store.getExpr(omission.expr);
+            try std.testing.expect(if (case.empty) expr == .e_empty_record else expr == .e_record);
+            var owned_count: usize = 0;
+            for (omissions) |other| {
+                if (other.expr == omission.expr) owned_count += 1;
+            }
+            try std.testing.expectEqual(case.fields_per_owner, owned_count);
+        }
+    }
+}
+
+test "check - issue 11271 - polymorphic calls preserve required fields and committed width" {
+    const sources = [_][]const u8{
+        \\Config := { count : U8, other : U8 ?? 20 }
+        \\id : a -> a
+        \\id = |x| x
+        \\value : Config
+        \\value = id({})
+        ,
+        \\Config := { count : U8 ?? 10 }
+        \\id : a -> a
+        \\id = |x| x
+        \\make : {} -> Config
+        \\make = |empty| id(empty)
+        ,
+        \\Config := { count : U8 ?? 10 }
+        \\id : a -> a
+        \\id = |x| x
+        \\read : Config -> U8
+        \\read = |config| config.count
+        \\use : {} -> U8
+        \\use = |empty| read(id(empty))
+        ,
+    };
+    for (sources) |source| {
+        var env = try TestEnv.init("Test", source);
+        defer env.deinit();
+        try env.assertOneTypeError("Type Mismatch");
+    }
+}
+
+test "check - issue 11271 - polymorphic omission preserves independent nominal arguments" {
+    var env = try TestEnv.init("Test",
+        \\Config(a) := { values : List(a) ?? [] }
+        \\id : a -> a
+        \\id = |x| x
+        \\numbers : Config(U8)
+        \\numbers = id({})
+        \\strings : Config(Str)
+        \\strings = id({})
+    );
+    defer env.deinit();
+    try env.assertDefType("numbers", "Config(U8)");
+    try env.assertDefType("strings", "Config(Str)");
+    try std.testing.expectEqual(2, env.module_env.record_omitted_defaults.items.items.len);
+}
+
+test "check - issue 11271 - merged constructions retain recursive-default rejection" {
+    var env = try TestEnv.init("Test",
+        \\Config := { count : U64 ?? make(True).count }
+        \\id : a -> a
+        \\id = |x| x
+        \\make : Bool -> Config
+        \\make = |flag| id(if flag {} else {})
+    );
+    defer env.deinit();
+    try env.assertOneTypeError("Recursive Default Value");
+}
+
 test "check - issue 11024 - nested empty literals own their omitted defaults" {
     const src =
         \\Foo := { bar : U64 ?? 3, baz : U64 ?? 7 }

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -418,7 +418,7 @@ const Unifier = struct {
     /// This allows error messages to point to the original expression rather than the resolved type.
     unresolved_a: ?Var,
     unresolved_b: ?Var,
-    /// The two record vars of the innermost record-vs-record relation currently
+    /// The checked record vars of the innermost record relation currently
     /// being unified. A row absorbed into an empty record names that empty row's
     /// var, which for a nested literal is the literal's internal extension var
     /// rather than the literal's own var; the enclosing pair is how the checker
@@ -736,6 +736,8 @@ const Unifier = struct {
                 self.scratch.visited_vars.items.items.len = handler.visited_vars_len;
                 self.unresolved_a = handler.saved_unresolved_a;
                 self.unresolved_b = handler.saved_unresolved_b;
+            } else if (frame_tag == .restore_enclosing_records) {
+                self.enclosing_records = frame.restore_enclosing_records;
             } else if (frame_tag == .mismatch_handler) {
                 const handler = frame.mismatch_handler;
                 if (handler != .propagate) return try self.applyMismatchHandling(handler);
@@ -1630,6 +1632,7 @@ const Unifier = struct {
                 // Relate the source construction directly to the backing row.
                 // Never merge the opened backing root with the nominal result:
                 // later constructions may reuse that structural opening.
+                try self.enterRecordRelation(vars);
                 try self.unifyRowWithEmptyRecord(vars, source, record.fields, record.ext, direction);
             }
             return;
@@ -2394,6 +2397,19 @@ const Unifier = struct {
         }
     }
 
+    /// Retain the checked representatives of a record relation while its
+    /// children run. A polymorphic call's raw operand may name a formal slot,
+    /// whereas its checked representative still names the record construction.
+    fn enterRecordRelation(self: *Self, vars: *const ResolvedVarDescs) std.mem.Allocator.Error!void {
+        // Pushed before any child work so it pops once that work has drained;
+        // a plain `defer` would restore while the children are still queued.
+        _ = try self.scratch.unify_work_stack.append(
+            self.scratch.gpa,
+            .{ .restore_enclosing_records = self.enclosing_records },
+        );
+        self.enclosing_records = .{ vars.a.var_, vars.b.var_ };
+    }
+
     /// Unify two extensible records.
     ///
     /// This function implements Elm-style record unification.
@@ -2482,13 +2498,7 @@ const Unifier = struct {
         const trace = tracy.trace(@src());
         defer trace.end();
 
-        // Pushed before any child work so it pops once that work has drained;
-        // a plain `defer` would restore while the children are still queued.
-        _ = try self.scratch.unify_work_stack.append(
-            self.scratch.gpa,
-            .{ .restore_enclosing_records = self.enclosing_records },
-        );
-        self.enclosing_records = .{ vars.a.var_, vars.b.var_ };
+        try self.enterRecordRelation(vars);
 
         // First, unwrap all fields for record, erroring if we encounter an
         // invalid record ext var

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -21,6 +21,44 @@ const simd_tests = @import("eval_simd_tests.zig");
 /// Every value-producing test is observed solely through `Str.inspect(...)`.
 const core_tests = [_]TestCase{
     .{
+        .name = "issue 11271: polymorphic record constructions materialize all defaults",
+        .source_kind = .module,
+        .source =
+        \\Config := { count : U64 ?? 10, other : U64 ?? 20 }
+        \\id : a -> a
+        \\id = |x| x
+        \\value : Config
+        \\value = id({})
+        \\repeated : List(Config)
+        \\repeated = List.repeat({}, 2)
+        \\mapped : List(Config)
+        \\mapped = List.map([1, 2], |_| {})
+        \\siblings : List(Config)
+        \\siblings = id([id({}), id({})])
+        \\partial : List(Config)
+        \\partial = id([{ count: 1 }, { count: 2 }])
+        \\total : List(Config) -> U64
+        \\total = |configs| List.fold(configs, 0, |sum, config| sum + config.count + config.other)
+        \\main = (value.count, value.other, total(repeated), total(mapped), total(siblings), total(partial))
+        ,
+        .expected = .{ .inspect_str = "(10, 20, 60, 60, 60, 43)" },
+    },
+    .{
+        .name = "issue 11271: polymorphic branch constructions retain optional and heap defaults",
+        .source_kind = .module,
+        .imports = &.{.{ .name = "Cfg", .source = "Cfg := { text : Str ?? \"a default string longer than the inline capacity\", count ?: U64 }\n" }},
+        .source =
+        \\import Cfg
+        \\id : a -> a
+        \\id = |x| x
+        \\make : Bool -> List(Cfg.Cfg)
+        \\make = |flag| id(if flag [{}, {}] else [{}, {}])
+        \\valid = |configs| List.all(configs, |config| (config.text == "a default string longer than the inline capacity") and ((config.?count ?? 9) == 9))
+        \\main = valid(make(True)) and valid(make(False))
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
         .name = "issue 11024: implicit empty nominal records materialize defaults at every site",
         .source_kind = .module,
         .source =

--- a/test/snapshots/issue/issue_11271_empty_record_absorbs_nominal_defaults.md
+++ b/test/snapshots/issue/issue_11271_empty_record_absorbs_nominal_defaults.md
@@ -1,0 +1,520 @@
+# META
+~~~ini
+description=An empty record literal absorbs a nominal record's defaulted and optional fields wherever a literal that omits fields does
+type=snippet
+~~~
+# SOURCE
+~~~roc
+# repro for https://github.com/roc-lang/roc/issues/11271
+Config := { count : U8 ?? 10, other : U8 ?? 20 }
+
+Mixed := { label ?: Str, count : U8 ?? 7 }
+
+id : a -> a
+id = |x| x
+
+total : Config -> U8
+total = |config| config.count
+
+# A literal that omits `other` absorbs its default, and so must `{}`.
+supplied : Config
+supplied = id({ count: 1 })
+
+omitted : Config
+omitted = id({})
+
+# Same pairing through a builtin that only learns the element type from the
+# annotation on the def.
+supplied_list : List(Config)
+supplied_list = List.repeat({ count: 1 }, 2)
+
+omitted_list : List(Config)
+omitted_list = List.repeat({}, 2)
+
+supplied_mapped : List(Config)
+supplied_mapped = List.map([1, 2], |_| { count: 1 })
+
+omitted_mapped : List(Config)
+omitted_mapped = List.map([1, 2], |_| {})
+
+# An optional (`?:`) sibling does not change the answer.
+omitted_mixed : Mixed
+omitted_mixed = id({})
+
+expect total({ count: 1 }) == 1
+expect total(Config.{}) == 10
+expect total({}) == 10
+expect omitted.count == 10
+expect omitted.other == 20
+expect omitted_mixed.count == 7
+expect {
+	config : Config
+	config = {}
+	config.count == 10
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenCurly,LowerIdent,OpColon,UpperIdent,OpDoubleQuestion,Int,Comma,LowerIdent,OpColon,UpperIdent,OpDoubleQuestion,Int,CloseCurly,
+UpperIdent,OpColonEqual,OpenCurly,LowerIdent,OpQuestion,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,OpDoubleQuestion,Int,CloseCurly,
+LowerIdent,OpColon,LowerIdent,OpArrow,LowerIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,Comma,Int,CloseRound,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,Comma,Int,CloseRound,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,Comma,Int,CloseSquare,Comma,OpBar,Underscore,OpBar,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,CloseRound,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,Comma,Int,CloseSquare,Comma,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+KwExpect,LowerIdent,NoSpaceOpenRound,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,CloseRound,OpEquals,Int,
+KwExpect,LowerIdent,NoSpaceOpenRound,UpperIdent,Dot,OpenCurly,CloseCurly,CloseRound,OpEquals,Int,
+KwExpect,LowerIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,OpEquals,Int,
+KwExpect,LowerIdent,NoSpaceDotLowerIdent,OpEquals,Int,
+KwExpect,LowerIdent,NoSpaceDotLowerIdent,OpEquals,Int,
+KwExpect,LowerIdent,NoSpaceDotLowerIdent,OpEquals,Int,
+KwExpect,OpenCurly,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,OpenCurly,CloseCurly,
+LowerIdent,NoSpaceDotLowerIdent,OpEquals,Int,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-decl
+			(header (name "Config")
+				(args))
+			(ty-record
+				(anno-record-field (name "count")
+					(ty (name "U8"))
+					(default
+						(e-int (raw "10"))))
+				(anno-record-field (name "other")
+					(ty (name "U8"))
+					(default
+						(e-int (raw "20"))))))
+		(s-type-decl
+			(header (name "Mixed")
+				(args))
+			(ty-record
+				(anno-record-field (name "label") (optional true)
+					(ty (name "Str")))
+				(anno-record-field (name "count")
+					(ty (name "U8"))
+					(default
+						(e-int (raw "7"))))))
+		(s-type-anno (name "id")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty-var (raw "a"))))
+		(s-decl
+			(p-ident (raw "id"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-type-anno (name "total")
+			(ty-fn
+				(ty (name "Config"))
+				(ty (name "U8"))))
+		(s-decl
+			(p-ident (raw "total"))
+			(e-lambda
+				(args
+					(p-ident (raw "config")))
+				(e-field-access
+					(receiver
+						(e-ident (raw "config")))
+					(segment (mode "required") (field "count")))))
+		(s-type-anno (name "supplied")
+			(ty (name "Config")))
+		(s-decl
+			(p-ident (raw "supplied"))
+			(e-apply
+				(e-ident (raw "id"))
+				(e-record
+					(field (field "count")
+						(e-int (raw "1"))))))
+		(s-type-anno (name "omitted")
+			(ty (name "Config")))
+		(s-decl
+			(p-ident (raw "omitted"))
+			(e-apply
+				(e-ident (raw "id"))
+				(e-record)))
+		(s-type-anno (name "supplied_list")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Config"))))
+		(s-decl
+			(p-ident (raw "supplied_list"))
+			(e-apply
+				(e-ident (raw "List.repeat"))
+				(e-record
+					(field (field "count")
+						(e-int (raw "1"))))
+				(e-int (raw "2"))))
+		(s-type-anno (name "omitted_list")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Config"))))
+		(s-decl
+			(p-ident (raw "omitted_list"))
+			(e-apply
+				(e-ident (raw "List.repeat"))
+				(e-record)
+				(e-int (raw "2"))))
+		(s-type-anno (name "supplied_mapped")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Config"))))
+		(s-decl
+			(p-ident (raw "supplied_mapped"))
+			(e-apply
+				(e-ident (raw "List.map"))
+				(e-list
+					(e-int (raw "1"))
+					(e-int (raw "2")))
+				(e-lambda
+					(args
+						(p-underscore))
+					(e-record
+						(field (field "count")
+							(e-int (raw "1")))))))
+		(s-type-anno (name "omitted_mapped")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Config"))))
+		(s-decl
+			(p-ident (raw "omitted_mapped"))
+			(e-apply
+				(e-ident (raw "List.map"))
+				(e-list
+					(e-int (raw "1"))
+					(e-int (raw "2")))
+				(e-lambda
+					(args
+						(p-underscore))
+					(e-record))))
+		(s-type-anno (name "omitted_mixed")
+			(ty (name "Mixed")))
+		(s-decl
+			(p-ident (raw "omitted_mixed"))
+			(e-apply
+				(e-ident (raw "id"))
+				(e-record)))
+		(s-expect
+			(e-binop (op "==")
+				(e-apply
+					(e-ident (raw "total"))
+					(e-record
+						(field (field "count")
+							(e-int (raw "1")))))
+				(e-int (raw "1"))))
+		(s-expect
+			(e-binop (op "==")
+				(e-apply
+					(e-ident (raw "total"))
+					(e-nominal-record
+						(mapper (e-tag (raw "Config")))
+						(backing (e-record))))
+				(e-int (raw "10"))))
+		(s-expect
+			(e-binop (op "==")
+				(e-apply
+					(e-ident (raw "total"))
+					(e-record))
+				(e-int (raw "10"))))
+		(s-expect
+			(e-binop (op "==")
+				(e-field-access
+					(receiver
+						(e-ident (raw "omitted")))
+					(segment (mode "required") (field "count")))
+				(e-int (raw "10"))))
+		(s-expect
+			(e-binop (op "==")
+				(e-field-access
+					(receiver
+						(e-ident (raw "omitted")))
+					(segment (mode "required") (field "other")))
+				(e-int (raw "20"))))
+		(s-expect
+			(e-binop (op "==")
+				(e-field-access
+					(receiver
+						(e-ident (raw "omitted_mixed")))
+					(segment (mode "required") (field "count")))
+				(e-int (raw "7"))))
+		(s-expect
+			(e-block
+				(statements
+					(s-type-anno (name "config")
+						(ty (name "Config")))
+					(s-decl
+						(p-ident (raw "config"))
+						(e-record))
+					(e-binop (op "==")
+						(e-field-access
+							(receiver
+								(e-ident (raw "config")))
+							(segment (mode "required") (field "count")))
+						(e-int (raw "10"))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "id"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x"))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-rigid-var-lookup (ty-rigid-var (name "a"))))))
+	(d-let
+		(p-assign (ident "total"))
+		(e-lambda
+			(args
+				(p-assign (ident "config")))
+			(e-field-access
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "config"))))
+				(segments
+					(segment (name "count") (mode "required")))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "Config") (local))
+				(ty-lookup (name "U8") (builtin)))))
+	(d-let
+		(p-assign (ident "supplied"))
+		(e-call (constraint-fn-var 431)
+			(e-lookup-local
+				(p-assign (ident "id")))
+			(e-record
+				(fields
+					(field (name "count")
+						(e-num (value "1"))))))
+		(annotation
+			(ty-lookup (name "Config") (local))))
+	(d-let
+		(p-assign (ident "omitted"))
+		(e-call (constraint-fn-var 445)
+			(e-lookup-local
+				(p-assign (ident "id")))
+			(e-empty_record))
+		(annotation
+			(ty-lookup (name "Config") (local))))
+	(d-let
+		(p-assign (ident "supplied_list"))
+		(e-call (constraint-fn-var 480)
+			(e-lookup-external
+				(builtin))
+			(e-record
+				(fields
+					(field (name "count")
+						(e-num (value "1")))))
+			(e-num (value "2")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Config") (local)))))
+	(d-let
+		(p-assign (ident "omitted_list"))
+		(e-call (constraint-fn-var 498)
+			(e-lookup-external
+				(builtin))
+			(e-empty_record)
+			(e-num (value "2")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Config") (local)))))
+	(d-let
+		(p-assign (ident "supplied_mapped"))
+		(e-call (constraint-fn-var 545)
+			(e-lookup-external
+				(builtin))
+			(e-list
+				(elems
+					(e-num (value "1"))
+					(e-num (value "2"))))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record
+					(fields
+						(field (name "count")
+							(e-num (value "1")))))))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Config") (local)))))
+	(d-let
+		(p-assign (ident "omitted_mapped"))
+		(e-call (constraint-fn-var 578)
+			(e-lookup-external
+				(builtin))
+			(e-list
+				(elems
+					(e-num (value "1"))
+					(e-num (value "2"))))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-empty_record)))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Config") (local)))))
+	(d-let
+		(p-assign (ident "omitted_mixed"))
+		(e-call (constraint-fn-var 585)
+			(e-lookup-local
+				(p-assign (ident "id")))
+			(e-empty_record))
+		(annotation
+			(ty-lookup (name "Mixed") (local))))
+	(s-nominal-decl
+		(ty-header (name "Config"))
+		(ty-record
+			(field (field "count") (defaulted true)
+				(ty-lookup (name "U8") (builtin)))
+			(field (field "other") (defaulted true)
+				(ty-lookup (name "U8") (builtin)))))
+	(s-nominal-decl
+		(ty-header (name "Mixed"))
+		(ty-record
+			(field (field "label") (optional true)
+				(ty-lookup (name "Str") (builtin)))
+			(field (field "count") (defaulted true)
+				(ty-lookup (name "U8") (builtin)))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-call (constraint-fn-var 614)
+					(e-lookup-local
+						(p-assign (ident "total")))
+					(e-record
+						(fields
+							(field (name "count")
+								(e-num (value "1")))))))
+			(rhs
+				(e-num (value "1")))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-call (constraint-fn-var 643)
+					(e-lookup-local
+						(p-assign (ident "total")))
+					(e-nominal (nominal "Config")
+						(e-empty_record))))
+			(rhs
+				(e-num (value "10")))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-call (constraint-fn-var 662)
+					(e-lookup-local
+						(p-assign (ident "total")))
+					(e-empty_record)))
+			(rhs
+				(e-num (value "10")))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-field-access
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "omitted"))))
+					(segments
+						(segment (name "count") (mode "required")))))
+			(rhs
+				(e-num (value "10")))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-field-access
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "omitted"))))
+					(segments
+						(segment (name "other") (mode "required")))))
+			(rhs
+				(e-num (value "20")))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-field-access
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "omitted_mixed"))))
+					(segments
+						(segment (name "count") (mode "required")))))
+			(rhs
+				(e-num (value "7")))))
+	(s-expect
+		(e-block
+			(s-let
+				(p-assign (ident "config"))
+				(e-empty_record))
+			(e-method-eq (negated "false")
+				(lhs
+					(e-field-access
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "config"))))
+						(segments
+							(segment (name "count") (mode "required")))))
+				(rhs
+					(e-num (value "10")))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "Config -> U8"))
+		(patt (type "Config"))
+		(patt (type "Config"))
+		(patt (type "List(Config)"))
+		(patt (type "List(Config)"))
+		(patt (type "List(Config)"))
+		(patt (type "List(Config)"))
+		(patt (type "Mixed")))
+	(type_decls
+		(nominal (type "Config")
+			(ty-header (name "Config")))
+		(nominal (type "Mixed")
+			(ty-header (name "Mixed"))))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "Config -> U8"))
+		(expr (type "Config"))
+		(expr (type "Config"))
+		(expr (type "List(Config)"))
+		(expr (type "List(Config)"))
+		(expr (type "List(Config)"))
+		(expr (type "List(Config)"))
+		(expr (type "Mixed"))))
+~~~


### PR DESCRIPTION
Empty record literals now absorb nominal field defaults through polymorphic calls such as `id({})`, `List.repeat`, and `List.map`. Defaults are attached to every contributing record literal when their types unify, while required fields and committed record widths remain enforced. Omission decisions are coalesced at settlement instead of repeatedly scanning the module's omission table during unification.

Closes #11271.
