### PR TITLE
Fix compiler crash from reordered method evidence

### DIFF
--- a/design.md
+++ b/design.md
@@ -9048,15 +9048,22 @@ does not mutate checked data or create a second name registry.
 
 When an edge uses a procedure as data, an otherwise-unpinned requirement that
 is reachable through the procedure's own callable type is not
-`unreachable`. Checker output records `from_callable(k)` at that construction
-site, where `k` is the requirement's template evidence-param index and its
-evidence-param record owns the exact dispatcher path. If compile-time
-evaluation stores that function inside another value before the callable is
-concrete, `ConstStore` retains the same symbolic entry in the function's
-evidence vector. Restoring the function projects the recorded path over the
-consumer's concrete callable request, selects the exact method evidence, and
-uses the resolved vector as the specialization identity. This work is linear
-only in the function's evidence vector at a specialization request; the
+`unreachable`. Checker output records a `from_callable` marker in that
+requirement's evidence-vector slot. The owning schema's parameter at that
+position supplies the exact method and dispatcher path; the marker carries no
+second parameter index. Forwarding follows the checked edge to its source
+requirement and places the marker in the destination requirement's slot, so
+different parameter orders across schemes require no rebasing pass or lookup
+table. Lexical `constraint` references retain their explicit depth and index.
+If compile-time evaluation stores that function inside another value before the
+callable is concrete, `ConstStore` retains the same symbolic entry in the
+function's evidence vector, including inside nested evidence trees. Pool offsets are not
+parameter positions. Restoring the function walks the vector alongside its
+owning schema, validates that each marker has a callable-reachable dispatcher
+path, projects that path over the consumer's concrete callable request, selects
+the exact method evidence, and uses the resolved vector as the specialization
+identity. This work is linear only in the function's evidence vector at a
+specialization request; the
 existing specialization cache prevents duplicate function bodies. Aggregate
 restoration neither scans nested values nor reconstructs where a function came
 from.
@@ -13535,9 +13542,9 @@ When a later compilation materializes a cached const, Monotype lowering turns
   alpha-renaming its parameters, and binding each captured symbol to the
   ordinary Monotype expression materialized from the corresponding captured
   `ConstNodeId`
-- stored function evidence marked `from_callable(k)` is resolved from the
-  checker-authored path of evidence param `k` over the consumer's concrete
-  function request before the checked template is specialized
+- stored function evidence marked `from_callable` is resolved from the
+  checker-authored path of its owning vector slot's parameter over the
+  consumer's concrete function request before the checked template is specialized
 - generated parser runtime functions materialize through their explicit generated
   function kind: Monotype lowering recovers the checked static-dispatch plan,
   materializes generated captures such as transformed field-name strings by their

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -31334,7 +31334,9 @@ pub const CheckedModuleArtifact = struct {
     // Version 93 distinguishes rejected function values from callable templates.
     // Version 94 retains explicit equality guards and matched-value binders
     // for custom literal patterns.
-    const serialized_layout_version: u32 = 94;
+    // Version 95 makes stored callable-derived evidence own its vector slot
+    // instead of retaining a parameter index from a forwarding scheme.
+    const serialized_layout_version: u32 = 95;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -37900,8 +37902,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0xD7, 0x46, 0xCF, 0x78, 0xBA, 0x30, 0x9B, 0x80, 0xAE, 0xC6, 0x91, 0x50, 0x5F, 0xB2, 0xD7, 0x53,
-        0xDC, 0x7B, 0xEF, 0x6D, 0x06, 0x6C, 0x66, 0x30, 0xD7, 0xF4, 0x5D, 0x5D, 0x06, 0x0C, 0x7F, 0x87,
+        0x17, 0xC0, 0xDF, 0xF1, 0xE9, 0xDA, 0x5A, 0x3F, 0xB8, 0x10, 0x4B, 0x58, 0x33, 0xBF, 0x14, 0xA2,
+        0xA5, 0xA6, 0x52, 0x90, 0x6E, 0x9B, 0xB6, 0x69, 0x6B, 0x9B, 0x96, 0x39, 0x07, 0x3C, 0xA4, 0x49,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -289,9 +289,10 @@ pub const ConstFnEvidence = union(enum(u8)) {
     },
     structural: ConstFnStructuralEvidence,
     /// A callable-reachable requirement that must be resolved from the
-    /// concrete function type when this stored function is restored.
+    /// concrete function type when this stored function is restored. Its
+    /// position in its evidence vector selects the owning schema parameter,
+    /// independently of offsets in the flattened nested-evidence pool.
     from_callable: struct {
-        index: u32,
         independent_callable: bool = false,
     },
     /// Abstract local scheme parameter, supplied by the checked use edge.
@@ -1271,7 +1272,7 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
         } },
         .{ .structural = .{ .derivation = .equality } },
         .checked_error,
