### PR TITLE
Preserve hosted return descriptors during Boxy lowering

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -177,6 +177,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11236_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11249_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11263_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11286_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11286_test.zig
+++ b/src/compile/test/issue_11286_test.zig
@@ -1,0 +1,69 @@
+//! Regression test for issue #11286.
+
+const std = @import("std");
+const base = @import("base");
+const harness = @import("lower_to_lir_harness.zig");
+
+// repro for https://github.com/roc-lang/roc/issues/11286
+//
+// `Echo.line!` is hosted at the closed error row `[EchoErr(Str)]`, and `?`
+// widens that row at the use site into `main!`'s open row (design.md "Hosted
+// Try Question Widening"). Boxy lowers the hosted worker at the widened row
+// while the host boundary keeps the declared closed row, so the worker return
+// and the hosted call result are two values governed by different descriptors
+// even though they share a storage layout. Lowering must keep them apart.
+const app_source =
+    \\app [main!] { pf: platform "./platform.roc" }
+    \\
+    \\import pf.Echo
+    \\
+    \\main! : List(Str) => Try({}, [Exit(I8), EchoErr(Str), ..])
+    \\main! = |_args| {
+    \\    greeting = Echo.line!("hello")?
+    \\    if Str.is_empty(greeting) Err(Exit(1)) else Ok({})
+    \\}
+;
+
+const platform_source =
+    \\platform ""
+    \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
+    \\    exposes [Echo]
+    \\    packages {}
+    \\    provides { "roc_main": main_for_host! }
+    \\    hosted { "roc_echo_line": Echo.line! }
+    \\
+    \\import Echo
+    \\
+    \\main_for_host! : List(Str) => I8
+    \\main_for_host! = |args| match main!(args) {
+    \\    Ok({}) => 0
+    \\    Err(Exit(code)) => code
+    \\    Err(_) => 1
+    \\}
+;
+
+const echo_source =
+    \\Echo := [].{
+    \\    line! : Str => Try(Str, [EchoErr(Str)])
+    \\}
+;
+
+test "issue 11286: a widened hosted Try result keeps its own boxy descriptor" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "app.roc", .data = app_source });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "platform.roc", .data = platform_source });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "Echo.roc", .data = echo_source });
+
+    const app_path = try tmp_dir.dir.realPathFileAlloc(io, "app.roc", gpa);
+    defer gpa.free(app_path);
+
+    for ([_]base.SpecializationStrategy{ .lss, .boxy }) |strategy| {
+        try harness.expectAppPathLowersToLirWithOptions(app_path, .{
+            .specialization_strategy = strategy,
+        });
+    }
+}

--- a/src/postcheck/boxy/lower.zig
+++ b/src/postcheck/boxy/lower.zig
@@ -11173,11 +11173,22 @@ const ProcedureBuilder = struct {
         }
 
         const host_ret_layout = proc.hostRuntimeLayoutForRep(host_function.ret);
-        const ret_layout = self.result.store.getLocal(ret_local).layout_idx;
-        const host_ret_local = if (host_ret_layout.layoutIdx() == ret_layout)
+        const host_result_desc = try proc.descriptorRefForRepIfNeeded(host_function.ret);
+        const worker_ret = self.result.store.getLocal(ret_local);
+        // Equal layouts can still describe different hosted and worker error
+        // rows. Reuse requires the same descriptor as well; otherwise the
+        // representation boundary must convert between distinct value locals.
+        const host_ret_local = if (host_ret_layout.layoutIdx() == worker_ret.layout_idx and
+            std.meta.eql(worker_ret.boxy_desc, host_result_desc))
             ret_local
         else
-            try proc.addFrameLocalForRuntimeRep(host_ret_layout, host_function.ret);
+            try proc.addFrameLocal(host_ret_layout.layoutIdx());
+        // The hosted call produces this exact descriptor. Generic frame-local
+        // allocation can reserve a runtime descriptor for nested dynamic data,
+        // which would conflict with the call's descriptor even on a fresh local.
+        if (host_result_desc) |desc| {
+            self.result.store.setLocalBoxyDesc(host_ret_local, desc);
+        }
 
         var continuation = ret_stmt;
         if (host_ret_local != ret_local) {
@@ -11189,11 +11200,6 @@ const ProcedureBuilder = struct {
                 continuation,
             );
         }
-        const host_result_desc = try proc.descriptorRefForRepIfNeeded(host_function.ret);
-        if (host_result_desc) |desc| {
-            self.result.store.setLocalBoxyDesc(host_ret_local, desc);
-        }
-
         continuation = try self.result.store.addCFStmt(.{ .assign_call = .{
             .target = host_ret_local,
             .proc = try self.emitHostedExternalProc(proc.worker_layout.worker, resolved),


### PR DESCRIPTION
When a hosted `Try` result is widened by `?`, Boxy lowering could reuse a return local with the same layout but a different descriptor, causing an invariant panic. Reuse now requires matching layouts and descriptors; otherwise, the hosted result gets its exact descriptor in a separate local before conversion to the worker representation.

Closes #11286.
