### PR TITLE
Classify canonicalized complete reads by their representative's dismantle plan

### DIFF
--- a/design.md
+++ b/design.md
@@ -12093,6 +12093,16 @@ When one ownership place is read repeatedly by ownership-complete struct-field
 or tag-payload reads along a single control-flow path, dismantle analysis
 chooses the earliest same-root, same-layout read that dominates each later read
 and rewrites those later reads as explicit local aliases before ARC solving.
+That rewrite is materialized only when the representative commits a dismantle
+plan, and a canonicalized read is classified by that same plan: under a
+committed representative it is an occurrence of the representative (a whole
+use when its target binds owned, a transparent alias when borrowed), and
+otherwise it stays an ordinary field read of its root. Candidates are solved
+representatives first; a representative is a complete field read whose layout
+is a proper part of its root's layout, so the order is acyclic and each
+deferred read is settled exactly once.
+A root therefore never commits a take on a read that is emitted as an alias of
+a container already holding the root's unit.
 Dominance is computed once from the explicit statement-successor graph with a
 synthetic entry for all procedure roots. Immediate dominators settle in reverse
 postorder, and dominator-tree intervals answer field-read and tag-payload-read

--- a/design.md
+++ b/design.md
@@ -12096,8 +12096,8 @@ and rewrites those later reads as explicit local aliases before ARC solving.
 That rewrite is materialized only when the representative commits a dismantle
 plan, and a canonicalized read is classified by that same plan: under a
 committed representative it is an occurrence of the representative (a whole
-use when its target binds owned, a transparent alias when borrowed), and
-otherwise it stays an ordinary field read of its root. Candidates are solved
+use when its target is emitted owned, a transparent alias when it stays
+borrowed), and otherwise it stays an ordinary field read of its root. Candidates are solved
 representatives first; a representative is a complete field read whose layout
 is a proper part of its root's layout, so the order is acyclic and each
 deferred read is settled exactly once.

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -1667,9 +1667,13 @@ pub const tests = [_]TestCase{
         // and returns that record either updated (`{ ..model, query }`) or
         // untouched on the two branches of an `if`, while the caller builds a
         // nominal value through a method of a type declared in another module
-        // on its error path. The ARC solve must account for the captured
-        // record's field places consistently on both branches; the run
-        // produces one effect.
+        // on its error path. The captured record is the captures struct's only
+        // refcounted field, so its reads are ownership-complete and both
+        // branch reads canonicalize to the one dominating read before the
+        // comparison. Dismantle analysis must classify those branch reads by
+        // that representative's plan rather than commit a take of the
+        // captures struct on a read emitted as the representative's alias;
+        // the run produces one effect.
         .name = "issue 11275: closure returning captured record updated or unchanged solves ARC",
         .source_kind = .module,
         .imports = &.{.{

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -1661,4 +1661,64 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "[]" },
     },
+    .{
+        // https://github.com/roc-lang/roc/issues/11275
+        // A closure captures a record whose non-updated field is refcounted
+        // and returns that record either updated (`{ ..model, query }`) or
+        // untouched on the two branches of an `if`, while the caller builds a
+        // nominal value through a method of a type declared in another module
+        // on its error path. The ARC solve must account for the captured
+        // record's field places consistently on both branches; the run
+        // produces one effect.
+        .name = "issue 11275: closure returning captured record updated or unchanged solves ARC",
+        .source_kind = .module,
+        .imports = &.{.{
+            .name = "Effect",
+            .source =
+            \\Effect := [Log].{
+            \\    log : Str -> Effect
+            \\    log = |_message| Log
+            \\}
+            \\
+            ,
+        }},
+        .source =
+        \\import Effect exposing [Effect]
+        \\
+        \\Model : { query : Str, items : List(Str) }
+        \\
+        \\update : Model -> (Model, List(Effect))
+        \\update = |model|
+        \\    run(
+        \\        |body| {
+        \\            decoded : Try({ query : Str }, [Bad])
+        \\            decoded = if body == "" { Err(Bad) } else { Ok({ query: body }) }
+        \\
+        \\            match decoded {
+        \\                Ok({ query }) =>
+        \\                    if query == model.query {
+        \\                        Ok(({ ..model, query }, []))
+        \\                    } else {
+        \\                        Ok((model, []))
+        \\                    }
+        \\
+        \\                Err(Bad) => Err(Bad)
+        \\            }
+        \\        },
+        \\    )
+        \\
+        \\run : (Str -> Try((Model, List(Effect)), [Bad])) -> (Model, List(Effect))
+        \\run = |f|
+        \\    match f("") {
+        \\        Ok(updated) => updated
+        \\        Err(Bad) => ({ query: "", items: [] }, [Effect.log("")])
+        \\    }
+        \\
+        \\main = {
+        \\    (_updated, effects) = update({ query: "q", items: [] })
+        \\    List.len(effects)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "1" },
+    },
 };

