### PR TITLE
Fix symbolic method evidence forwarding

### DIFF
--- a/design.md
+++ b/design.md
@@ -9049,8 +9049,12 @@ does not mutate checked data or create a second name registry.
 When an edge uses a procedure as data, an otherwise-unpinned requirement that
 is reachable through the procedure's own callable type is not
 `unreachable`. Checker output records `from_callable(k)` at that construction
-site, where `k` is the requirement's template evidence-param index and its
-evidence-param record owns the exact dispatcher path. If compile-time
+site, where `k` is the containing vector slot, whose evidence-param record owns
+the exact dispatcher path. Symbolic entries carry no separate index: forwarding
+into another scheme makes the destination slot authoritative, even when the two
+schemes enumerate requirements in different orders. Live and stored evidence,
+serialization, and specialization identity all preserve this slot-relative
+meaning and the independent-callable flag. If compile-time
 evaluation stores that function inside another value before the callable is
 concrete, `ConstStore` retains the same symbolic entry in the function's
 evidence vector. Restoring the function projects the recorded path over the
@@ -9059,7 +9063,9 @@ uses the resolved vector as the specialization identity. This work is linear
 only in the function's evidence vector at a specialization request; the
 existing specialization cache prevents duplicate function bodies. Aggregate
 restoration neither scans nested values nor reconstructs where a function came
-from.
+from. Resolution borrows immutable evidence until an entry resolves, then copies
+the vector once for that request. An unchanged vector is returned directly.
+Unresolved results are not memoized across instantiation-graph refinement.
 
 **The default rule.** A constrained var no edge can pin follows exactly the
 rule Monotype uses to materialize unresolved variables: numeral literals and

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -31334,7 +31334,9 @@ pub const CheckedModuleArtifact = struct {
     // Version 93 distinguishes rejected function values from callable templates.
     // Version 94 retains explicit equality guards and matched-value binders
     // for custom literal patterns.
-    const serialized_layout_version: u32 = 94;
+    // Version 95 removes the redundant source-scheme index from stored
+    // callable-derived function evidence; its vector slot owns the requirement.
+    const serialized_layout_version: u32 = 95;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -37900,8 +37902,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0xD7, 0x46, 0xCF, 0x78, 0xBA, 0x30, 0x9B, 0x80, 0xAE, 0xC6, 0x91, 0x50, 0x5F, 0xB2, 0xD7, 0x53,
-        0xDC, 0x7B, 0xEF, 0x6D, 0x06, 0x6C, 0x66, 0x30, 0xD7, 0xF4, 0x5D, 0x5D, 0x06, 0x0C, 0x7F, 0x87,
+        0x17, 0xC0, 0xDF, 0xF1, 0xE9, 0xDA, 0x5A, 0x3F, 0xB8, 0x10, 0x4B, 0x58, 0x33, 0xBF, 0x14, 0xA2,
+        0xA5, 0xA6, 0x52, 0x90, 0x6E, 0x9B, 0xB6, 0x69, 0x6B, 0x9B, 0x96, 0x39, 0x07, 0x3C, 0xA4, 0x49,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -289,9 +289,9 @@ pub const ConstFnEvidence = union(enum(u8)) {
     },
     structural: ConstFnStructuralEvidence,
     /// A callable-reachable requirement that must be resolved from the
-    /// concrete function type when this stored function is restored.
+    /// concrete function type when this stored function is restored. The slot
+    /// within its owning evidence vector supplies the checked requirement path.
     from_callable: struct {
-        index: u32,
         independent_callable: bool = false,
     },
     /// Abstract local scheme parameter, supplied by the checked use edge.
@@ -1271,7 +1271,7 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
         } },
         .{ .structural = .{ .derivation = .equality } },
         .checked_error,
