### PR TITLE
Share the interface-replay memo across every template request in a specialization job

### DIFF
--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -13907,10 +13907,15 @@ const BodyDraftStore = struct {
     /// Retains graph-to-program mappings across eager coordinator calls and the
     /// final ordered commit.
     committed_type_relocation: ?Type.Store.TypeRelocation,
+    /// Interface-replay memo shared by every template request lowered into
+    /// this draft's graph. Entries hold graph-owned provisional views, so the
+    /// memo is graph-qualified state and is discarded with the graph.
+    interface_replay: InterfaceReplayState,
 
     fn init(allocator: Allocator) BodyDraftStore {
         return .{
             .allocator = allocator,
+            .interface_replay = InterfaceReplayState.init(allocator),
             .symbol_domain = .coordinator,
             .worker_local_symbol_count = 0,
             .fns = .empty,
@@ -14111,6 +14116,7 @@ const BodyDraftStore = struct {
     }
 
     fn deinit(self: *BodyDraftStore) void {
+        self.interface_replay.deinit(self.allocator);
         for (self.template_specs.items) |*spec| {
             if (spec.lexical) |lexical| {
                 self.allocator.free(lexical.binders);
@@ -14820,6 +14826,8 @@ const BodyDraftStore = struct {
     /// consumers have run. Retained core data and coordinator intents remain;
     /// no slice in those intents may continue to borrow the graph arena.
     fn discardGraphStateAfterSeal(self: *BodyDraftStore) void {
+        self.interface_replay.deinit(self.allocator);
+        self.interface_replay = InterfaceReplayState.init(self.allocator);
         for (self.deferred_const_uses.items) |boundary| {
             self.allocator.free(boundary.lexical.binders);
             self.allocator.free(boundary.lexical.local_procs);
@@ -20593,8 +20601,7 @@ const BodyContext = struct {
         template: checked.CheckedProcedureTemplate,
         root_node: NodeId,
     ) Allocator.Error!void {
-        var replay_state = InterfaceReplayState.init(self.allocator);
-        defer replay_state.deinit(self.allocator);
+        const replay_state = &self.draft.interface_replay;
         var active_local_scopes = collections.DenseMap(checked.DispatchScopeId, NodeId).init(self.allocator);
         defer active_local_scopes.deinit();
         try self.applyCheckedTemplateInterfaceScopeRelations(
@@ -20602,7 +20609,7 @@ const BodyContext = struct {
             null,
             root_node,
             &active_local_scopes,
-            &replay_state,
+            replay_state,
         );
     }
 


### PR DESCRIPTION
Each template request lowered into a specialization job's draft graph created its own interface-replay memo (`InterfaceReplayState`), so a body with many call sites re-expanded the same callee interface closures once per call site. In the repro from #11326 the 2000-arm `route` body replayed the `List.map` and `Str.concat` closures 2000 times each: all 18,001 closure expansions in that job were memo misses with no bucket, and the same (family, evidence digest, provisional digest) keys recurred once per arm.

This moves the memo onto `BodyDraftStore` for the lifetime of the job's graph and discards it with the other graph-qualified state at seal time, so each unique (family, evidence, provisional view) closure is expanded once per job. On the N=2000, CHUNK=0 repro built with ReleaseFast, the `route` job drops from 324,035 to 132,131 graph nodes and from 964 ms to 702 ms, Specializing from 1,692 ms to 1,469 ms, and Parallel Worker Wait from 1,074 ms to 840 ms. This is a partial fix for #11326; the remaining per-call-site cost, cross-job sharing, and the wave barrier are tracked in follow-up issues.