--- a/src/lir/arc_dismantle.zig
+++ b/src/lir/arc_dismantle.zig
@@ -694,9 +694,12 @@ const Analysis = struct {
     /// whole use of the representative, a borrowed target reads through it.
     /// The root defers the read until the representative's plan is known;
     /// the representative's plan never depends on the root's, so solving
-    /// representatives first settles every deferred read exactly once.
+    /// representatives first settles every deferred read exactly once. The
+    /// read's mention stays on the root: the representative's defining read
+    /// dominates this one, so the root's flow already observes the field
+    /// before it, and a mention of the representative here would poison the
+    /// root's own take when the read rejoins its field reads.
     fn noteEquivalencedRead(self: *Analysis, stmt: LIR.CFStmtId, root: LIR.LocalId, field_idx: u32, target: LIR.LocalId, representative: LIR.LocalId) Error!void {
-        if (self.rc_local[@intFromEnum(target)]) try self.noteMention(stmt, representative);
         if (!self.solution.isBorrowed(target)) {
             if (try self.entryOf(representative)) |candidate| try candidate.whole_uses.append(self.gpa, stmt);
         }

--- a/src/lir/arc_dismantle.zig
+++ b/src/lir/arc_dismantle.zig
@@ -690,8 +690,10 @@ const Analysis = struct {
 
     /// A complete read canonicalized to a dominating representative. If the
     /// representative commits a plan, the read is materialized as a pure
-    /// alias of it and is scanned as that alias now: an owned target is a
-    /// whole use of the representative, a borrowed target reads through it.
+    /// alias of it and is scanned as that alias now: a target emitted owned
+    /// is a whole use of the representative (an owned-demanded borrowed
+    /// target joins it once demand is closed), and a borrowed target reads
+    /// through it.
     /// The root defers the read until the representative's plan is known;
     /// the representative's plan never depends on the root's, so solving
     /// representatives first settles every deferred read exactly once. The
@@ -1703,6 +1705,19 @@ pub fn compute(
 
     analysis.closeOwnedDemand();
 
+    // Owned demand is closed only now. A deferred read whose borrowed target
+    // is re-emitted owned retains through its representative exactly like an
+    // owned target, so it is the same whole use of that representative.
+    var demand_it = analysis.candidates.valueIterator();
+    while (demand_it.next()) |candidate| {
+        for (candidate.equivalenced_reads.items) |deferred| {
+            const target_index = @intFromEnum(deferred.read.target);
+            if (!solution.isBorrowed(deferred.read.target) or !analysis.owned_demand[target_index]) continue;
+            const representative = analysis.candidates.getPtr(@intFromEnum(deferred.representative)) orelse continue;
+            try representative.whole_uses.append(gpa, deferred.read.stmt);
+        }
+    }
+
     // Second phase: verify the surviving candidates' read shapes and spines,
     // and build the output.
     var result = Dismantles{
@@ -2190,7 +2205,7 @@ pub fn compute(
                 try result.owned_only_takes.put(gpa, read.stmt, take);
                 const target_index = @intFromEnum(read.target);
                 const prior = result.owned_only_binding_roots[target_index];
-                if (prior != no_index and prior != @intFromEnum(local)) {
+                if (prior != no_index and prior != @intFromEnum(activation_root)) {
                     dismantleInvariant("ARC owned-only field binding had conflicting parameter roots");
                 }
                 result.owned_only_binding_roots[target_index] = @intFromEnum(activation_root);
@@ -2245,6 +2260,11 @@ pub fn compute(
         const representative_local: LIR.LocalId = @enumFromInt(representative);
         if (!result.containers.contains(representative_local) and
             !result.owned_only_containers.contains(representative_local)) continue;
+        // The deferred reads of this alias were settled against this exact
+        // plan, which only a candidate solved in dependency order can hold.
+        if (order_marks[representative] != .ordered) {
+            dismantleInvariant("ARC dismantle materialized an alias of a representative that was never solved");
+        }
         const stmt_index = projected_stmt[local_index];
         if (stmt_index == no_index) continue;
         const stmt = store.getCFStmtPtr(@enumFromInt(stmt_index));

--- a/src/lir/arc_dismantle.zig
+++ b/src/lir/arc_dismantle.zig
@@ -342,6 +342,15 @@ const Read = struct {
     field_idx: u32,
 };
 
+/// A complete field read of a root that dominance canonicalized to an
+/// earlier read of the same root and layout. Whether it is a field read of
+/// the root or a pure alias of that representative is decided by the
+/// representative's plan, so the root defers its classification.
+const EquivalencedRead = struct {
+    read: Read,
+    representative: LIR.LocalId,
+};
+
 const MentionEdge = struct {
     stmt: u32,
     next: u32,
@@ -364,12 +373,25 @@ const UnionRoot = struct {
 
 const ambiguous_view: u32 = no_index - 1;
 
+/// Depth-first ordering state for solving projection representatives
+/// before the roots whose deferred reads they settle.
+const OrderMark = enum(u8) {
+    unvisited,
+    visiting,
+    ordered,
+};
+
 const Candidate = struct {
     def_stmt: LIR.CFStmtId = @enumFromInt(no_index),
     def_count: u32 = 0,
     join_starts: std.ArrayList(LIR.CFStmtId) = .empty,
     disqualified: bool = false,
     reads: std.ArrayList(Read) = .empty,
+    /// Complete reads canonicalized to a dominating representative. Once the
+    /// representative commits a plan they are materialized as its aliases and
+    /// belong to its occurrence set; otherwise they rejoin `reads` before
+    /// this container's flow runs.
+    equivalenced_reads: std.ArrayList(EquivalencedRead) = .empty,
     /// Statements consuming or observing the container as one value—moved
     /// into an aggregate, passed to a call, returned, or join-carried. Takes
     /// stay valid as long as no whole use can run after a take, which the
@@ -426,6 +448,7 @@ const Analysis = struct {
         var it = self.candidates.valueIterator();
         while (it.next()) |candidate| {
             candidate.reads.deinit(self.gpa);
+            candidate.equivalenced_reads.deinit(self.gpa);
             candidate.join_starts.deinit(self.gpa);
             candidate.whole_uses.deinit(self.gpa);
         }
@@ -651,11 +674,36 @@ const Analysis = struct {
         // source's stored unit at the read itself when the target retains.
         if (self.rc_local[@intFromEnum(target)]) try self.noteMention(stmt, source);
         const root = self.resolveRoot(source);
+        const target_index = @intFromEnum(target);
+        const representative_index = self.projected_container[target_index];
+        if (representative_index != no_index and representative_index != target_index) {
+            try self.noteEquivalencedRead(stmt, root, field_idx, target, @enumFromInt(representative_index));
+            return;
+        }
         const candidate = (try self.entryOf(root)) orelse return;
         try candidate.reads.append(self.gpa, .{
             .stmt = stmt,
             .target = target,
             .field_idx = field_idx,
+        });
+    }
+
+    /// A complete read canonicalized to a dominating representative. If the
+    /// representative commits a plan, the read is materialized as a pure
+    /// alias of it and is scanned as that alias now: an owned target is a
+    /// whole use of the representative, a borrowed target reads through it.
+    /// The root defers the read until the representative's plan is known;
+    /// the representative's plan never depends on the root's, so solving
+    /// representatives first settles every deferred read exactly once.
+    fn noteEquivalencedRead(self: *Analysis, stmt: LIR.CFStmtId, root: LIR.LocalId, field_idx: u32, target: LIR.LocalId, representative: LIR.LocalId) Error!void {
+        if (self.rc_local[@intFromEnum(target)]) try self.noteMention(stmt, representative);
+        if (!self.solution.isBorrowed(target)) {
+            if (try self.entryOf(representative)) |candidate| try candidate.whole_uses.append(self.gpa, stmt);
+        }
+        const root_candidate = (try self.entryOf(root)) orelse return;
+        try root_candidate.equivalenced_reads.append(self.gpa, .{
+            .read = .{ .stmt = stmt, .target = target, .field_idx = field_idx },
+            .representative = representative,
         });
     }
 
@@ -1706,11 +1754,59 @@ pub fn compute(
     var borrow_stack = std.ArrayList(u32).empty;
     defer borrow_stack.deinit(gpa);
 
-    var it = analysis.candidates.iterator();
-    candidates: while (it.next()) |entry| {
-        const local: LIR.LocalId = @enumFromInt(entry.key_ptr.*);
-        const candidate = entry.value_ptr;
+    // A root's deferred reads are settled by their representatives' plans,
+    // and a representative's layout is a proper part of its root's layout,
+    // so the dependency graph is acyclic. Solve representatives before roots.
+    var candidate_order = std.ArrayList(u32).empty;
+    defer candidate_order.deinit(gpa);
+    try candidate_order.ensureTotalCapacity(gpa, analysis.candidates.count());
+    const order_marks = try gpa.alloc(OrderMark, store.localCount());
+    defer gpa.free(order_marks);
+    @memset(order_marks, .unvisited);
+    var order_stack = std.ArrayList(u32).empty;
+    defer order_stack.deinit(gpa);
+    var order_it = analysis.candidates.keyIterator();
+    while (order_it.next()) |key| {
+        if (order_marks[key.*] != .unvisited) continue;
+        try order_stack.append(gpa, key.*);
+        while (order_stack.items.len != 0) {
+            const index = order_stack.items[order_stack.items.len - 1];
+            switch (order_marks[index]) {
+                .unvisited => {
+                    order_marks[index] = .visiting;
+                    for (analysis.candidates.getPtr(index).?.equivalenced_reads.items) |deferred| {
+                        const representative_index = @intFromEnum(deferred.representative);
+                        switch (order_marks[representative_index]) {
+                            .unvisited => if (analysis.candidates.contains(representative_index)) {
+                                try order_stack.append(gpa, representative_index);
+                            },
+                            .visiting => dismantleInvariant("ARC dismantle projection representatives formed a cycle"),
+                            .ordered => {},
+                        }
+                    }
+                },
+                .visiting => {
+                    order_marks[index] = .ordered;
+                    candidate_order.appendAssumeCapacity(index);
+                    _ = order_stack.pop();
+                },
+                .ordered => _ = order_stack.pop(),
+            }
+        }
+    }
+
+    candidates: for (candidate_order.items) |candidate_index| {
+        const local: LIR.LocalId = @enumFromInt(candidate_index);
+        const candidate = analysis.candidates.getPtr(candidate_index).?;
         if (candidate.disqualified) continue;
+        // A deferred read whose representative committed a plan is that
+        // representative's alias; every other one is an ordinary field read
+        // of this container.
+        for (candidate.equivalenced_reads.items) |deferred| {
+            if (result.containers.contains(deferred.representative) or
+                result.owned_only_containers.contains(deferred.representative)) continue;
+            try candidate.reads.append(gpa, deferred.read);
+        }
         if (candidate.reads.items.len == 0) continue;
 
         // A payload view dismantles its tag union: the view holds no unit of


### PR DESCRIPTION
Fixes #11275. Dismantle analysis canonicalizes repeated ownership-complete field reads of one root to the earliest dominating read and rewrites the later reads as aliases of that representative once it commits a plan, but the scan still attributed those later reads to the root as field reads. The root could therefore commit a field take on a statement that was then emitted as a pure alias of a projected container already holding the root's unit, and the ARC solver panicked with "ARC field take reached an absent aggregate resource" for the closure in the issue, which returns its captured record either updated or untouched.

The root now defers such reads until its representative has been solved: under a committed representative the read is that container's occurrence (a whole use when its target binds owned, a transparent alias when borrowed), and otherwise it rejoins the root's ordinary field reads. Candidates are solved in representative-first dependency order, which is acyclic because a representative's layout is a proper part of its root's layout, so each deferred read is settled exactly once and the committed plan matches the LIR that is materialized.