-        .{ .from_callable = .{ .index = 2, .independent_callable = true } },
+        .{ .from_callable = .{ .independent_callable = true } },
         .{ .from_scheme = 3 },
     };
     const evidence_frames = [_]ConstFnEvidenceFrame{
@@ -1346,7 +1346,7 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     try std.testing.expectEqual(@as(u32, 1), loaded_nested.subtree_len);
     try std.testing.expectEqual(ConstFnEvidence{ .structural = .{ .derivation = .equality } }, loaded_fn.evidence[1]);
     try std.testing.expectEqual(ConstFnEvidence.checked_error, loaded_fn.evidence[2]);
-    try std.testing.expectEqual(ConstFnEvidence{ .from_callable = .{ .index = 2, .independent_callable = true } }, loaded_fn.evidence[3]);
+    try std.testing.expectEqual(ConstFnEvidence{ .from_callable = .{ .independent_callable = true } }, loaded_fn.evidence[3]);
     try std.testing.expectEqual(ConstFnEvidence{ .from_scheme = 3 }, loaded_fn.evidence[4]);
     try std.testing.expectEqualSlices(ConstFnEvidenceFrame, &evidence_frames, loaded_fn.evidence_frames);
     try std.testing.expectEqual(@as(?u32, 1), loaded_fn.evidence_frame_head);

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -177,6 +177,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11236_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11249_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11263_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11301_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11301_test.zig
+++ b/src/compile/test/issue_11301_test.zig
@@ -1,0 +1,53 @@
+//! Regression tests for issue #11301: forwarding an Err-only closure through
+//! records permutes the enclosing functions' symbolic method requirements.
+
+const harness = @import("lower_to_lir_harness.zig");
+const std = @import("std");
+const postcheck = @import("postcheck");
+
+const hooks_app_body =
+    \\main! : List(Str) => Try({}, _)
+    \\main! = |_args|
+    \\    outer({
+    \\        run: || Err(CommandNotFound),
+    \\        get: |_name| "x",
+    \\    }).map_err(|_| Exit(1))
+    \\
+    \\outer = |hooks| {
+    \\    _ = hooks.get
+    \\    middle(hooks)
+    \\}
+    \\
+    \\middle = |hooks| {
+    \\    get = hooks.get
+    \\    _ = get("name")
+    \\    inner(hooks)
+    \\}
+    \\
+    \\inner = |hooks| {
+    \\    run = hooks.run
+    \\    output = run()?
+    \\    _ = output.trim()
+    \\    Ok({})
+    \\}
+;
+
+test "issue 11301: a method call pinning a forwarded Err-only closure's Ok payload lowers to Monotype" {
+    try harness.expectLowersToLirWithOptions(hooks_app_body, .{ .monotype_only = true });
+}
+
+test "issue 11301: a method call pinning a forwarded Err-only closure's Ok payload lowers to LIR" {
+    try harness.expectLowersToLir(hooks_app_body);
+}
+
+test "issue 11301: unresolved callable evidence reuses its immutable vector" {
+    var diagnostics: postcheck.Monotype.Lower.Diagnostics = .{};
+    try harness.expectLowersToLirWithOptions(hooks_app_body, .{
+        .monotype_only = true,
+        .monotype_diagnostics_out = &diagnostics,
+    });
+    // The Err-only payload stays open across repeated interface requests.
+    // Those requests must not each allocate another identical evidence vector.
+    try std.testing.expect(diagnostics.body.callable_evidence_symbolic_requests >
+        diagnostics.body.callable_evidence_vector_copies);
+}

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -249,6 +249,34 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "Err(Wrapped(B(\"propagated\")))" },
     },
     .{
+        .name = "issue 11301: stored record callables forward evidence through nested scopes independently",
+        .source_kind = .module,
+        .source =
+        \\stored = { invoke: outer }
+        \\outer = |hooks| {
+        \\    _ = hooks.get
+        \\    forward = |next| middle(next)
+        \\    forward(hooks)
+        \\}
+        \\middle = |hooks| {
+        \\    get = hooks.get
+        \\    _ = get("name")
+        \\    inner(hooks)
+        \\}
+        \\inner = |hooks| {
+        \\    run = hooks.run
+        \\    output = run()?
+        \\    _ = output.trim()
+        \\    Ok({})
+        \\}
+        \\main = (
+        \\    (stored.invoke)({ run: || Err(CommandNotFound), get: |_name| "x" }),
+        \\    (stored.invoke)({ run: || Ok("  found  "), get: |_name| "y" }),
+        \\)
+        ,
+        .expected = .{ .inspect_str = "(Err(CommandNotFound), Ok({}))" },
+    },
+    .{
         .name = "issue 11217: stored closures retain enclosing callable alias contexts",
         .source_kind = .module,
         .source =

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -299,7 +299,7 @@ pub fn fnEvidenceDigest(
     head: ?u32,
 ) EvidenceDigest {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    writeBytes(&hasher, "roc.monotype.fn_evidence.v3");
+    writeBytes(&hasher, "roc.monotype.fn_evidence.v4");
     writeU32(&hasher, @intCast(evidence.len));
     for (evidence) |entry| {
         writeU8(&hasher, @intFromEnum(entry));
@@ -338,7 +338,6 @@ pub fn fnEvidenceDigest(
                 } else writeU8(&hasher, 0);
             },
             .from_callable => |use| {
-                writeU32(&hasher, use.index);
                 writeU8(&hasher, @intFromBool(use.independent_callable));
             },
             .from_scheme => |index| writeU32(&hasher, index),
@@ -510,15 +509,28 @@ test "function evidence identity uses checked callable type keys" {
         check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 1),
     };
     const symbolic_left = [_]check.ConstStore.ConstFnEvidence{.{
-        .from_callable = .{ .index = 0, .independent_callable = false },
+        .from_callable = .{ .independent_callable = false },
     }};
     const symbolic_right = [_]check.ConstStore.ConstFnEvidence{.{
-        .from_callable = .{ .index = 1, .independent_callable = false },
+        .from_callable = .{ .independent_callable = true },
     }};
     try std.testing.expect(!fnEvidenceEql(&symbolic_left, &symbolic_frames, 0, &symbolic_right, &symbolic_frames, 0));
     try std.testing.expect(!std.meta.eql(
         fnEvidenceDigest(&symbolic_left, &symbolic_frames, 0),
         fnEvidenceDigest(&symbolic_right, &symbolic_frames, 0),
+    ));
+
+    // The vector order still identifies which requirement is symbolic. Dropping
+    // the redundant source index must not erase the destination slot's identity.
+    const slot_frames = [_]check.ConstStore.ConstFnEvidenceFrame{
+        check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 2),
+    };
+    const first_symbolic = [_]check.ConstStore.ConstFnEvidence{ symbolic_left[0], .unreachable_value };
+    const second_symbolic = [_]check.ConstStore.ConstFnEvidence{ .unreachable_value, symbolic_left[0] };
+    try std.testing.expect(!fnEvidenceEql(&first_symbolic, &slot_frames, 0, &second_symbolic, &slot_frames, 0));
+    try std.testing.expect(!std.meta.eql(
+        fnEvidenceDigest(&first_symbolic, &slot_frames, 0),
+        fnEvidenceDigest(&second_symbolic, &slot_frames, 0),
     ));
 }
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -616,6 +616,10 @@ pub const BodyDiagnostics = struct {
     nested_callable_checks: u64 = 0,
     nested_lambdas_prepared: u64 = 0,
     nested_closures_prepared: u64 = 0,
+    /// Requests that project symbolic evidence over their checked callable.
+    callable_evidence_symbolic_requests: u64 = 0,
+    /// Immutable evidence vectors copied because at least one entry resolved.
+    callable_evidence_vector_copies: u64 = 0,
 };
 
 /// Deterministic Monotype workload counts. These diagnose how much exact
