### PR TITLE
Index draft template specialization candidates

### DIFF
--- a/design.md
+++ b/design.md
@@ -8022,17 +8022,20 @@ During active Monotype specialization, unresolved checked variables and row
 extensions remain instantiation graph nodes. They are not represented by
 durable Monotype `TypeId`s.
 
-Open draft specialization indexes retain permanent interface node ids. A lookup
-visits each current union-find class once and probes all its permanent members;
-repeated argument or return positions do not repeat those probes. Candidate
-inspection does not merge existing classes during this scan. Its visited set
-is local to the scan and uses pooled scratch, so a later lookup observes any
-intervening unions. Evidence, capture, and exact interface checks still decide
-whether a candidate may be reused. Probe work is proportional to interface
-positions plus the members of distinct classes, even when many positions share
-one class. The index interns the exact family and evidence-digest prefix once
-per request, using an append-only index-local ID in each interface key. Growing
-the index during recursive lowering does not invalidate those IDs. Request
+Open draft specialization indexes retain permanent interface node ids. Template
+lookup collects the request's distinct interface classes once, then tests only
+the permanent-node/candidate pairs registered under its exact family/evidence
+prefix against those classes. A prefix with no open registrations skips this
+probe entirely. Later unions require no rekeying: class equality is tested at
+lookup time. Resolved template lookup also indexes candidates by the explicit
+procedure template reference, preserving reuse through different checked roots
+without scanning unrelated templates. Nested lookup visits each current
+interface class once and probes its permanent members. Candidate inspection
+does not merge classes, and evidence, capture, recursive-edge, and exact
+interface checks remain authoritative. The index interns the exact family and
+evidence-digest prefix once per request, using an append-only index-local ID in
+each interface key. Growing the index during recursive lowering does not
+invalidate those IDs. Request
 kinds remain disjoint, and interning a prefix does not replace exact candidate
 validation. Permanent-node requests use the prefix ID and node ID directly in
 a separate index; only structural type and open-shape requests carry digests.

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -12737,7 +12737,7 @@ fn DraftSpecLookup(comptime Family: type) type {
         }
 
         fn add(self: *Self, address: Address, raw_spec: u32) Allocator.Error!void {
-            // Reserve before publishing either index so allocation failure cannot
+            // Reserve before updating either index so allocation failure cannot
             // leave a registered candidate absent from the prefix inventory.
             const pairs: ?*std.ArrayList(OpenPair) = switch (address) {
                 .open => |key| &self.prefixes.values()[@intFromEnum(key.prefix)],

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -6045,49 +6045,48 @@ const Builder = struct {
             }
         }
         if (selection.selected() == null) {
-            var seen_specs = std.AutoHashMap(u32, void).init(self.allocator);
-            defer seen_specs.deinit();
-            var interface = try source_ctx.graph.functionInterfaceClassIterator(request_fn_node);
-            defer interface.deinit();
-            while (try interface.next()) |interface_class| {
-                var aliases = source_ctx.graph.classMemberIterator(interface_class);
-                while (aliases.next()) |member| {
-                    const lookup_address = DraftTemplateLookupAddress{
-                        .open = .{
-                            .prefix = lookup_prefix,
-                            .node = member,
-                        },
-                    };
-                    if (source_ctx.draft.template_spec_lookup.get(lookup_address)) |candidate_iterator| {
-                        var candidates = candidate_iterator;
-                        while (candidates.next()) |raw_spec| {
-                            const seen = try seen_specs.getOrPut(raw_spec);
-                            if (seen.found_existing) continue;
-                            const spec = &source_ctx.draft.template_specs.items[raw_spec];
-                            if (!specEvidenceVectorEql(spec.evidence, evidence)) continue;
-                            if (!optionalTypeDigestEql(spec.lexical_context_key, lexical_context_key)) continue;
-                            if (!optionalDraftCodecContractContextEql(source_ctx.graph, spec.codec_contract, codec_contract)) continue;
-                            const exact_interface = source_ctx.graph.sameFunctionInterface(
-                                draftTemplateSpecLookupRequestNode(spec),
-                                request_fn_node,
-                            );
-                            const active_recursive_edge = source_ctx.draft.ownerDescendsFromDraftFn(
-                                source_ctx.draft.current_owner,
-                                spec.fn_id,
-                            );
-                            const partial_recursive_allowed = active_recursive_edge and
-                                request_edge == .recursive_reference and
-                                substitutionsShareClasses(source_ctx.graph, spec.subst, edge.subst);
-                            if (!draftOpenCandidateQualifies(
-                                spec.state,
-                                exact_interface,
-                                active_recursive_edge,
-                                partial_recursive_allowed,
-                            )) continue;
-                            if (!selection.add(raw_spec, exact_interface)) {
-                                Common.invariant("draft template request matched more than one partial active recursive specialization");
-                            }
-                        }
+            const open_pairs = source_ctx.draft.template_spec_lookup.openPairs(lookup_prefix);
+            // A fresh prefix has no registrations. Avoid even collecting its
+            // interface: no open candidate can exist for this exact family.
+            if (open_pairs.len != 0) {
+                var seen_specs = std.AutoHashMap(u32, void).init(self.allocator);
+                defer seen_specs.deinit();
+                var interface_roots: std.ArrayList(NodeId) = .empty;
+                defer interface_roots.deinit(self.allocator);
+                var interface = try source_ctx.graph.functionInterfaceClassIterator(request_fn_node);
+                defer interface.deinit();
+                while (try interface.next()) |root| try interface_roots.append(self.allocator, root);
+                var candidates = DraftTemplateSpecLookup.OpenIterator{
+                    .pairs = open_pairs,
+                    .graph = source_ctx.graph,
+                    .interface_roots = interface_roots.items,
+                };
+                while (candidates.next()) |raw_spec| {
+                    const seen = try seen_specs.getOrPut(raw_spec);
+                    if (seen.found_existing) continue;
+                    const spec = &source_ctx.draft.template_specs.items[raw_spec];
+                    if (!specEvidenceVectorEql(spec.evidence, evidence)) continue;
+                    if (!optionalTypeDigestEql(spec.lexical_context_key, lexical_context_key)) continue;
+                    if (!optionalDraftCodecContractContextEql(source_ctx.graph, spec.codec_contract, codec_contract)) continue;
+                    const exact_interface = source_ctx.graph.sameFunctionInterface(
+                        draftTemplateSpecLookupRequestNode(spec),
+                        request_fn_node,
+                    );
+                    const active_recursive_edge = source_ctx.draft.ownerDescendsFromDraftFn(
+                        source_ctx.draft.current_owner,
+                        spec.fn_id,
+                    );
+                    const partial_recursive_allowed = active_recursive_edge and
+                        request_edge == .recursive_reference and
+                        substitutionsShareClasses(source_ctx.graph, spec.subst, edge.subst);
+                    if (!draftOpenCandidateQualifies(
+                        spec.state,
+                        exact_interface,
+                        active_recursive_edge,
+                        partial_recursive_allowed,
+                    )) continue;
+                    if (!selection.add(raw_spec, exact_interface)) {
+                        Common.invariant("draft template request matched more than one partial active recursive specialization");
                     }
                 }
             }
@@ -6099,9 +6098,9 @@ const Builder = struct {
             // interface identity for active recursive and partially overlapping
             // requests.
             if (resolved_request_ty) |request_fn_ty| {
-                for (source_ctx.draft.template_specs.items, 0..) |*spec, raw_spec_usize| {
-                    const raw_spec: u32 = @intCast(raw_spec_usize);
-                    if (!names.procedureTemplateRefEql(spec.template_ref, template_ref)) continue;
+                const template_candidates = source_ctx.draft.template_specs_by_template.get(template_ref);
+                for (if (template_candidates) |list| list.items else &.{}) |raw_spec| {
+                    const spec = &source_ctx.draft.template_specs.items[raw_spec];
                     // The checked source root selects the template body, but it is
                     // not part of a resolved specialization's identity. Recursive
                     // calls can reach the same template through a different checked
@@ -6249,8 +6248,11 @@ const Builder = struct {
             .codec_contract = codec_contract,
             .fn_id = fn_id,
         });
-        try source_ctx.draft.template_spec_by_fn.put(fn_id, @intCast(spec_index));
         lexical_needs_cleanup = false;
+        const template_bucket = try source_ctx.draft.template_specs_by_template.getOrPut(template_ref);
+        if (!template_bucket.found_existing) template_bucket.value_ptr.* = .empty;
+        try template_bucket.value_ptr.append(self.allocator, @intCast(spec_index));
+        try source_ctx.draft.template_spec_by_fn.put(fn_id, @intCast(spec_index));
         try updateTemplateSpecInterfaceLookups(
             source_ctx.draft,
             self.allocator,
@@ -12627,6 +12629,23 @@ fn DraftSpecLookup(comptime Family: type) type {
             evidence_digest: [32]u8,
         };
         const PrefixId = enum(u32) { _ };
+        const OpenPair = struct { node: NodeId, spec: u32 };
+        const OpenIterator = struct {
+            pairs: []const OpenPair,
+            graph: *InstGraph,
+            interface_roots: []const NodeId,
+
+            fn next(self: *OpenIterator) ?u32 {
+                while (self.pairs.len != 0) {
+                    const pair = self.pairs[0];
+                    self.pairs = self.pairs[1..];
+                    for (self.interface_roots) |root| {
+                        if (self.graph.sameClass(pair.node, root)) return pair.spec;
+                    }
+                }
+                return null;
+            }
+        };
         const OpenAddress = struct {
             prefix: PrefixId,
             node: NodeId,
@@ -12666,7 +12685,7 @@ fn DraftSpecLookup(comptime Family: type) type {
         };
 
         allocator: Allocator,
-        prefixes: std.array_hash_map.Auto(Prefix, void),
+        prefixes: std.array_hash_map.Auto(Prefix, std.ArrayList(OpenPair)),
         open_requests: std.AutoHashMap(OpenAddress, Candidates),
         digest_requests: std.AutoHashMap(DigestAddress, Candidates),
         /// Only buckets with multiple candidates own an overflow list. Its
@@ -12688,6 +12707,7 @@ fn DraftSpecLookup(comptime Family: type) type {
             self.digest_requests.deinit();
             for (self.overflow_lists.items) |*list| list.deinit(self.allocator);
             self.overflow_lists.deinit(self.allocator);
+            for (self.prefixes.values()) |*pairs| pairs.deinit(self.allocator);
             self.prefixes.deinit(self.allocator);
         }
 
@@ -12717,9 +12737,17 @@ fn DraftSpecLookup(comptime Family: type) type {
         }
 
         fn add(self: *Self, address: Address, raw_spec: u32) Allocator.Error!void {
+            // Reserve before publishing either index so allocation failure cannot
+            // leave a registered candidate absent from the prefix inventory.
+            const pairs: ?*std.ArrayList(OpenPair) = switch (address) {
+                .open => |key| &self.prefixes.values()[@intFromEnum(key.prefix)],
+                .digest => null,
+            };
+            if (pairs) |list| try list.ensureUnusedCapacity(self.allocator, 1);
             const entry = try self.getOrPut(address);
             if (!entry.found_existing) {
                 entry.value_ptr.* = .{ .first = raw_spec };
+                if (pairs) |list| list.appendAssumeCapacity(.{ .node = address.open.node, .spec = raw_spec });
                 return;
             }
             if (entry.value_ptr.first == raw_spec) return;
@@ -12736,6 +12764,7 @@ fn DraftSpecLookup(comptime Family: type) type {
                 try self.overflow_lists.append(self.allocator, list);
                 entry.value_ptr.overflow = overflow;
             }
+            if (pairs) |list| list.appendAssumeCapacity(.{ .node = address.open.node, .spec = raw_spec });
         }
 
         fn internPrefix(self: *Self, family: Family, evidence_digest: [32]u8) Allocator.Error!PrefixId {
@@ -12743,7 +12772,12 @@ fn DraftSpecLookup(comptime Family: type) type {
                 .family = family,
                 .evidence_digest = evidence_digest,
             });
+            if (!entry.found_existing) entry.value_ptr.* = .empty;
             return @enumFromInt(entry.index);
+        }
+
+        fn openPairs(self: *const Self, prefix: PrefixId) []const OpenPair {
+            return self.prefixes.values()[@intFromEnum(prefix)].items;
         }
     };
 }
@@ -13807,6 +13841,7 @@ const BodyDraftStore = struct {
     def_owners: std.ArrayList(DraftOwner),
     nested_defs: std.ArrayList(DraftNestedDef),
     template_specs: std.ArrayList(DraftTemplateSpec),
+    template_specs_by_template: std.AutoHashMap(names.ProcTemplate, std.ArrayList(u32)),
     sealed_template_specs: std.ArrayList(SealedTemplateSpec),
     template_spec_by_fn: collections.DenseMap(DraftFnId, u32),
     template_spec_lookup: DraftTemplateSpecLookup,
@@ -13928,6 +13963,7 @@ const BodyDraftStore = struct {
             .nested_defs = .empty,
             .template_specs = .empty,
             .sealed_template_specs = .empty,
+            .template_specs_by_template = std.AutoHashMap(names.ProcTemplate, std.ArrayList(u32)).init(allocator),
             .template_spec_by_fn = collections.DenseMap(DraftFnId, u32).init(allocator),
             .template_spec_lookup = DraftTemplateSpecLookup.init(allocator),
             .closed_direct_specializations = std.AutoHashMap(ClosedDirectCallIdentity, ClosedDirectDraftSpecialization).init(allocator),
@@ -14152,6 +14188,9 @@ const BodyDraftStore = struct {
         self.local_proc_contexts.deinit(self.allocator);
         self.template_spec_lookup.deinit();
         self.closed_direct_specializations.deinit();
+        var template_lists = self.template_specs_by_template.valueIterator();
+        while (template_lists.next()) |list| list.deinit(self.allocator);
+        self.template_specs_by_template.deinit();
         self.template_spec_by_fn.deinit();
         self.nested_spec_lookup.deinit();
         self.nested_spec_families.deinit();
@@ -14911,7 +14950,11 @@ const BodyDraftStore = struct {
         self.nested_spec_families.deinit();
         self.nested_spec_lookup = DraftNestedSpecLookup.init(self.allocator);
         self.nested_spec_families = std.AutoHashMap(DraftNestedFamilyAddress, void).init(self.allocator);
+        var template_lists = self.template_specs_by_template.valueIterator();
+        while (template_lists.next()) |list| list.deinit(self.allocator);
+        self.template_specs_by_template.deinit();
         self.template_spec_by_fn.deinit();
+        self.template_specs_by_template = std.AutoHashMap(names.ProcTemplate, std.ArrayList(u32)).init(self.allocator);
         self.template_spec_by_fn = collections.DenseMap(DraftFnId, u32).init(self.allocator);
         self.closed_direct_specializations.deinit();
         self.closed_direct_specializations = std.AutoHashMap(
@@ -14942,6 +14985,7 @@ const BodyDraftStore = struct {
             !self.nested_spec_lookup.isEmpty() or
             self.nested_spec_families.count() != 0 or
             self.template_specs.items.len != 0 or
+            self.template_specs_by_template.count() != 0 or
             self.nested_specs.items.len != 0 or
             self.spec_job_workspace != null or
             self.mutable_graph_names != null or
@@ -55775,6 +55819,7 @@ test "draft specialization candidates retain insertion order across overflow gro
                         try lookup.add(other, raw_spec);
                         try lookup.add(other, std.math.maxInt(u32));
                     }
+                    try std.testing.expect(lookup.openPairs(prefix).len == 61);
                     var candidates = lookup.get(address).?;
                     try std.testing.expect(candidates.next().? == std.math.maxInt(u32));
                     for (0..20) |i| try std.testing.expect(candidates.next().? == i);
@@ -55794,6 +55839,55 @@ test "draft specialization candidates retain insertion order across overflow gro
     };
     try Scenario.run(std.testing.allocator);
     try std.testing.checkAllAllocationFailures(std.testing.allocator, Scenario.run, .{});
+}
+
+test "draft specialization open lookup follows unions within its prefix" {
+    const gpa = std.testing.allocator;
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+    var lookup = DraftTemplateSpecLookup.init(gpa);
+    defer lookup.deinit();
+    const family = std.mem.zeroes(DraftTemplateFamilyAddress);
+    const prefix = try lookup.internPrefix(family, @splat(0));
+    const other_prefix = try lookup.internPrefix(family, @splat(1));
+    try std.testing.expectEqual(@as(usize, 0), lookup.openPairs(prefix).len);
+    const arg = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    const ret = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    const registered = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    const unrelated = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+    try lookup.add(.{ .open = .{ .prefix = prefix, .node = registered } }, 7);
+    try lookup.add(.{ .open = .{ .prefix = prefix, .node = registered } }, 8);
+    try lookup.add(.{ .open = .{ .prefix = prefix, .node = registered } }, 7);
+    try lookup.add(.{ .open = .{ .prefix = prefix, .node = unrelated } }, 9);
+    try lookup.add(.{ .open = .{ .prefix = other_prefix, .node = arg } }, 10);
+    const roots = [_]NodeId{ arg, ret };
+    var before = DraftTemplateSpecLookup.OpenIterator{ .pairs = lookup.openPairs(prefix), .graph = graph, .interface_roots = &roots };
+    try std.testing.expectEqual(null, before.next());
+    // The registered permanent node becomes an alias only after registration.
+    // Thousands of unrelated registrations join the same live class, but do
+    // not enlarge this prefix's candidate inventory.
+    try graph.unify(arg, registered);
+    for (0..2000) |i| {
+        const node = try graph.newNode(.{ .unresolved = InstVariable.checkedVariable(null, null) });
+        try lookup.add(.{ .open = .{ .prefix = other_prefix, .node = node } }, @intCast(i + 11));
+        try graph.unify(arg, node);
+    }
+    try std.testing.expectEqual(@as(usize, 3), lookup.openPairs(prefix).len);
+    var after = DraftTemplateSpecLookup.OpenIterator{ .pairs = lookup.openPairs(prefix), .graph = graph, .interface_roots = &roots };
+    try std.testing.expectEqual(@as(?u32, 7), after.next());
+    try std.testing.expectEqual(@as(?u32, 8), after.next());
+    try std.testing.expectEqual(null, after.next());
+    // Return-only overlap must also retain candidates for recursive checks.
+    try graph.unify(ret, unrelated);
+    var returned = DraftTemplateSpecLookup.OpenIterator{ .pairs = lookup.openPairs(prefix), .graph = graph, .interface_roots = &roots };
+    try std.testing.expectEqual(@as(?u32, 7), returned.next());
+    try std.testing.expectEqual(@as(?u32, 8), returned.next());
+    try std.testing.expectEqual(@as(?u32, 9), returned.next());
+    try std.testing.expectEqual(null, returned.next());
 }
 
 test "open draft recursive provenance joins fresh interface cells only while lowering" {

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -745,7 +745,6 @@ test "Monotype open specialization lookup covers the complete function interface
     );
     inline for (.{ template_source, nested_source }) |lookup_source| {
         try expectContains(lookup_source, "functionInterfaceClassIterator(request_fn_node)");
-        try expectContains(lookup_source, "classMemberIterator(interface_class)");
         try expectContains(lookup_source, "seen_specs.getOrPut(raw_spec)");
         try expectContains(lookup_source, "draftOpenCandidateQualifies(");
         try expectContains(lookup_source, "spec.runtime_demand_guard_frames");
@@ -756,6 +755,15 @@ test "Monotype open specialization lookup covers the complete function interface
         try expectContains(lookup_source, "spec.initial_request_arg_classes");
         try expectNotContains(lookup_source, "functionInterfaceAnchor");
     }
+    try expectContains(template_source, "template_spec_lookup.openPairs(lookup_prefix)");
+    try expectContains(template_source, "if (open_pairs.len != 0)");
+    try expectContains(template_source, ".interface_roots = interface_roots.items");
+    try expectContains(template_source, "template_specs_by_template.get(template_ref)");
+    try expectNotContains(template_source, "classMemberIterator(");
+    try expectNotContains(template_source, "for (source_ctx.draft.template_specs.items");
+    const prefix_lookup = sourceSliceBetween(lower_source, "fn DraftSpecLookup(", "const EagerTemplateResolution");
+    try expectContains(prefix_lookup, "self.graph.sameClass(pair.node, root)");
+    try expectContains(nested_source, "classMemberIterator(interface_class)");
     try expectContains(template_source, "draftTemplateSpecLookupRequestNode(spec)");
     try expectContains(nested_source, "sameFunctionInterface(spec.request_fn_node, request_fn_node)");
     const interface_registration = sourceSliceBetween(


### PR DESCRIPTION
Direct calls to distinct templates scanned growing union-find classes and all prior draft specializations, making wide bodies quadratic in their call-site count.

Index open node/spec registrations by the exact family/evidence prefix, skip prefixes without open registrations, and compare registered permanent nodes against the request's complete interface. Index resolved candidates by procedure template so recursive calls through different checked roots retain their existing reuse behavior. Evidence, lexical context, codec, interface, and recursive-edge checks remain authoritative.

Regression coverage includes unions after registration, return-only overlap, duplicate registrations, unrelated registrations in a large shared class, and allocation failures. Update the design and structural guards for the new lookup strategy.

Fixes #11337.

Validation:

- Merged `origin/main` at `4fd10c74cf`; full MiniCI on merge commit `caf4c2df3d` passed all 76 phases (0 failures, crashes, or skips): `MINICI_MAX_CPUS=1 zig build minici -j1 -- -j1`.

- `zig build run-test-zig -j1`: 5,542 unit tests passed; all 95 LSP integration specs passed.
- `zig build run-check-snapshots`: passed with no snapshot changes.
- `zig build run-test-zig-module-postcheck -j1`: all 492 tests passed, including recursive specialization coverage.
- Formatting, Zig lints, post-check architecture checks, and `run-check-semantic-audit` passed.

Benchmark: baseline `125f687a23` (after #11336) versus implementation `d80126fe8e`, measured before merging the later `origin/main` changes; the generator from #11326 with `test/fx/platform`, macOS arm64, compiler flags `-Doptimize=ReleaseFast -Dstrip=false`, and `roc build --opt=dev --timings --no-cache`. Values are medians of three alternating runs per variant. All 24 generated executables printed the expected result.

| Router | Specializing (ms), before → after | Worker wait (ms), before → after |
| --- | ---: | ---: |
| 1,000 arms, flat | 397 → 270 | 264 → 137 |
| 2,000 arms, flat | 1,463 → 902 | 846 → 309 |
| 2,000 arms, chunks of 50 | 816 → 807 | 226 → 217 |
| 4,000 arms, flat | 6,380 → 4,417 | 2,619 → 675 |

For the 2,000-arm flat case, specialization time dropped 38%. Samply profiles scoped to `lowerPendingSpecJobToShard` attributed 854/2,331 samples (36.6%) to `DraftSpecLookup.get` itself before the change, versus 0/1,517 afterward. Every baseline `get` self sample came from `lowerDraftTemplateFromContext`.
