### PR TITLE
Fix crash lowering method-constrained lambdas in returned records

### DIFF
--- a/design.md
+++ b/design.md
@@ -7745,6 +7745,14 @@ generalized local-procedure uses. A generalized scope also records its exact
 checked scheme root, so evidence paths are replayed against the same callable
 shape that authored them. Static-dispatch relation records remain the separate
 explicit authority for dispatch constraints.
+
+Record-field steps in callable evidence paths select the explicit source-value
+cell, independently of field-kind resolution. An optional field's tagged runtime
+slot and an undetermined field's placeholder slot are not the checked value
+type. Reading the source-value cell neither commits the field kind nor relates
+the value to its storage slot; ordinary interface relations and relation freeze
+retain ownership of those decisions.
+
 The `CheckedBodyStore.contains_diagnostic_error` column excludes rejected
 expression sites from this relation table; an error-containing checked type is
 not a valid specialization constraint and never reaches Monotype instantiation.

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -178,6 +178,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_11249_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11263_test.zig"));
     std.testing.refAllDecls(@import("test/issue_11286_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_11303_test.zig"));
     std.testing.refAllDecls(@import("test/package_effect_boundary_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));

--- a/src/compile/test/issue_11303_test.zig
+++ b/src/compile/test/issue_11303_test.zig
@@ -1,0 +1,61 @@
+//! Regression test for issue #11303.
+
+const harness = @import("lower_to_lir_harness.zig");
+
+// repro for https://github.com/roc-lang/roc/issues/11303
+//
+// `hooks` returns a record whose `render` field is an unannotated lambda, and
+// that lambda's parameter is constrained only by the `to_str` method call.
+// Nothing in the program ever instantiates the parameter at a concrete type,
+// so lowering the call to `hooks` must resolve the field lambda's
+// callable-derived evidence from the function request that produced it.
+test "issue 11303: a returned record field lambda constrained only by a method call lowers to Monotype" {
+    try harness.expectLowersToLirWithOptions(
+        \\hooks = |{}| { render: |value| value.to_str() }
+        \\
+        \\main! : List(Str) => Try({}, [Exit(I8), ..])
+        \\main! = |_args| {
+        \\    _ = hooks({})
+        \\    Ok({})
+        \\}
+    , .{ .monotype_only = true });
+}
+
+test "issue 11303: an unused returned method-constrained lambda lowers through LIR" {
+    try harness.expectLowersToLir(
+        \\hooks = |{}| { render: |value| value.to_str() }
+        \\
+        \\main! : List(Str) => Try({}, [Exit(I8), ..])
+        \\main! = |_args| {
+        \\    _ = hooks({})
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "issue 11303: nested returned fields retain independent method evidence" {
+    try harness.expectLowersToLir(
+        \\hooks = |{}| { nested: { render: |value| value.to_str(), size: |value| value.len() } }
+        \\
+        \\main! : List(Str) => Try({}, [Exit(I8), ..])
+        \\main! = |_args| {
+        \\    _ = hooks({})
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "issue 11303: returned callable fields retain distinct concrete requests" {
+    try harness.expectLowersToLir(
+        \\hooks = |{}| { render: |value| value.to_str() }
+        \\
+        \\main! : List(Str) => Try({}, [Exit(I8), ..])
+        \\main! = |_args| {
+        \\    number_render = hooks({}).render
+        \\    text_render = hooks({}).render
+        \\    _ = number_render(1)
+        \\    _ = text_render("hello")
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -40531,7 +40531,7 @@ const BodyContext = struct {
                     .redirect, .unresolved, .primitive, .list, .box, .func, .tag_union, .record, .empty_tag_union, .empty_record, .named, .erased, .zst => return null,
                 },
                 .record_field => switch (content) {
-                    .record => node = try self.graph.recordFieldNode(node, try self.recordFieldName(view, @enumFromInt(step.data))),
+                    .record => node = try self.graph.recordFieldValueNode(node, try self.recordFieldName(view, @enumFromInt(step.data))),
                     .redirect, .unresolved, .primitive, .list, .box, .tuple, .func, .tag_union, .empty_tag_union, .empty_record, .named, .erased, .zst => return null,
                 },
                 .tag_payload_tag => switch (content) {

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -3631,6 +3631,25 @@ pub const InstGraph = struct {
         return self.recordFieldNodeWithAccess(raw_record, name, .inspectable, "record field access");
     }
 
+    /// Follow a checked field-value type without selecting its storage kind.
+    /// Evidence paths address this source value even while the runtime slot
+    /// remains unresolved or carries an optional field's presence tag.
+    pub fn recordFieldValueNode(self: *InstGraph, raw_record: NodeId, name: names.RecordFieldNameId) Allocator.Error!NodeId {
+        const field = try self.recordFieldWithAccess(raw_record, name, .inspectable, "record field access");
+        const value = switch (field.kind) {
+            .required, .defaulted => blk: {
+                if (field.value_ty != null) Common.invariant("inline record field carried a separate source value node");
+                break :blk field.ty;
+            },
+            .optional, .undetermined => field.value_ty orelse
+                Common.invariant("record field carried no source value node"),
+            // Sealed Monotypes retain source-value metadata for optional slots;
+            // its absence explicitly denotes an inline source value.
+            .sealed => field.value_ty orelse field.ty,
+        };
+        return self.find(value);
+    }
+
     /// Apply one checked required-access judgment to the field-kind cell and
     /// return the inline value slot selected by that judgment.
     pub fn requiredRecordFieldNode(self: *InstGraph, raw_record: NodeId, name: names.RecordFieldNameId) Allocator.Error!NodeId {
@@ -7354,6 +7373,100 @@ test "provisional Monotype view preserves an undetermined record field" {
     try std.testing.expectEqual(@as(usize, 1), provisional_fields.len);
     const provisional_value_ty = GuardedList.at(provisional_fields, 0).value_ty orelse return error.TestExpectedEqual;
     try std.testing.expectEqual(Type.Content{ .primitive = .u64 }, type_store.get(provisional_value_ty));
+}
+
+test "issue 11303: reading a field value preserves its undetermined storage until freeze" {
+    const gpa = std.testing.allocator;
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+
+    const field_name = try name_store.internRecordFieldLabel("render");
+    const arg = try graph.newNode(.{ .primitive = .u64 });
+    const value = try graph.newNode(.{ .func = .{
+        .args = try graph.arena().dupe(NodeId, &.{arg}),
+        .ret = try graph.newNode(.{ .primitive = .str }),
+    } });
+    const slot = try graph.newNode(.{ .unresolved = InstVariable.placeholder() });
+    const kind = try graph.newUndeterminedFieldKind();
+    graph.registerUndeterminedFieldKindCells(kind, slot, value);
+    const record = try graph.newNode(.{ .record = .{
+        .fields = try graph.arena().dupe(InstField, &.{.{
+            .name = field_name,
+            .ty = slot,
+            .value_ty = value,
+            .kind = .{ .undetermined = kind },
+            .default = null,
+        }}),
+        .ext = try graph.newNode(.empty_record),
+    } });
+
+    try std.testing.expectEqual(slot, try graph.recordFieldNode(record, field_name));
+    const node_count = graph.nodes.items.len;
+    try std.testing.expectEqual(value, try graph.recordFieldValueNode(record, field_name));
+    try std.testing.expectEqual(node_count, graph.nodes.items.len);
+    try std.testing.expect(graph.resolvedFieldKind(.{ .undetermined = kind }) == null);
+    try std.testing.expect(graph.content(slot) == .unresolved);
+    try std.testing.expect(!graph.sameClass(slot, value));
+
+    try graph.freezeRelations();
+    try std.testing.expect(graph.resolvedFieldKind(.{ .undetermined = kind }).? == .required);
+    try std.testing.expect(graph.sameClass(slot, value));
+    try std.testing.expectEqual(try graph.recordFieldNode(record, field_name), try graph.recordFieldValueNode(record, field_name));
+}
+
+test "issue 11303: field value reads preserve optional tagged storage and sealed metadata" {
+    const gpa = std.testing.allocator;
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+
+    const field_name = try name_store.internRecordFieldLabel("render");
+    const arg = try graph.newNode(.{ .primitive = .u64 });
+    const value = try graph.newNode(.{ .func = .{
+        .args = try graph.arena().dupe(NodeId, &.{arg}),
+        .ret = try graph.newNode(.{ .primitive = .str }),
+    } });
+    const missing = try name_store.internTagLabel("#Missing");
+    const present = try name_store.internTagLabel("#Present");
+    const slot = try graph.newNode(.{ .tag_union = .{
+        .tags = try graph.arena().dupe(InstTag, &.{
+            .{ .name = missing, .checked_name = missing, .payloads = try graph.arena().alloc(NodeId, 0) },
+            .{ .name = present, .checked_name = present, .payloads = try graph.arena().dupe(NodeId, &.{value}) },
+        }),
+        .ext = try graph.newNode(.empty_tag_union),
+    } });
+
+    const cases = [_]struct { kind: InstFieldKind, optional: bool }{
+        .{ .kind = .optional, .optional = true },
+        .{ .kind = .sealed, .optional = true },
+        .{ .kind = .required, .optional = false },
+        .{ .kind = .sealed, .optional = false },
+    };
+    for (cases) |case| {
+        const field_slot = if (case.optional) slot else value;
+        const record = try graph.newNode(.{ .record = .{
+            .fields = try graph.arena().dupe(InstField, &.{.{
+                .name = field_name,
+                .ty = field_slot,
+                .value_ty = if (case.optional) value else null,
+                .kind = case.kind,
+                .default = null,
+            }}),
+            .ext = try graph.newNode(.empty_record),
+        } });
+        try std.testing.expectEqual(value, try graph.recordFieldValueNode(record, field_name));
+        try std.testing.expectEqual(field_slot, try graph.recordFieldNode(record, field_name));
+        try std.testing.expect(graph.content(value) == .func);
+        try std.testing.expect(graph.content(slot) == .tag_union);
+        try std.testing.expect(!graph.sameClass(slot, value));
+    }
 }
 
 test "record field node carries contextual row evidence into receiver" {


### PR DESCRIPTION
Fixes a compiler crash when a function returns a record containing an uncalled, method-constrained lambda. Callable evidence now follows the field's source-value cell through the existing lookup, preserving unresolved field kinds and optional storage representations.

Fixes #11303.