-        .{ .from_callable = .{ .index = 2, .independent_callable = true } },
+        .{ .from_callable = .{ .independent_callable = true } },
         .{ .from_scheme = 3 },
     };
     const evidence_frames = [_]ConstFnEvidenceFrame{
@@ -1346,7 +1347,7 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     try std.testing.expectEqual(@as(u32, 1), loaded_nested.subtree_len);
     try std.testing.expectEqual(ConstFnEvidence{ .structural = .{ .derivation = .equality } }, loaded_fn.evidence[1]);
     try std.testing.expectEqual(ConstFnEvidence.checked_error, loaded_fn.evidence[2]);
-    try std.testing.expectEqual(ConstFnEvidence{ .from_callable = .{ .index = 2, .independent_callable = true } }, loaded_fn.evidence[3]);
+    try std.testing.expectEqual(ConstFnEvidence{ .from_callable = .{ .independent_callable = true } }, loaded_fn.evidence[3]);
     try std.testing.expectEqual(ConstFnEvidence{ .from_scheme = 3 }, loaded_fn.evidence[4]);
     try std.testing.expectEqualSlices(ConstFnEvidenceFrame, &evidence_frames, loaded_fn.evidence_frames);
     try std.testing.expectEqual(@as(?u32, 1), loaded_fn.evidence_frame_head);

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -177,6 +177,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11236_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11249_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11263_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11300_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11300_test.zig
+++ b/src/compile/test/issue_11300_test.zig
@@ -1,0 +1,169 @@
+//! Regression test for issue #11300: forwarding a record of closures must
+//! preserve method evidence when the callee orders its requirements differently.
+
+const std = @import("std");
+const postcheck = @import("postcheck");
+const harness = @import("lower_to_lir_harness.zig");
+
+test "issue 11300: a forwarded record closure that only returns Err lowers with a method call on its Ok payload" {
+    try harness.expectLowersToLir(
+        \\main! : List(Str) => Try({}, [Exit(I8), ..])
+        \\main! = |_args|
+        \\    outer({
+        \\        run: || Err(CommandNotFound),
+        \\        get: |_name| "x",
+        \\    }).map_err(|_| Exit(1)).map_ok(|_| {})
+        \\
+        \\outer = |hooks| {
+        \\    _ = hooks.get
+        \\    middle(hooks)
+        \\}
+        \\
+        \\middle = |hooks| {
+        \\    get = hooks.get
+        \\    _ = get("name")
+        \\    run = hooks.run
+        \\    output = run()?
+        \\    parse(output.trim())
+        \\}
+        \\
+        \\parse : Str -> Try(I32, _)
+        \\parse = |_s| Ok(1)
+        \\
+    );
+}
+
+test "issue 11300: multiple forwarding edges preserve reordered Boolean method evidence" {
+    try harness.expectLowersToLir(
+        \\main! : List(Str) => Try({}, [Exit(I8), ..])
+        \\main! = |_args|
+        \\    outer({
+        \\        run: || Err(CommandNotFound),
+        \\        get: |_name| "x",
+        \\    }).map_err(|_| Exit(1)).map_ok(|_| {})
+        \\
+        \\outer = |hooks| {
+        \\    _ = hooks.get
+        \\    forward(hooks)
+        \\}
+        \\
+        \\forward = |hooks| {
+        \\    _ = hooks.run
+        \\    middle(hooks)
+        \\}
+        \\
+        \\middle = |hooks| {
+        \\    get = hooks.get
+        \\    _ = get("name")
+        \\    run = hooks.run
+        \\    output = run()?
+        \\    parse(output.is_empty())
+        \\}
+        \\
+        \\parse : Bool -> Try(I32, _)
+        \\parse = |_s| Ok(1)
+    );
+}
+
+test "issue 11300: imported stored functions preserve symbolic and concrete method evidence" {
+    var dir = std.testing.tmpDir(.{});
+    defer dir.cleanup();
+    try dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "platform.roc",
+        .data =
+        \\platform ""
+        \\    requires {} { main! : Str => Str }
+        \\    exposes []
+        \\    packages {}
+        \\    provides { "roc_main": run! }
+        \\run! = |input| main!(input)
+        ,
+    });
+    try dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "Hooks.roc",
+        .data =
+        \\module [stored]
+        \\
+        \\stored = { call: outer }
+        \\
+        \\outer = |hooks| {
+        \\    _ = hooks.get
+        \\    middle(hooks)
+        \\}
+        \\
+        \\middle = |hooks| {
+        \\    get = hooks.get
+        \\    _ = get("name")
+        \\    run = hooks.run
+        \\    output = run()?
+        \\    parse(output.trim())
+        \\}
+        \\
+        \\parse : Str -> Try(I32, _)
+        \\parse = |_s| Ok(1)
+        ,
+    });
+    try dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\app [main!] { pf: platform "./platform.roc" }
+        \\import Hooks
+        \\
+        \\main! = |input| {
+        \\    call = Hooks.stored.call
+        \\    failed = call({ run: || Err(CommandNotFound), get: |_name| input })
+        \\    succeeded = call({ run: || Ok(input), get: |_name| input })
+        \\    match (failed, succeeded) {
+        \\        (Err(CommandNotFound), Ok(1)) => input
+        \\        _ => "unexpected"
+        \\    }
+        \\}
+        ,
+    });
+    const path = try dir.dir.realPathFileAlloc(std.testing.io, "main.roc", std.testing.allocator);
+    defer std.testing.allocator.free(path);
+    try harness.expectAppPathLowersToLir(path);
+}
+
+test "issue 11300: repeated symbolic forwarding reuses specialization bodies" {
+    const prefix =
+        \\outer = |hooks| {
+        \\    _ = hooks.get
+        \\    middle(hooks)
+        \\}
+        \\middle = |hooks| {
+        \\    get = hooks.get
+        \\    _ = get("name")
+        \\    run = hooks.run
+        \\    output = run()?
+        \\    parse(output.trim())
+        \\}
+        \\parse : Str -> Try(I32, _)
+        \\parse = |_s| Ok(1)
+        \\main! = |_args| {
+        \\    hooks = { run: || Err(CommandNotFound), get: |_name| "x" }
+        \\    _ = outer(hooks)
+        \\
+    ;
+    const suffix =
+        \\    Ok({})
+        \\}
+    ;
+    var once: postcheck.Monotype.Lower.Diagnostics = .{};
+    var repeated: postcheck.Monotype.Lower.Diagnostics = .{};
+    try harness.expectLowersToLirWithOptions(prefix ++ suffix, .{
+        .monotype_only = true,
+        .monotype_diagnostics_out = &once,
+    });
+    try harness.expectLowersToLirWithOptions(prefix ++ "    _ = outer(hooks)\n" ++ suffix, .{
+        .monotype_only = true,
+        .monotype_diagnostics_out = &repeated,
+    });
+    // Open requests reserve independent graph cells before their completed
+    // interfaces can share a body. Count body lowering, not provisional misses.
+    try std.testing.expect(once.body.deferred_template_bodies_lowered > 0);
+    try std.testing.expectEqual(once.specialization.nested_misses, repeated.specialization.nested_misses);
+    try std.testing.expectEqual(once.body.deferred_template_bodies_lowered, repeated.body.deferred_template_bodies_lowered);
+    try std.testing.expectEqual(once.body.caller_owned_template_bodies_lowered, repeated.body.caller_owned_template_bodies_lowered);
+    try std.testing.expectEqual(@as(u64, 0), repeated.specialization.evidence_missing);
+}

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -299,7 +299,7 @@ pub fn fnEvidenceDigest(
     head: ?u32,
 ) EvidenceDigest {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    writeBytes(&hasher, "roc.monotype.fn_evidence.v3");
+    writeBytes(&hasher, "roc.monotype.fn_evidence.v4");
     writeU32(&hasher, @intCast(evidence.len));
     for (evidence) |entry| {
         writeU8(&hasher, @intFromEnum(entry));
@@ -338,7 +338,6 @@ pub fn fnEvidenceDigest(
                 } else writeU8(&hasher, 0);
             },
             .from_callable => |use| {
-                writeU32(&hasher, use.index);
                 writeU8(&hasher, @intFromBool(use.independent_callable));
             },
             .from_scheme => |index| writeU32(&hasher, index),
@@ -507,18 +506,28 @@ test "function evidence identity uses checked callable type keys" {
     try std.testing.expect(!std.meta.eql(fnEvidenceDigest(&left, &frames, 0), fnEvidenceDigest(&right, &frames, 0)));
 
     const symbolic_frames = [_]check.ConstStore.ConstFnEvidenceFrame{
-        check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 1),
+        check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 2),
     };
