### PR TITLE
Fix ARC restitution for retained low-level arguments

### DIFF
--- a/design.md
+++ b/design.md
@@ -11861,12 +11861,22 @@ statically known `assign_tag` discriminant for the current binding of the
 returned local, and whose ownership-neutral
 control-flow graph can account mechanically for every ownership-moving
 statement on every path. The solver propagates one bit per represented owned
-entry parameter. A consuming call position, consuming low-level argument,
+entry parameter. A consuming call position, ownership-transferring low-level argument,
 aggregate operand, tag payload, store operand, moving Boxy operand, or returned
 same-value alias clears that entry bit. Borrowing reads leave it set. At each
 normal return, the bits still set are intersected with every other path that
 returns the same discriminant. A loop is the ordinary finite fixed point over
 the per-resource rows below.
+
+For a low-level operation, ownership-transferring positions are exactly
+`consume_args | retain_args` from its explicit ARC effect. A `retain_args`
+operand supplies a stored unit to the result, and emission may move its existing
+unit instead of retaining it. That entry unit is therefore spent on this path,
+just like an aggregate operand; it cannot also be promised back to the caller.
+Pure same-value aliases preserve this transfer identity. For a checked list
+replacement, success spends both the list and replacement item, while
+failure may restitute both untouched entry units. Ordinary borrowing reads
+continue to preserve the entry bit.
 
 Restitution consumes the structural lift's existing procedure statement
 inventory. Its reusable scratch arrays and statement-to-ordinal lookup contain

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -178,6 +178,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11249_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11263_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11286_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11310_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11310_test.zig
+++ b/src/compile/test/issue_11310_test.zig
@@ -1,0 +1,70 @@
+//! Regression test for issue #11310.
+
+const std = @import("std");
+const harness = @import("lower_to_lir_harness.zig");
+
+// The same-field fallback and nested record update demand an outcome variant
+// of List.set under dev lowering. Success must transfer the replacement Str
+// into the result rather than also promising its entry unit to the caller.
+const app_source =
+    \\app [main!] { pf: platform "./platform.roc" }
+    \\
+    \\import pf.FallibleHost
+    \\
+    \\Upload : { chunk_hashes : List(Str) }
+    \\Page : { upload : Upload }
+    \\
+    \\replace_first : Upload, Str -> List(Str)
+    \\replace_first = |upload, event| upload.chunk_hashes.set(0, event) ?? upload.chunk_hashes
+    \\
+    \\update : Page, Str -> Page
+    \\update = |page, msg| { ..page, upload: { chunk_hashes: replace_first(page.upload, msg) } }
+    \\
+    \\main! : () => Str
+    \\main! = || {
+    \\    msg = FallibleHost.json_input!({})
+    \\    upload = { chunk_hashes: [] }
+    \\    page = update({ upload: upload }, msg)
+    \\    "${page.upload.chunk_hashes.len().to_str()}"
+    \\}
+;
+
+const platform_source =
+    \\platform ""
+    \\    requires {} { main! : () => Str }
+    \\    exposes [FallibleHost]
+    \\    packages {}
+    \\    provides { "roc_main": main_for_host! }
+    \\    hosted { "roc_json_input": FallibleHost.json_input! }
+    \\
+    \\import FallibleHost
+    \\
+    \\main_for_host! : () => Str
+    \\main_for_host! = main!
+;
+
+const fallible_host_source =
+    \\FallibleHost := [].{
+    \\    json_input! : {} => Str
+    \\}
+;
+
+test "issue 11310: a set fallback to its own field transfers the replacement string" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "app.roc", .data = app_source });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "platform.roc", .data = platform_source });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "FallibleHost.roc", .data = fallible_host_source });
+
+    const app_path = try tmp_dir.dir.realPathFileAlloc(io, "app.roc", gpa);
+    defer gpa.free(app_path);
+
+    // Both dev options are required to preserve the failing call shape.
+    try harness.expectAppPathLowersToLirWithOptions(app_path, .{
+        .inline_mode = .wrappers,
+        .spec_constr_clone_inlining = .iterator_fusion,
+    });
+}

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -12647,6 +12647,102 @@ test "RC outcome restitution preserves List Str on failure and seeds the success
     try testing.expectEqual(@as(usize, 0), f.countRc(input, .incref));
 }
 
