### PR TITLE
Persist range facts by what they denote across aliases and walk regions

### DIFF
--- a/src/compile/test/range_prove_test.zig
+++ b/src/compile/test/range_prove_test.zig
@@ -298,6 +298,215 @@ test "a byte merged from a read and a literal keeps its byte range for the overf
     try std.testing.expectEqual(@as(usize, 1), meet_shape.mul_proven);
 }
 
+const SearchShape = struct {
+    found: bool = false,
+    is_lt: usize = 0,
+    get_unsafe: usize = 0,
+    folded: usize = 0,
+};
+
+var search_shape: SearchShape = .{};
+
+fn countSearchShape(store: *const lir.LirStore, layouts: *const layout.Store) harness.LowerToLirHarnessError!void {
+    search_shape = .{};
+    const gpa = std.testing.allocator;
+    const buf = try gpa.alloc(u8, 1 << 20);
+    defer gpa.free(buf);
+    for (0..store.getProcSpecs().len) |index| {
+        var writer = std.Io.Writer.fixed(buf);
+        try lir.DebugPrint.writeProc(gpa, store, layouts, @enumFromInt(@as(u32, @intCast(index))), &writer);
+        const text = writer.buffered();
+        if (std.mem.count(u8, text, "list_get_unsafe") == 0 or std.mem.count(u8, text, "i16_to_u64_wrap") == 0) continue;
+        search_shape = .{
+            .found = true,
+            .is_lt = std.mem.count(u8, text, "num_is_lt("),
+            .get_unsafe = std.mem.count(u8, text, "list_get_unsafe"),
+            .folded = std.mem.count(u8, text, "tag v1 d1"),
+        };
+        if (std.c.getenv("RANGE_PROVE_DUMP") != null) std.debug.print("\n===== search proc =====\n{s}\n", .{text});
+        return;
+    }
+}
+
+const real_search =
+    "Match : { length : U64, offset : U64 }\n" ++
+    "ext : List(U8), U64, U64, U64, U64 -> U64\n" ++
+    "ext = |input, a, b, start_len, max_len| {\n" ++
+    "    var $len = start_len\n" ++
+    "    while $len < max_len and (List.get(input, a.plus_wrap($len)) ?? 0) == (List.get(input, b.plus_wrap($len)) ?? 1) {\n" ++
+    "        $len = $len + 1\n" ++
+    "    }\n" ++
+    "    $len\n" ++
+    "}\n" ++
+    "mi : U64, I16 -> U64\n" ++
+    "mi = |in_base, node| in_base.to_i64_wrap().plus_wrap(node.to_i64()).to_u64_wrap()\n" ++
+    "longest_match : List(I16), I16, I16, U64, List(U8), U64, U64, U64, U64, U64 -> Try(Match, [CompressBug])\n" ++
+    "longest_match = |next_tab, cur_node3, cur_node4, in_base, input, in_next, best_len_in, max_len, nice_len, max_search_depth| {\n" ++
+    "    if List.len(input) < 4 {\n" ++
+    "        return Err(CompressBug)\n" ++
+    "    } else {\n" ++
+    "    }\n" ++
+    "    # The chain table is one window long, so every masked chain index is in\n" ++
+    "    # range. Establishing that once here lets the bounds test on each chain\n" ++
+    "    # read fold away instead of running per candidate. The node is masked\n" ++
+    "    # before it is widened so the next read's address needs only the mask\n" ++
+    "    # on top of the load, which is the loop's critical path.\n" ++
+    "    if List.len(next_tab) < 32768 {\n" ++
+    "        return Err(CompressBug)\n" ++
+    "    } else {\n" ++
+    "    }\n" ++
+    "    cur_pos = in_next - in_base\n" ++
+    "    cutoff = cur_pos.to_i32_wrap() - 32768\n" ++
+    "\n" ++
+    "    var $best_len = best_len_in\n" ++
+    "    var $best_match_at = in_next\n" ++
+    "\n" ++
+    "    seq4 = U32.from_le_bytes(input, in_next) ?? 0\n" ++
+    "    var $node4 = cur_node4\n" ++
+    "    var $depth = max_search_depth\n" ++
+    "    var $done = 0.U64\n" ++
+    "\n" ++
+    "    if $best_len < 4 {\n" ++
+    "        if cur_node3.to_i32() <= cutoff {\n" ++
+    "            $done = 1\n" ++
+    "        } else {\n" ++
+    "            if $best_len < 3 {\n" ++
+    "                match_at = mi(in_base, cur_node3)\n" ++
+    "                if (U32.from_le_bytes(input, match_at) ?? 0).bitwise_and(0xFFFFFF)\n" ++
+    "                    == seq4.bitwise_and(0xFFFFFF) {\n" ++
+    "                    $best_len = 3\n" ++
+    "                    $best_match_at = match_at\n" ++
+    "                } else {\n" ++
+    "                }\n" ++
+    "            } else {\n" ++
+    "            }\n" ++
+    "\n" ++
+    "            if $node4.to_i32() <= cutoff {\n" ++
+    "                $done = 1\n" ++
+    "            } else {\n" ++
+    "                # Walk the chain until four bytes agree.\n" ++
+    "                var $found_at = 0.U64\n" ++
+    "                while True {\n" ++
+    "                    match_at = mi(in_base, $node4)\n" ++
+    "                    if (U32.from_le_bytes(input, match_at) ?? 0) == seq4 {\n" ++
+    "                        $found_at = match_at\n" ++
+    "                        break\n" ++
+    "                    } else {\n" ++
+    "                    }\n" ++
+    "                    $node4 = List.get(next_tab, $node4.bitwise_and(32767).to_u64_wrap()) ?? 0\n" ++
+    "                    $depth = $depth.minus_wrap(1)\n" ++
+    "                    if $node4.to_i32() <= cutoff or $depth == 0 {\n" ++
+    "                        $done = 1\n" ++
+    "                        break\n" ++
+    "                    } else {\n" ++
+    "                    }\n" ++
+    "                }\n" ++
+    "\n" ++
+    "                if $done == 0 {\n" ++
+    "                    $best_match_at = $found_at\n" ++
+    "                    $best_len = ext(input, in_next, $found_at, 4, max_len)\n" ++
+    "                    if $best_len >= nice_len {\n" ++
+    "                        $done = 1\n" ++
+    "                    } else {\n" ++
+    "                        $node4 = List.get(next_tab, $node4.bitwise_and(32767).to_u64_wrap()) ?? 0\n" ++
+    "                        $depth = $depth.minus_wrap(1)\n" ++
+    "                        if $node4.to_i32() <= cutoff or $depth == 0 {\n" ++
+    "                            $done = 1\n" ++
+    "                        } else {\n" ++
+    "                        }\n" ++
+    "                    }\n" ++
+    "                } else {\n" ++
+    "                }\n" ++
+    "            }\n" ++
+    "        }\n" ++
+    "    } else {\n" ++
+    "        if $node4.to_i32() <= cutoff or $best_len >= nice_len {\n" ++
+    "            $done = 1\n" ++
+    "        } else {\n" ++
+    "        }\n" ++
+    "    }\n" ++
+    "\n" ++
+    "    # Now look only for matches longer than the one in hand.\n" ++
+    "    while $done == 0 {\n" ++
+    "        var $cand_at = 0.U64\n" ++
+    "        while True {\n" ++
+    "            match_at = mi(in_base, $node4)\n" ++
+    "            # The four bytes ending just past the current best length\n" ++
+    "            # are what a longer match must agree on, so check them\n" ++
+    "            # before anything else.\n" ++
+    "            # Wrapping arithmetic: positions are far below 2^63, and a checked\n" ++
+    "            # add or subtract would put an overflow branch on every candidate.\n" ++
+    "            if (U32.from_le_bytes(input, match_at.plus_wrap($best_len).minus_wrap(3)) ?? 0)\n" ++
+    "                == (U32.from_le_bytes(input, in_next.plus_wrap($best_len).minus_wrap(3)) ?? 0)\n" ++
+    "                and (U32.from_le_bytes(input, match_at) ?? 0)\n" ++
+    "                    == (U32.from_le_bytes(input, in_next) ?? 0) {\n" ++
+    "                $cand_at = match_at\n" ++
+    "                break\n" ++
+    "            } else {\n" ++
+    "            }\n" ++
+    "            $node4 = List.get(next_tab, $node4.bitwise_and(32767).to_u64_wrap()) ?? 0\n" ++
+    "            $depth = $depth.minus_wrap(1)\n" ++
+    "            if $node4.to_i32() <= cutoff or $depth == 0 {\n" ++
+    "                $done = 1\n" ++
+    "                break\n" ++
+    "            } else {\n" ++
+    "            }\n" ++
+    "        }\n" ++
+    "\n" ++
+    "        if $done == 0 {\n" ++
+    "            len = ext(input, in_next, $cand_at, 4, max_len)\n" ++
+    "            if len > $best_len {\n" ++
+    "                $best_len = len\n" ++
+    "                $best_match_at = $cand_at\n" ++
+    "                if $best_len >= nice_len {\n" ++
+    "                    $done = 1\n" ++
+    "                } else {\n" ++
+    "                }\n" ++
+    "            } else {\n" ++
+    "            }\n" ++
+    "            if $done == 0 {\n" ++
+    "                $node4 = List.get(next_tab, $node4.bitwise_and(32767).to_u64_wrap()) ?? 0\n" ++
+    "                $depth = $depth.minus_wrap(1)\n" ++
+    "                if $node4.to_i32() <= cutoff or $depth == 0 {\n" ++
+    "                    $done = 1\n" ++
+    "                } else {\n" ++
+    "                }\n" ++
+    "            } else {\n" ++
+    "            }\n" ++
+    "        } else {\n" ++
+    "        }\n" ++
+    "    }\n" ++
+    "\n" ++
+    "    Ok({ length: $best_len, offset: in_next - $best_match_at })\n" ++
+    "}\n" ++
+    "\n" ++
+    "## Insert `count` positions into the tables without searching them.\n" ++
+    "\n" ++
+    "main! : List(Str) => Try({}, [Exit(I8), ..])\n" ++
+    "main! = |_args| {\n" ++
+    "    r = longest_match([], 1, 2, 0, Str.to_utf8(Str.join_with(_args, \",\")), 9, 3, 20, 16, 8) ?? { length: 0, offset: 0 }\n" ++
+    "    echo!(Str.inspect(r.length))\n" ++
+    "    Ok({})\n" ++
+    "}\n";
+
+// The hash-chain search of a lazy compressor: a first walk for a four-byte
+// match, then a restart loop that walks the chain for longer matches. The
+// loops lower to joins that jump among one another, so the chain table's
+// length guard reaches the later walks only through several persisted meets
+// across walk regions.
+test "the lazy matchfinder's search proves every chain read against its entry guard" {
+    try harness.expectLirInspectionWithOptions(
+        real_search,
+        .{ .inline_mode = .wrappers, .prove_ranges = true },
+        countSearchShape,
+    );
+    try std.testing.expect(search_shape.found);
+    try std.testing.expectEqual(@as(usize, 4), search_shape.get_unsafe);
+    // Only the two entry guards and the two loop conditions compare with
+    // `<`; every chain read's bounds test is proven away.
+    try std.testing.expectEqual(@as(usize, 4), search_shape.is_lt);
+}
+
 test "checked multiply is discharged from a masked range" {
     arithmetic_selection = .masked_mul;
     try harness.expectLirInspectionWithOptions(

--- a/src/compile/test/range_prove_test.zig
+++ b/src/compile/test/range_prove_test.zig
@@ -507,6 +507,130 @@ test "the lazy matchfinder's search proves every chain read against its entry gu
     try std.testing.expectEqual(@as(usize, 4), search_shape.is_lt);
 }
 
+const real_skip =
+    "State : { hash_tab : List(I16), in_cur_base : U64, next_hash : U64 }\n" ++
+    "required_nbytes : U64\n" ++
+    "required_nbytes = 5\n" ++
+    "table_size : U64\n" ++
+    "table_size = 65536\n" ++
+    "hash_order : U64\n" ++
+    "hash_order = 15\n" ++
+    "lz_hash : U32, U64 -> U64\n" ++
+    "lz_hash = |seq, num_bits|\n" ++
+    "    seq.times_wrap(0x1E35A7BD).shr_zf_wrap((32 - num_bits).to_u8_wrap()).to_u64()\n" ++
+    "rebase : List(I16) -> Try(List(I16), [CompressBug])\n" ++
+    "rebase = |table0| {\n" ++
+    "    var $table = table0\n" ++
+    "    n = List.len($table)\n" ++
+    "    var $i = 0.U64\n" ++
+    "    while $i < n {\n" ++
+    "        v = List.get($table, $i) ?? 0\n" ++
+    "        slid = (-32768).bitwise_or(v.bitwise_and(v.shr_wrap(15).bitwise_not()))\n" ++
+    "        $table = match List.set($table, $i, slid) {\n" ++
+    "            Ok(next) => next\n" ++
+    "            Err(_) => return Err(CompressBug)\n" ++
+    "        }\n" ++
+    "        $i = $i + 1\n" ++
+    "    }\n" ++
+    "    Ok($table)\n" ++
+    "}\n" ++
+    "skip_bytes : List(I16), U64, U64, List(U8), U64, U64, U64 -> Try(State, [CompressBug])\n" ++
+    "skip_bytes = |tab_0, base_0, hash_0, input, in_next0, in_end, count| {\n" ++
+    "    # The run ends at `end`, and every hash read the loop makes lies within\n" ++
+    "    # `required_nbytes` of it. Bounding the run against the input's length\n" ++
+    "    # here, and the bucket table's size once after any slide, lets the\n" ++
+    "    # range prover discharge the bounds test on every read and bucket\n" ++
+    "    # access in the loop, so each byte pays only for the work itself.\n" ++
+    "    end = in_next0 + count\n" ++
+    "    if end + required_nbytes > in_end {\n" ++
+    "        Ok({ hash_tab: tab_0, in_cur_base: base_0, next_hash: hash_0 })\n" ++
+    "    } else if in_end > List.len(input) {\n" ++
+    "        Err(CompressBug)\n" ++
+    "    } else {\n" ++
+    "        var $tab = tab_0\n" ++
+    "        var $base = base_0\n" ++
+    "        var $in_next = in_next0\n" ++
+    "        var $cur_pos = ($in_next - base_0).to_i64_wrap()\n" ++
+    "        # One slide covers the whole run, since it is bounded by a window.\n" ++
+    "        if $cur_pos + count.to_i64_wrap() - 1 >= 32768.to_i64_wrap() {\n" ++
+    "            $tab = rebase($tab)?\n" ++
+    "            $base = $base + 32768\n" ++
+    "            $cur_pos = $cur_pos - 32768.to_i64_wrap()\n" ++
+    "        } else {\n" ++
+    "        }\n" ++
+    "        if List.len($tab) < table_size {\n" ++
+    "            return Err(CompressBug)\n" ++
+    "        } else {\n" ++
+    "        }\n" ++
+    "\n" ++
+    "        var $hash = hash_0\n" ++
+    "        while $in_next < end {\n" ++
+    "            slot0 = $hash.bitwise_and(0x7FFF) * 2\n" ++
+    "            first = List.get($tab, slot0) ?? 0\n" ++
+    "            tab1 = match List.set($tab, slot0 + 1, first) {\n" ++
+    "                Ok(next) => next\n" ++
+    "                Err(_) => return Err(CompressBug)\n" ++
+    "            }\n" ++
+    "            $tab = match List.set(tab1, slot0, $cur_pos.to_i16_wrap()) {\n" ++
+    "                Ok(next) => next\n" ++
+    "                Err(_) => return Err(CompressBug)\n" ++
+    "            }\n" ++
+    "\n" ++
+    "            $in_next = $in_next + 1\n" ++
+    "            $hash = lz_hash(U32.from_le_bytes(input, $in_next) ?? 0, hash_order)\n" ++
+    "            $cur_pos = $cur_pos.plus_wrap(1)\n" ++
+    "        }\n" ++
+    "        Ok({ hash_tab: $tab, in_cur_base: $base, next_hash: $hash })\n" ++
+    "    }\n" ++
+    "}\n" ++
+    "\n" ++
+    "main! : List(Str) => Try({}, [Exit(I8), ..])\n" ++
+    "main! = |_args| {\n" ++
+    "    r = skip_bytes([], 0, 3, Str.to_utf8(Str.join_with(_args, \",\")), 1, 90, 8) ?? { hash_tab: [], in_cur_base: 0, next_hash: 0 }\n" ++
+    "    echo!(Str.inspect(r.next_hash))\n" ++
+    "    Ok({})\n" ++
+    "}\n";
+
+const SkipShape = struct { found: bool = false, is_gt: usize = 0, is_lt: usize = 0, folded: usize = 0 };
+var skip_shape: SkipShape = .{};
+
+fn countSkipShape(store: *const lir.LirStore, layouts: *const layout.Store) harness.LowerToLirHarnessError!void {
+    skip_shape = .{};
+    const gpa = std.testing.allocator;
+    const buf = try gpa.alloc(u8, 1 << 20);
+    defer gpa.free(buf);
+    for (0..store.getProcSpecs().len) |index| {
+        var writer = std.Io.Writer.fixed(buf);
+        try lir.DebugPrint.writeProc(gpa, store, layouts, @enumFromInt(@as(u32, @intCast(index))), &writer);
+        const text = writer.buffered();
+        if (std.mem.count(u8, text, "num_from_le_bytes_unchecked") == 0 or std.mem.count(u8, text, "list_set") == 0) continue;
+        skip_shape = .{
+            .found = true,
+            .is_gt = std.mem.count(u8, text, "num_is_gt("),
+            .is_lt = std.mem.count(u8, text, "num_is_lt("),
+            .folded = std.mem.count(u8, text, "tag v1 d1"),
+        };
+        if (std.c.getenv("RANGE_PROVE_DUMP") != null) std.debug.print("\n===== skip proc =====\n{s}\n", .{text});
+        return;
+    }
+}
+
+// The bucket matchfinder's insert run: a cursor loop whose entry guards bound
+// the run against the input and the bucket table against its size. Its
+// hash read and three bucket accesses per byte all prove from those guards.
+test "the bucket insert run proves every table access and hash read against its entry guards" {
+    try harness.expectLirInspectionWithOptions(
+        real_skip,
+        .{ .inline_mode = .wrappers, .prove_ranges = true },
+        countSkipShape,
+    );
+    try std.testing.expect(skip_shape.found);
+    // The two entry guards are the only `>` compares left; the loop
+    // conditions (the run's and the slide's) are the only `<` compares.
+    try std.testing.expectEqual(@as(usize, 2), skip_shape.is_gt);
+    try std.testing.expectEqual(@as(usize, 3), skip_shape.is_lt);
+}
+
 test "checked multiply is discharged from a masked range" {
     arithmetic_selection = .masked_mul;
     try harness.expectLirInspectionWithOptions(

--- a/src/lir/range_prove.zig
+++ b/src/lir/range_prove.zig
@@ -75,7 +75,10 @@ pub const ResourceError = Allocator.Error;
 
 /// Bound on proof rounds per proc. Each round can only fold branches that
 /// exist, so rounds converge; this bound is a backstop, not a tuning knob.
-const max_rounds: u32 = 12;
+/// A loop lowered as several joins that jump among one another (a search
+/// with a restart state, say) carries a persisted fact one join further per
+/// round, so the backstop must cover a chain of a couple of dozen joins.
+const max_rounds: u32 = 48;
 /// Bound on collected facts along one path.
 const max_facts: usize = 512;
 /// Bound on symbolic value nodes per proc round.
@@ -316,14 +319,20 @@ const merge_env_cap: usize = 64;
 const MergeState = struct {
     captures: u32,
     facts: std.ArrayList(Fact),
+    /// The all-edge meet of the facts in round-stable form, for persisting
+    /// across rounds; `facts` keeps the raw meet for in-round seeding, which
+    /// only helps when the edges share the head's region and its node ids.
+    stable: LoopFacts,
     env: std.ArrayList(EnvMeet),
     /// Facts held by every captured edge arriving from OUTSIDE the merge
-    /// head's own region. For a loop join these are its entry edges; a fact
-    /// between round-stable single-assignment values that holds on entry is
-    /// a loop invariant outright, because nothing in the loop can reassign
-    /// the values it relates.
+    /// head's own region, in round-stable form. For a loop join these are
+    /// its entry edges; a fact between round-stable single-assignment values
+    /// that holds on entry is a loop invariant outright, because nothing in
+    /// the loop can reassign the values it relates. Entry edges may arrive
+    /// from different walk regions, whose nodes for the same value differ,
+    /// so the meet is taken on what the nodes denote rather than on node ids.
     entry_captures: u32,
-    entry_facts: std.ArrayList(Fact),
+    entry_stable: LoopFacts,
 };
 
 /// One endpoint of a cross-round persisted fact, in round-stable form.
@@ -1065,7 +1074,6 @@ const Pass = struct {
         while (it.next()) |state| {
             state.facts.deinit(self.allocator);
             state.env.deinit(self.allocator);
-            state.entry_facts.deinit(self.allocator);
         }
         self.merge_states.clearRetainingCapacity();
     }
@@ -1186,28 +1194,44 @@ const Pass = struct {
     fn captureMergeEdge(self: *Pass, head: CFStmtId) ResourceError!void {
         const entry = try self.merge_states.getOrPut(head);
         if (!entry.found_existing) {
-            entry.value_ptr.* = .{ .captures = 0, .facts = .empty, .env = .empty, .entry_captures = 0, .entry_facts = .empty };
+            entry.value_ptr.* = .{ .captures = 0, .facts = .empty, .stable = .{}, .env = .empty, .entry_captures = 0, .entry_stable = .{} };
         }
         const state = entry.value_ptr;
 
         // An edge arriving from outside the loop is an entry edge; its facts
         // meet separately so loop-invariant relations survive the back
         // edge's inability to derive them before its region is seeded.
+        const mine_stable = self.stabilizeFacts(self.facts.items);
+        if (state.captures == 0) {
+            state.stable = mine_stable;
+        } else {
+            var keep_stable: usize = 0;
+            for (state.stable.items[0..state.stable.len]) |fact| {
+                for (mine_stable.items[0..mine_stable.len]) |candidate| {
+                    if (std.meta.eql(fact, candidate)) {
+                        state.stable.items[keep_stable] = fact;
+                        keep_stable += 1;
+                        break;
+                    }
+                }
+            }
+            state.stable.len = keep_stable;
+        }
         if (self.edgeEntersLoop(head)) {
             if (state.entry_captures == 0) {
-                try state.entry_facts.appendSlice(self.allocator, self.facts.items);
+                state.entry_stable = mine_stable;
             } else {
                 var keep_entry: usize = 0;
-                for (state.entry_facts.items) |fact| {
-                    for (self.facts.items) |mine| {
-                        if (mine.a == fact.a and mine.b == fact.b and mine.c == fact.c) {
-                            state.entry_facts.items[keep_entry] = fact;
+                for (state.entry_stable.items[0..state.entry_stable.len]) |fact| {
+                    for (mine_stable.items[0..mine_stable.len]) |candidate| {
+                        if (std.meta.eql(fact, candidate)) {
+                            state.entry_stable.items[keep_entry] = fact;
                             keep_entry += 1;
                             break;
                         }
                     }
                 }
-                state.entry_facts.shrinkRetainingCapacity(keep_entry);
+                state.entry_stable.len = keep_entry;
             }
             state.entry_captures += 1;
         }
@@ -1365,7 +1389,11 @@ const Pass = struct {
             return;
         }
 
+        // The raw meet carries node ids, which only mean something for edges
+        // captured in the head's own region; the stable meet is what edges
+        // from other regions agree on.
         try self.facts.appendSlice(self.allocator, state.facts.items);
+        try self.seedStableFacts(&state.stable);
 
         for (state.env.items) |meet| {
             if (meet.valid) {
@@ -1477,7 +1505,7 @@ const Pass = struct {
     /// every entry edge makes it hold throughout the loop.
     fn persistLoopFacts(self: *Pass, join_id: JoinPointId, state: *const MergeState) ResourceError!void {
         if (state.entry_captures == 0) return;
-        const stable = self.stabilizeFacts(state.entry_facts.items);
+        const stable = state.entry_stable;
         if (stable.len == 0) return;
         const previous = self.loop_facts.get(join_id);
         if (previous == null or previous.?.len != stable.len) self.new_loop_bounds = true;
@@ -1488,14 +1516,7 @@ const Pass = struct {
     /// materialized against this round's nodes.
     fn seedLoopFacts(self: *Pass, join_id: JoinPointId) ResourceError!void {
         const stored = self.loop_facts.get(join_id) orelse return;
-        for (stored.items[0..stored.len]) |fact| {
-            const a = (try self.materializeTerm(fact.a)) orelse continue;
-            const b = (try self.materializeTerm(fact.b)) orelse continue;
-            // The persisted relation is between values; restated on roots:
-            // root_a <= value_a - off_lo_a and value_b <= root_b + off_hi_b.
-            const c = fact.c + self.offHiOf(b) - self.offLoOf(a);
-            try self.addFact(.{ .a = self.rootOf(a), .b = self.rootOf(b), .c = c, .origin = .meet });
-        }
+        try self.seedStableFacts(&stored);
     }
 
     /// This round's node for a stable term: the local's value, the list
@@ -1527,7 +1548,16 @@ const Pass = struct {
             const a = self.stabilizeTerm(fact.a) orelse continue;
             const b = self.stabilizeTerm(fact.b) orelse continue;
             if (a == .constant and b == .constant) continue;
-            stable.items[stable.len] = .{ .a = a, .b = b, .c = fact.c };
+            const candidate = StableFact{ .a = a, .b = b, .c = fact.c };
+            var known = false;
+            for (stable.items[0..stable.len]) |have| {
+                if (std.meta.eql(have, candidate)) {
+                    known = true;
+                    break;
+                }
+            }
+            if (known) continue;
+            stable.items[stable.len] = candidate;
             stable.len += 1;
         }
         return stable;
@@ -1536,7 +1566,7 @@ const Pass = struct {
     /// Persist a fully-captured merge's all-edge fact intersection for
     /// seeding when a later round must walk it before capture completes.
     fn persistMergeFacts(self: *Pass, head: CFStmtId, state: *const MergeState) ResourceError!void {
-        const stable = self.stabilizeFacts(state.facts.items);
+        const stable = state.stable;
         if (stable.len == 0) return;
         if (self.merge_facts.get(head)) |previous| {
             if (previous.len != stable.len) {
@@ -1555,6 +1585,14 @@ const Pass = struct {
     /// every edge carried last round.
     fn seedMergeFacts(self: *Pass, head: CFStmtId) ResourceError!void {
         const stored = self.merge_facts.get(head) orelse return;
+        try self.seedStableFacts(&stored);
+    }
+
+    /// Add round-stable facts to the current path, materialized against
+    /// this round's nodes. The persisted relation is between values;
+    /// restated on roots: root_a <= value_a - off_lo_a and
+    /// value_b <= root_b + off_hi_b.
+    fn seedStableFacts(self: *Pass, stored: *const LoopFacts) ResourceError!void {
         for (stored.items[0..stored.len]) |fact| {
             const a = (try self.materializeTerm(fact.a)) orelse continue;
             const b = (try self.materializeTerm(fact.b)) orelse continue;
@@ -2708,7 +2746,12 @@ const Pass = struct {
             .f64_literal, .f32_literal, .dec_literal, .str_literal, .static_data, .bytes_literal, .null_ptr, .proc_ref, .boxy_dynamic_num_literal, .boxy_dynamic_frac_literal => null,
         };
         if (literal) |v| {
-            if (trackedIntMax(self.localLayout(target)) != null) {
+            // A non-negative literal is the same number whatever its type,
+            // so a signed literal binds too: as a mask it bounds a masked
+            // signed value, which the wrap rules can then carry into the
+            // unsigned world.
+            const layout_idx = self.localLayout(target);
+            if (trackedIntMax(layout_idx) != null or isSignedInt(layout_idx)) {
                 if (try self.constNode(v)) |node| {
                     try self.bind(target, .{ .node = node });
                     return;
@@ -2716,6 +2759,14 @@ const Pass = struct {
             }
         }
         try self.bindFresh(target);
+    }
+
+    fn isSignedInt(layout_idx: layout_mod.Idx) bool {
+        return switch (layout_idx) {
+            .i8, .i16, .i32, .i64, .i128 => true,
+            .u8, .u16, .u32, .u64, .u128, .bool, .str, .f32, .f64, .dec, .opaque_ptr, .zst, .u8x16, .i8x16, .u16x8, .i16x8, .u32x4, .i32x4, .u64x2, .i64x2 => false,
+            _ => false,
+        };
     }
 
     fn modelLowLevel(self: *Pass, stmt: CFStmtId, s: anytype) ResourceError!void {
@@ -2788,6 +2839,25 @@ const Pass = struct {
                 }
                 try self.bindFresh(s.target);
             },
+            .i8_to_u8_wrap, .i8_to_u16_wrap, .i8_to_u32_wrap, .i8_to_u64_wrap, .i16_to_u8_wrap, .i16_to_u16_wrap, .i16_to_u32_wrap, .i16_to_u64_wrap, .i32_to_u8_wrap, .i32_to_u16_wrap, .i32_to_u32_wrap, .i32_to_u64_wrap, .i64_to_u8_wrap, .i64_to_u16_wrap, .i64_to_u32_wrap, .i64_to_u64_wrap => {
+                // A signed value the path proves non-negative and in range
+                // (a masked table node, say) is the same number afterwards.
+                // Signed values are otherwise untracked, so the argument's
+                // range is only ever narrower than its type when a rule here
+                // established it.
+                if (arg_count == 1) {
+                    if (try self.valueOf(GuardedList.at(args, 0))) |node_id| {
+                        const node = self.nodes.items[node_id];
+                        const root = self.nodes.items[node.root];
+                        const max = trackedIntMax(self.localLayout(s.target));
+                        if (max != null and root.lo + node.off_lo >= 0 and root.hi + node.off_hi <= max.?) {
+                            try self.bind(s.target, .{ .node = node_id });
+                            return;
+                        }
+                    }
+                }
+                try self.bindFresh(s.target);
+            },
             .u16_to_u8_wrap, .u32_to_u8_wrap, .u32_to_u16_wrap, .u64_to_u8_wrap, .u64_to_u16_wrap, .u64_to_u32_wrap, .u128_to_u8_wrap, .u128_to_u16_wrap, .u128_to_u32_wrap, .u128_to_u64_wrap => {
                 // A narrowing that provably cannot wrap leaves the number
                 // alone as well: a shift amount computed from literals, say,
@@ -2852,6 +2922,10 @@ const Pass = struct {
                     // index masked by a runtime table size, say).
                     if (arg_count == 2) {
                         for (0..2) |i| {
+                            // A signed operand can be negative, where the
+                            // result exceeds it; only unsigned operands bound
+                            // the result.
+                            if (trackedIntMax(self.localLayout(GuardedList.at(args, i))) == null) continue;
                             if (try self.valueOf(GuardedList.at(args, i))) |operand| {
                                 const fact = Fact{
                                     .a = node,
@@ -3131,13 +3205,9 @@ const Pass = struct {
             .u8_to_f64,
             .u8_to_dec,
             .i8_to_i128,
-            .i8_to_u8_wrap,
             .i8_to_u8_try,
-            .i8_to_u16_wrap,
             .i8_to_u16_try,
-            .i8_to_u32_wrap,
             .i8_to_u32_try,
-            .i8_to_u64_wrap,
             .i8_to_u64_try,
             .i8_to_u128_wrap,
             .i8_to_u128_try,
@@ -3157,13 +3227,9 @@ const Pass = struct {
             .i16_to_i8_wrap,
             .i16_to_i8_try,
             .i16_to_i128,
-            .i16_to_u8_wrap,
             .i16_to_u8_try,
-            .i16_to_u16_wrap,
             .i16_to_u16_try,
-            .i16_to_u32_wrap,
             .i16_to_u32_try,
-            .i16_to_u64_wrap,
             .i16_to_u64_try,
             .i16_to_u128_wrap,
             .i16_to_u128_try,
@@ -3188,13 +3254,9 @@ const Pass = struct {
             .i32_to_i16_wrap,
             .i32_to_i16_try,
             .i32_to_i128,
-            .i32_to_u8_wrap,
             .i32_to_u8_try,
-            .i32_to_u16_wrap,
             .i32_to_u16_try,
-            .i32_to_u32_wrap,
             .i32_to_u32_try,
-            .i32_to_u64_wrap,
             .i32_to_u64_try,
             .i32_to_u128_wrap,
             .i32_to_u128_try,
@@ -3224,13 +3286,9 @@ const Pass = struct {
             .i64_to_i32_wrap,
             .i64_to_i32_try,
             .i64_to_i128,
-            .i64_to_u8_wrap,
             .i64_to_u8_try,
-            .i64_to_u16_wrap,
             .i64_to_u16_try,
-            .i64_to_u32_wrap,
             .i64_to_u32_try,
-            .i64_to_u64_wrap,
             .i64_to_u64_try,
             .i64_to_u128_wrap,
             .i64_to_u128_try,

--- a/src/lir/range_prove.zig
+++ b/src/lir/range_prove.zig
@@ -392,6 +392,10 @@ const Pass = struct {
     undo: std.ArrayList(Undo),
     len_terms: collections.DenseMap(NodeId, NodeId),
     assign_counts: collections.DenseMap(LocalId, u32),
+    /// Source local of every `ref.local` alias, so a stable term can name
+    /// the value a chain of single-assignment aliases denotes rather than
+    /// whichever alias first computed it.
+    alias_of: collections.DenseMap(LocalId, LocalId),
     pred_counts: collections.DenseMap(CFStmtId, u32),
     jump_counts: collections.DenseMap(JoinPointId, u32),
     join_stmts: collections.DenseMap(JoinPointId, CFStmtId),
@@ -468,6 +472,7 @@ const Pass = struct {
             .undo = .empty,
             .len_terms = collections.DenseMap(NodeId, NodeId).init(allocator),
             .assign_counts = collections.DenseMap(LocalId, u32).init(allocator),
+            .alias_of = collections.DenseMap(LocalId, LocalId).init(allocator),
             .pred_counts = collections.DenseMap(CFStmtId, u32).init(allocator),
             .jump_counts = collections.DenseMap(JoinPointId, u32).init(allocator),
             .join_stmts = collections.DenseMap(JoinPointId, CFStmtId).init(allocator),
@@ -513,6 +518,7 @@ const Pass = struct {
         self.undo.deinit(self.allocator);
         self.len_terms.deinit();
         self.assign_counts.deinit();
+        self.alias_of.deinit();
         self.pred_counts.deinit();
         self.jump_counts.deinit();
         self.join_stmts.deinit();
@@ -554,6 +560,7 @@ const Pass = struct {
         self.undo.clearRetainingCapacity();
         self.len_terms.clearRetainingCapacity();
         self.assign_counts.clearRetainingCapacity();
+        self.alias_of.clearRetainingCapacity();
         self.pred_counts.clearRetainingCapacity();
         self.jump_counts.clearRetainingCapacity();
         self.join_stmts.clearRetainingCapacity();
@@ -786,6 +793,20 @@ const Pass = struct {
         return (self.assign_counts.get(local) orelse 0) <= 1;
     }
 
+    /// The local a chain of single-assignment aliases denotes: lowering
+    /// binds one alias per use, so the same value is read through a
+    /// different local each time, and a stable term keyed by the alias
+    /// would never meet itself again.
+    fn stableLocalOf(self: *const Pass, local: LocalId) LocalId {
+        var current = local;
+        while (self.isSingleAssign(current)) {
+            const source = self.alias_of.get(current) orelse break;
+            if (!self.isSingleAssign(source)) break;
+            current = source;
+        }
+        return current;
+    }
+
     fn lookup(self: *const Pass, local: LocalId) ?Binding {
         if (self.isSingleAssign(local)) return self.global_env.get(local);
         return self.path_env.get(local);
@@ -793,6 +814,15 @@ const Pass = struct {
 
     fn bind(self: *Pass, local: LocalId, binding: Binding) ResourceError!void {
         if (self.isSingleAssign(local)) {
+            // A single-assignment integer local bound to a root names that
+            // root's value in round-stable form, wherever the root came
+            // from: a sum of two unrelated values or an unproven checked
+            // operation gets a fresh root just as an unbound read does, and
+            // facts about it must persist the same way.
+            if (trackedIntMax(self.localLayout(local)) != null and self.rootOf(binding.node) == binding.node) {
+                const entry = try self.value_roots.getOrPut(binding.node);
+                if (!entry.found_existing) entry.value_ptr.* = self.stableLocalOf(local);
+            }
             try self.global_env.put(local, binding);
             return;
         }
@@ -816,7 +846,7 @@ const Pass = struct {
         // fresh root for the whole round, so the root denotes the local's
         // value in round-stable form.
         if (trackedIntMax(self.localLayout(local)) != null and self.isSingleAssign(local)) {
-            try self.value_roots.put(node, local);
+            try self.value_roots.put(node, self.stableLocalOf(local));
         }
         try self.bind(local, .{ .node = node });
         return node;
@@ -827,7 +857,7 @@ const Pass = struct {
         // As in valueOf: a single-assignment integer local's fresh root
         // denotes its value in round-stable form.
         if (trackedIntMax(self.localLayout(local)) != null and self.isSingleAssign(local)) {
-            try self.value_roots.put(node, local);
+            try self.value_roots.put(node, self.stableLocalOf(local));
         }
         try self.bind(local, .{ .node = node });
     }
@@ -844,7 +874,7 @@ const Pass = struct {
         const node = (try self.unknownFor(self.localLayout(target))) orelse return self.bindFresh(target);
         try self.field_values.put(key, node);
         if (trackedIntMax(self.localLayout(target)) != null and self.isSingleAssign(target)) {
-            try self.value_roots.put(node, target);
+            try self.value_roots.put(node, self.stableLocalOf(target));
         }
         try self.bind(target, .{ .node = node });
     }
@@ -889,6 +919,7 @@ const Pass = struct {
                 },
                 .assign_ref => |s| {
                     try self.bumpAssign(s.target);
+                    if (s.op == .local) try self.alias_of.put(s.target, s.op.local);
                     try self.edgeTo(s.next);
                 },
                 .assign_literal => |s| {
@@ -1531,7 +1562,7 @@ const Pass = struct {
                 const fresh = (try self.freshRoot(0, std.math.maxInt(i64))) orelse return null;
                 try self.len_terms.put(root, fresh);
                 if (self.isSingleAssign(list_local)) {
-                    try self.len_roots.put(fresh, list_local);
+                    try self.len_roots.put(fresh, self.stableLocalOf(list_local));
                 }
                 return fresh;
             },
@@ -1809,7 +1840,7 @@ const Pass = struct {
                     const len_node = self.len_terms.get(root) orelse blk: {
                         const fresh = (try self.freshRoot(0, std.math.maxInt(i64))) orelse continue;
                         try self.len_terms.put(root, fresh);
-                        try self.len_roots.put(fresh, list_local);
+                        try self.len_roots.put(fresh, self.stableLocalOf(list_local));
                         break :blk fresh;
                     };
                     try self.addFact(.{ .a = node, .b = len_node, .c = bound.c, .origin = .meet });
@@ -1846,7 +1877,7 @@ const Pass = struct {
                         const fresh = (try self.freshRoot(0, std.math.maxInt(i64))) orelse break :blk null;
                         try self.len_terms.put(root, fresh);
                         if (self.isSingleAssign(list_local)) {
-                            try self.len_roots.put(fresh, list_local);
+                            try self.len_roots.put(fresh, self.stableLocalOf(list_local));
                         }
                         break :inner fresh;
                     };
@@ -2808,7 +2839,7 @@ const Pass = struct {
                         if (try self.freshRoot(0, std.math.maxInt(i64))) |len_node| {
                             try self.len_terms.put(root, len_node);
                             if (self.isSingleAssign(list_local)) {
-                                try self.len_roots.put(len_node, list_local);
+                                try self.len_roots.put(len_node, self.stableLocalOf(list_local));
                             }
                             try self.bind(s.target, .{ .node = len_node });
                             return;


### PR DESCRIPTION
The range prover's persisted facts were keyed by node id and by whichever alias local first computed a value, so a guard established before a loop often never reached the reads inside it. Two cases from roc-deflate show the gap: a length guard placed before the lazy matchfinder's search loop did not reach the loop nested after a preceding chain walk, because edges arriving from different walk regions hold different nodes for the same value; and a guard on `List.len(input)` before the bucket matchfinder's insert run never matched the reads inside it, because lowering binds one alias per use and the read named the same list through a different alias.

Loop-entry and merge meets now happen in the round-stable form that persistence already used, stable terms name the local a chain of single-assignment aliases denotes, and a single-assignment local bound to a fresh root registers that root as its stable value however the root came to be, so facts about sums and unproven checked operations can persist into loops too. A search lowered as several mutually jumping joins carries such a fact one join further per round, so the round backstop rises to cover a chain of a couple of dozen joins. Two smaller rules come from the same investigation: a non-negative literal of a signed type binds as a constant, and a signed-to-unsigned wrap of a value proven non-negative and in range keeps the value.

Two tests port the lazy matchfinder's search and the bucket matchfinder's insert run and check that every access in their loops proves against the entry guards. On roc-deflate the insert-run fold is what makes level 1 check-free per byte.