-    const symbolic_left = [_]check.ConstStore.ConstFnEvidence{.{
-        .from_callable = .{ .index = 0, .independent_callable = false },
-    }};
-    const symbolic_right = [_]check.ConstStore.ConstFnEvidence{.{
-        .from_callable = .{ .index = 1, .independent_callable = false },
-    }};
+    const symbolic_left = [_]check.ConstStore.ConstFnEvidence{
+        .{ .from_callable = .{ .independent_callable = false } },
+        .unreachable_value,
+    };
+    const symbolic_right = [_]check.ConstStore.ConstFnEvidence{
+        .unreachable_value,
+        .{ .from_callable = .{ .independent_callable = false } },
+    };
+    // The vector position owns the symbolic requirement's identity.
     try std.testing.expect(!fnEvidenceEql(&symbolic_left, &symbolic_frames, 0, &symbolic_right, &symbolic_frames, 0));
     try std.testing.expect(!std.meta.eql(
         fnEvidenceDigest(&symbolic_left, &symbolic_frames, 0),
         fnEvidenceDigest(&symbolic_right, &symbolic_frames, 0),
+    ));
+    var independent = symbolic_left;
+    independent[0].from_callable.independent_callable = true;
+    try std.testing.expect(!fnEvidenceEql(&symbolic_left, &symbolic_frames, 0, &independent, &symbolic_frames, 0));
+    try std.testing.expect(!std.meta.eql(
+        fnEvidenceDigest(&symbolic_left, &symbolic_frames, 0),
+        fnEvidenceDigest(&independent, &symbolic_frames, 0),
     ));
 }
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -802,8 +802,9 @@ const SpecEvidence = union(enum) {
     structural: SpecStructuralEvidence,
     /// Callable-reachable evidence that remains symbolic while a reusable
     /// compile-time value is produced and resolves from the eventual request.
+    /// Its position in the owning vector selects the checked parameter; no
+    /// index from a forwarding frame may survive into the destination schema.
     from_callable: struct {
-        index: u32,
         independent_callable: bool,
     },
     /// Abstract local scheme parameter, supplied by the checked use edge.
@@ -4593,7 +4594,6 @@ const Builder = struct {
             } }),
             .from_callable => |use| {
                 try nodes.append(self.allocator, .{ .from_callable = .{
-                    .index = use.index,
                     .independent_callable = use.independent_callable,
                 } });
             },