@@ -802,8 +806,9 @@ const SpecEvidence = union(enum) {
     structural: SpecStructuralEvidence,
     /// Callable-reachable evidence that remains symbolic while a reusable
     /// compile-time value is produced and resolves from the eventual request.
+    /// Its containing vector slot selects the receiving scheme's checked path;
+    /// forwarding never retains a coordinate in the sending scheme.
     from_callable: struct {
-        index: u32,
         independent_callable: bool,
     },
     /// Abstract local scheme parameter, supplied by the checked use edge.
@@ -4593,7 +4598,6 @@ const Builder = struct {
             } }),
             .from_callable => |use| {
                 try nodes.append(self.allocator, .{ .from_callable = .{
-                    .index = use.index,
                     .independent_callable = use.independent_callable,
                 } });
             },
@@ -40453,7 +40457,6 @@ const BodyContext = struct {
                     } };
                 },
                 .from_callable => |use| .{ .from_callable = .{
-                    .index = use.index,
                     .independent_callable = use.independent_callable,
                 } },
                 .from_scheme => |index| .{ .from_scheme = index },
@@ -40560,26 +40563,16 @@ const BodyContext = struct {
         request_fn_node: NodeId,
         purpose: EvidenceMaterializationPurpose,
     ) Allocator.Error![]const SpecEvidence {
-        var has_symbolic = false;
-        for (evidence) |entry| {
-            if (entry == .from_callable) {
-                has_symbolic = true;
-                break;
-            }
-        }
-        if (!has_symbolic) return evidence;
-
         const params = view.templates.evidenceParams(&template);
         if (evidence.len != params.len) {
             Common.invariant("callable-derived evidence length differed from its checked template");
         }
-        const resolved = try self.builder.evidence_arena.allocator().dupe(SpecEvidence, evidence);
-        for (resolved) |*entry| switch (entry.*) {
-            .from_callable => |recipe| {
-                if (recipe.index >= params.len) {
-                    Common.invariant("callable-derived evidence referenced an unknown checked parameter");
-                }
-                const param = params[recipe.index];
+        var resolved: ?[]SpecEvidence = null;
+        var has_symbolic = false;
+        for (evidence, 0..) |entry, index| switch (entry) {
+            .from_callable => {
+                has_symbolic = true;
+                const param = params[index];
                 const path = view.templates.evidenceParamPath(param);
                 if (path.len == 0) {
                     Common.invariant("callable-derived evidence named a pathless checked parameter");
@@ -40590,18 +40583,26 @@ const BodyContext = struct {
                     param.structural != null or
                     try self.nodeIsProvenUninhabited(component_node);
                 if (resolvable) {
-                    entry.* = try self.synthesizeComponentEvidenceAtNodeForPurpose(
+                    const replacement = try self.synthesizeComponentEvidenceAtNodeForPurpose(
                         view,
                         param.method,
                         param.structural,
                         component_node,
                         purpose,
                     );
+                    // Evidence can be shared with another request or lexical
+                    // frame. Copy once, only when this request resolves an entry.
+                    if (resolved == null) {
+                        resolved = try self.builder.evidence_arena.allocator().dupe(SpecEvidence, evidence);
+                        self.builder.countBodyDiagnostic("callable_evidence_vector_copies");
+                    }
+                    resolved.?[index] = replacement;
                 }
             },
             .target, .structural, .from_scheme, .unreachable_value, .checked_error => {},
         };
-        return resolved;
+        if (has_symbolic) self.builder.countBodyDiagnostic("callable_evidence_symbolic_requests");
+        return resolved orelse evidence;
     }
 
     /// The substitution and evidence the scheme instantiated at `expr` (a
@@ -40955,8 +40956,7 @@ const BodyContext = struct {
                         };
                         break :independent .{ .target = independent_target };
                     },
-                    .from_callable => |use| .{ .from_callable = .{
-                        .index = use.index,
+                    .from_callable => .{ .from_callable = .{
                         .independent_callable = true,
                     } },
                     .structural, .from_scheme, .unreachable_value, .checked_error => entry,
@@ -41136,7 +41136,6 @@ const BodyContext = struct {
                 .from_scheme => Common.invariant("abstract scheme evidence named an ordinary callable parameter"),
                 .from_callable => {
                     out[k] = .{ .from_callable = .{
-                        .index = @intCast(k),
                         .independent_callable = false,
                     } };
                     derived[k] = true;
@@ -41161,7 +41160,6 @@ const BodyContext = struct {
                     },
                     .from_callable => |use| {
                         out[k] = .{ .from_callable = .{
-                            .index = use.index,
                             .independent_callable = use.independent_callable or constraint.independent_callable,
                         } };
                         derived[k] = true;

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -28,6 +28,8 @@ const TestEvidenceMappingError = std.mem.Allocator.Error || CacheError || error{
 /// Magic bytes at the start of a specialization cache file.
 pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// Serialization format version for specialization cache files.
+/// Version 18: symbolic callable evidence is relative to its containing vector
+/// slot, without a source-scheme index in stored evidence or its digest.
 /// Version 17: generated-codec specialization identities retain the explicit
 /// public value shape separately from the constructor representation.
 /// Version 16: generated-codec specialization identities name their complete
@@ -48,7 +50,7 @@ pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// roots or one exact producer-authored graph.
 /// Version 8: specialization and function-template identity includes the
 /// SHA-256 digest of exact compile-time evidence topology.
-pub const FORMAT_VERSION: u32 = 17;
+pub const FORMAT_VERSION: u32 = 18;
 
 const SECTION_COUNT = 43;
 


### PR DESCRIPTION
Forwarding an unresolved `trim` requirement could accidentally select `from_quote` when the next function ordered its requirements differently, crashing the compiler. This keeps symbolic evidence relative to the receiving vector slot, updates stored evidence and cache formats, and reuses unchanged evidence vectors.

Fixes #11301.