+test "RC outcome restitution spends retained arguments through aliases only on success" {
+    for ([_]bool{ false, true }) |specialize| {
+        var f = try ArcTest.init(testing.allocator);
+        defer f.deinit();
+        const outcome_layout = try f.layouts.putTagUnion(&.{ try f.layouts.ensureZstLayout(), f.list_str });
+
+        const input_param = try f.local(f.list_str);
+        const index_param = try f.local(.u64);
+        const replacement_param = try f.local(.str);
+        const choose_param = try f.local(.i64);
+        const first_alias = try f.local(.str);
+        const second_alias = try f.local(.str);
+        const changed = try f.local(f.list_str);
+        const result = try f.local(outcome_layout);
+        const join_id = f.freshJoinPointId();
+        const ret = try f.ret(result);
+        const success_jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+        const success_tag = try f.assignTag(result, 1, changed, success_jump);
+        const mutate = try f.store.addCFStmt(.{ .assign_low_level = .{
+            .target = changed,
+            .op = .list_set,
+            .rc_effect = LIR.LowLevel.list_set.rcEffect(),
+            .args = try f.span(&.{ input_param, index_param, second_alias }),
+            .next = success_tag,
+        } });
+        const alias_again = try f.assignRefLocal(second_alias, first_alias, mutate);
+        const success = try f.assignRefLocal(first_alias, replacement_param, alias_again);
+        const failure_jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+        const failure = try f.assignTag(result, 0, null, failure_jump);
+        const choose = try f.switchStmt(choose_param, success, failure, null);
+        const body = try f.store.addCFStmt(.{ .join = .{
+            .id = join_id,
+            .params = LIR.LocalSpan.empty(),
+            .body = ret,
+            .remainder = choose,
+        } });
+        const callee = try f.addProc(&.{ input_param, index_param, replacement_param, choose_param }, body, outcome_layout);
+
+        // The caller needs the old list only on failure. The complete outcome
+        // convention must also return the unused replacement on that edge so
+        // the caller can release it. Success stores it in the changed list.
+        const input = try f.local(f.list_str);
+        const index = try f.local(.u64);
+        const replacement = try f.local(.str);
+        const caller_choose = try f.local(.i64);
+        const call_result = try f.local(outcome_layout);
+        const discriminant = try f.local(.u8);
+        const output = try f.local(.i64);
+        const caller_ret = try f.ret(output);
+        const success_done = try f.assignI64(output, 1, caller_ret);
+        const failure_done = try f.assignI64(output, 0, caller_ret);
+        const failure_use = try f.expectStmt(input, failure_done);
+        const refine = try f.switchStmt(discriminant, success_done, failure_use, null);
+        const read_discriminant = try f.assignDiscriminant(discriminant, call_result, refine);
+        const call = try f.store.addCFStmt(.{ .assign_call = .{
+            .target = call_result,
+            .proc = callee,
+            .args = try f.span(&.{ input, index, replacement, caller_choose }),
+            .next = read_discriminant,
+        } });
+        const caller = try f.addProc(&.{ input, index, replacement, caller_choose }, call, .i64);
+
+        const rc = try testing.allocator.alloc(bool, f.store.localCount());
+        defer testing.allocator.free(rc);
+        for (rc, 0..) |*is_rc, local_index| {
+            const local = f.store.getLocal(@enumFromInt(@as(u32, @intCast(local_index))));
+            is_rc.* = f.layouts.layoutContainsRefcounted(f.layouts.getLayout(local.layout_idx));
+        }
+        {
+            var solution = try arc_solve.solve(testing.allocator, &f.store, &f.layouts, rc, &.{}, &.{caller}, true);
+            defer solution.deinit();
+            const outcomes = solution.availableOutcomeSpanOf(callee);
+            try testing.expectEqual(@as(u32, 2), outcomes.len);
+            try testing.expectEqualDeep(arc_sig.Outcome{ .discriminant = 0, .restituted_params = 0b0101 }, solution.outcomes[outcomes.start]);
+            try testing.expectEqualDeep(arc_sig.Outcome{ .discriminant = 1, .restituted_params = 0 }, solution.outcomes[outcomes.start + 1]);
+            try testing.expectEqual(@as(arc_sig.ParamMask, 0b0101), solution.restitutionParamsAt(failure_jump));
+            try testing.expectEqual(@as(arc_sig.ParamMask, 0), solution.restitutionParamsAt(success_jump));
+        }
+
+        const base_proc_count = f.store.procSpecCount();
+        try insert(&f.store, &f.layouts, .{ .roots = &.{caller}, .specialize = specialize });
+        try testing.expectEqual(base_proc_count + 1, f.store.procSpecCount());
+        const caller_body = f.store.getCFStmt(f.store.getProcSpec(caller).body.?);
+        try testing.expect(caller_body == .assign_call);
+        try testing.expectEqual(base_proc_count, @intFromEnum(caller_body.assign_call.proc));
+
+        // Neither the caller nor either callee emission needs an extra unit
+        // for the list or replacement. The failure receipt releases exactly
+        // one caller-side replacement; ARC certification checks both paths.
+        for ([_]LIR.LocalId{ input_param, replacement_param, first_alias, second_alias, input, replacement }) |local| {
+            try testing.expectEqual(@as(usize, 0), f.countRc(local, .incref));
+        }
+        try testing.expectEqual(@as(usize, 1), f.countRc(replacement, .decref));
+    }
+}
+
 test "RC outcome restitution releases every returned argument before a nested join" {
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -1416,6 +1416,10 @@ fn computeOutcomeRestitution(
                             assign.op.arcBorrowedResultVariant().?.rcEffect()
                         else
                             assign.op.arcInferenceRcEffect(assign.rc_effect);
+                        // Stored arguments may move their entry unit into the
+                        // result instead of retaining it, just like aggregate
+                        // operands. Neither transfer can promise restitution.
+                        const transferred_args = effect.consume_args | effect.retain_args;
                         const args = store.getLocalSpan(assign.args);
                         for (0..GuardedList.borrowLen(args)) |position| {
                             if (position >= 64) {
@@ -1423,7 +1427,7 @@ fn computeOutcomeRestitution(
                                 break;
                             }
                             const bit = @as(u64, 1) << @as(u6, @intCast(position));
-                            if ((effect.consume_args & bit) == 0) continue;
+                            if ((transferred_args & bit) == 0) continue;
                             if (!consumeOutcomeLocal(solution, active_param, &next_state.present, GuardedList.at(args, position))) {
                                 valid = false;
                                 break;


### PR DESCRIPTION
Checked list updates could incorrectly promise to return the replacement string's ownership on success, causing dev lowering to panic when a same-field fallback was used in a nested record update. Account for both consumed and stored low-level arguments when deriving ARC restitution: success transfers their units into the result, while failure can return the untouched units. This preserves ownership moves without adding retains.

Fixes #11310.