@@ -40453,7 +40453,6 @@ const BodyContext = struct {
                     } };
                 },
                 .from_callable => |use| .{ .from_callable = .{
-                    .index = use.index,
                     .independent_callable = use.independent_callable,
                 } },
                 .from_scheme => |index| .{ .from_scheme = index },
@@ -40574,12 +40573,11 @@ const BodyContext = struct {
             Common.invariant("callable-derived evidence length differed from its checked template");
         }
         const resolved = try self.builder.evidence_arena.allocator().dupe(SpecEvidence, evidence);
-        for (resolved) |*entry| switch (entry.*) {
-            .from_callable => |recipe| {
-                if (recipe.index >= params.len) {
-                    Common.invariant("callable-derived evidence referenced an unknown checked parameter");
-                }
-                const param = params[recipe.index];
+        // Both columns belong to the destination template. Forwarded symbolic
+        // evidence keeps its meaning through the checked edge, even when that
+        // template enumerates its requirements in a different order.
+        for (resolved, params) |*entry, param| switch (entry.*) {
+            .from_callable => {
                 const path = view.templates.evidenceParamPath(param);
                 if (path.len == 0) {
                     Common.invariant("callable-derived evidence named a pathless checked parameter");
@@ -40955,8 +40953,7 @@ const BodyContext = struct {
                         };
                         break :independent .{ .target = independent_target };
                     },
-                    .from_callable => |use| .{ .from_callable = .{
-                        .index = use.index,
+                    .from_callable => .{ .from_callable = .{
                         .independent_callable = true,
                     } },
                     .structural, .from_scheme, .unreachable_value, .checked_error => entry,
@@ -41136,7 +41133,6 @@ const BodyContext = struct {
                 .from_scheme => Common.invariant("abstract scheme evidence named an ordinary callable parameter"),
                 .from_callable => {
                     out[k] = .{ .from_callable = .{
-                        .index = @intCast(k),
                         .independent_callable = false,
                     } };
                     derived[k] = true;
@@ -41161,7 +41157,6 @@ const BodyContext = struct {
                     },
                     .from_callable => |use| {
                         out[k] = .{ .from_callable = .{
-                            .index = use.index,
                             .independent_callable = use.independent_callable or constraint.independent_callable,
                         } };
                         derived[k] = true;

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -28,6 +28,8 @@ const TestEvidenceMappingError = std.mem.Allocator.Error || CacheError || error{
 /// Magic bytes at the start of a specialization cache file.
 pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// Serialization format version for specialization cache files.
+/// Version 18: callable-derived evidence belongs to its vector slot and no
+/// longer stores a parameter index from another scheme.
 /// Version 17: generated-codec specialization identities retain the explicit
 /// public value shape separately from the constructor representation.
 /// Version 16: generated-codec specialization identities name their complete
@@ -48,7 +50,7 @@ pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// roots or one exact producer-authored graph.
 /// Version 8: specialization and function-template identity includes the
 /// SHA-256 digest of exact compile-time evidence topology.
-pub const FORMAT_VERSION: u32 = 17;
+pub const FORMAT_VERSION: u32 = 18;
 
 const SECTION_COUNT = 43;
 
@@ -2334,9 +2336,12 @@ test "monotype specialization cache maps fresh single-shard program view equival
     const call_args = try program.addExprSpan(&.{local_expr});
     const typed_args = try program.addTypedLocalSpan(&.{.{ .local = local, .ty = unit_ty }});
 
-    const fn_evidence_nodes = [_]check.ConstStore.ConstFnEvidence{.{ .structural = .{ .derivation = .equality } }};
+    const fn_evidence_nodes = [_]check.ConstStore.ConstFnEvidence{
+        .{ .structural = .{ .derivation = .equality } },
+        .{ .from_callable = .{ .independent_callable = true } },
+    };
     const fn_evidence_frame_nodes = [_]check.ConstStore.ConstFnEvidenceFrame{
-        check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 1),
+        check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 2),
     };
     const fn_evidence = try program.addConstFnEvidence(&fn_evidence_nodes);
     const fn_evidence_frames = try program.addConstFnEvidenceFrames(&fn_evidence_frame_nodes);


### PR DESCRIPTION
Fixes a compiler crash when generic wrappers enumerate method requirements in different orders. Callable-derived evidence now belongs to its destination vector slot, preventing a forwarded `trim` obligation from selecting `from_quote`. Stored evidence and specialization identities use the same rule, with cache versions updated for the representation change.

Fixes #11300.
